### PR TITLE
chore: add Makefile and update docs with make commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,35 +4,44 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Build & Development Commands
 
+A `Makefile` is provided for common tasks. Run `make help` to see all targets.
+
 ```bash
-# Install with dev dependencies
-uv venv && uv pip install -e ".[dev]"
+make install      # Create venv and install with dev dependencies
+make format       # Format code with Black
+make lint         # Lint with Ruff (auto-fix)
+make typecheck    # Type-check with mypy
+make check        # Run format + lint + typecheck in sequence
+make test         # Run all tests
+make test-cov     # Run tests with coverage report
+make build-ui     # Build the web UI frontend
+make run          # Start interactive TUI
+make run-ui       # Start web UI
+```
+
+For cases not covered by `make`, the raw commands are:
+
+```bash
+# Activate the venv after install
 source .venv/bin/activate
 
-# Run the CLI
-opendev                    # Interactive TUI
-opendev -p "prompt"        # Non-interactive single prompt
-opendev --continue         # Resume most recent session
-opendev run ui             # Web UI
-
-# Code quality
-black opendev/ tests/ --line-length 100
-ruff check opendev/ tests/ --fix
-mypy opendev/
-
-# Tests
-uv run pytest                                    # All tests
+# Run specific tests
 uv run pytest tests/test_session_manager.py     # Single file
 uv run pytest tests/test_foo.py::test_bar       # Single test
-uv run pytest --cov=opendev                      # With coverage
 
-# Web UI (frontend build outputs to opendev/web/static/)
-cd web-ui && npm run build
+# Or via make
+make test-file FILE=tests/test_session_manager.py
 
 # MCP server management
 opendev mcp list
 opendev mcp add myserver uvx mcp-server-sqlite
 opendev mcp enable/disable myserver
+
+# CLI shortcuts
+opendev                    # Interactive TUI
+opendev -p "prompt"        # Non-interactive single prompt
+opendev --continue         # Resume most recent session
+opendev run ui             # Web UI
 ```
 
 ## Testing Requirements
@@ -50,10 +59,10 @@ Both unit tests AND end-to-end testing with real simulation are REQUIRED. Never 
 export OPENAI_API_KEY="your-key-here"
 
 # Run unit tests
-uv run pytest
+make test
 
 # Then run real end-to-end testing
-opendev
+make run
 # Execute real commands that exercise the changed code paths
 ```
 
@@ -61,7 +70,7 @@ opendev
 
 The CLI entry point is `opendev` (mapped to `opendev.cli:main`). The Python package is `opendev/`.
 
-```
+```text
 Entry Point (cli.py)
        |
 UI Layer

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,50 @@
+.PHONY: help install format lint typecheck test test-file test-cov check build-ui run run-ui
+
+PYTHON_DIRS = opendev/ tests/
+LINE_LENGTH = 100
+
+help:
+	@echo "Available commands:"
+	@echo "  make install      Install with dev dependencies"
+	@echo "  make format       Format code with Black"
+	@echo "  make lint         Lint with Ruff (auto-fix)"
+	@echo "  make typecheck    Type-check with mypy"
+	@echo "  make check        Run format + lint + typecheck"
+	@echo "  make test         Run all tests"
+	@echo "  make test-cov     Run tests with coverage"
+	@echo "  make build-ui     Build web UI frontend"
+	@echo "  make run          Start interactive TUI"
+	@echo "  make run-ui       Start web UI"
+
+install:
+	uv venv && uv pip install -e ".[dev]"
+
+format:
+	black $(PYTHON_DIRS) --line-length $(LINE_LENGTH)
+
+lint:
+	ruff check $(PYTHON_DIRS) --fix
+
+typecheck:
+	mypy opendev/
+
+check: format lint typecheck
+
+test:
+	uv run pytest
+
+test-cov:
+	uv run pytest --cov=opendev
+
+# Usage: make test-file FILE=tests/test_session_manager.py
+test-file:
+	uv run pytest $(FILE)
+
+build-ui:
+	cd web-ui && npm run build
+
+run:
+	opendev
+
+run-ui:
+	opendev run ui

--- a/README.md
+++ b/README.md
@@ -126,19 +126,20 @@ opendev mcp enable/disable myserver
 ```bash
 git clone https://github.com/opendev-to/opendev.git
 cd opendev
-uv venv && uv pip install -e ".[dev]"
+make install
 source .venv/bin/activate
+```
 
-# Run tests
-uv run pytest
+A `Makefile` provides shortcuts for all common tasks:
 
-# Code quality
-black opendev/ tests/ --line-length 100
-ruff check opendev/ tests/ --fix
-mypy opendev/
-
-# Build the Web UI frontend
-cd web-ui && npm run build
+```bash
+make check        # Format (Black) + lint (Ruff) + type-check (mypy)
+make test         # Run all tests
+make test-cov     # Run tests with coverage report
+make build-ui     # Build the Web UI frontend
+make run          # Start interactive TUI
+make run-ui       # Start web UI
+make help         # List all available targets
 ```
 
 ### Contributing


### PR DESCRIPTION
## Summary
- Add a `Makefile` with targets covering the full developer workflow: install, format, lint, typecheck, test, coverage, web UI build, and running the CLI
- Update `CLAUDE.md` to reference `make` commands as the primary workflow, keeping raw commands only for edge cases (single test file, MCP management, CLI flags)
- Update `README.md` Development section to use `make install` + a concise `make` command table

  ## Test plan

  - [ ] Run `make help` and verify all targets are listed
  - [ ] Run `make install` in a clean environment to confirm venv + deps install correctly
  - [ ] Run `make check` (format + lint + typecheck) and confirm it passes
  - [ ] Run `make test` and confirm all tests pass
  - [ ] Run `make test-file FILE=tests/test_session_manager.py` and confirm it works
  - [ ] Run `make build-ui` and confirm the frontend builds to `opendev/web/static/