### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TOCTOU vulnerability in MCP config file writing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Time-of-Check to Time-of-Use (TOCTOU) vulnerability where sensitive files (like `auth.json`) were created with default permissions using `std::fs::write` and then restricted using `std::fs::set_permissions(..., 0o600)`. This leaves a brief window where the file is readable by others.
 **Learning:** Post-creation permission modification leaves a race condition window that can be exploited, especially for files storing API keys and credentials.
 **Prevention:** Always use `std::fs::OpenOptions` with `std::os::unix::fs::OpenOptionsExt::mode(0o600)` to securely and atomically create the file with restricted permissions before writing any data to it.
+
+## 2024-05-18 - Atomic writes for MCP Configuration
+**Vulnerability:** MCP configuration files were being written directly to their target paths without temporary files and without restrictive permissions. This exposed sensitive config information (such as OAuth keys and tokens) and created TOCTOU vulnerabilities as well as the risk of configuration corruption if the write failed midway.
+**Learning:** Configurations often hold secrets and must be written securely. We should always use an atomic file rename combined with restrictive permissions to ensure secrets are safe from local unauthorized reads and file writes don't corrupt the file.
+**Prevention:** Use an atomic write pattern (`OpenOptionsExt::mode(0o600)` -> write to temp file -> rename to target file) for any configuration files, especially ones holding keys and credentials, to ensure security and prevent data corruption.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4175,6 +4175,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/opendev-mcp/Cargo.toml
+++ b/crates/opendev-mcp/Cargo.toml
@@ -17,6 +17,7 @@ regex = { workspace = true }
 opendev-models = { workspace = true }
 opendev-config = { workspace = true }
 futures = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/opendev-mcp/src/config.rs
+++ b/crates/opendev-mcp/src/config.rs
@@ -175,10 +175,18 @@ pub fn save_config(config: &McpConfig, config_path: &Path) -> McpResult<()> {
         let mut opts = std::fs::OpenOptions::new();
         opts.write(true).create(true).truncate(true).mode(0o600);
         let mut file = opts.open(&tmp_path).map_err(|e| {
-            McpError::Config(format!("Failed to open temp config file {}: {}", tmp_path.display(), e))
+            McpError::Config(format!(
+                "Failed to open temp config file {}: {}",
+                tmp_path.display(),
+                e
+            ))
         })?;
         std::io::Write::write_all(&mut file, content.as_bytes()).map_err(|e| {
-            McpError::Config(format!("Failed to write MCP config to {}: {}", tmp_path.display(), e))
+            McpError::Config(format!(
+                "Failed to write MCP config to {}: {}",
+                tmp_path.display(),
+                e
+            ))
         })?;
     }
     #[cfg(not(unix))]

--- a/crates/opendev-mcp/src/config.rs
+++ b/crates/opendev-mcp/src/config.rs
@@ -165,9 +165,36 @@ pub fn save_config(config: &McpConfig, config_path: &Path) -> McpResult<()> {
     }
 
     let content = serde_json::to_string_pretty(config)?;
-    std::fs::write(config_path, content).map_err(|e| {
+
+    // Atomic write to prevent TOCTOU and corruption, with secure permissions (0600)
+    let tmp_path = config_path.with_extension(format!("tmp.{}", uuid::Uuid::new_v4()));
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut opts = std::fs::OpenOptions::new();
+        opts.write(true).create(true).truncate(true).mode(0o600);
+        let mut file = opts.open(&tmp_path).map_err(|e| {
+            McpError::Config(format!("Failed to open temp config file {}: {}", tmp_path.display(), e))
+        })?;
+        std::io::Write::write_all(&mut file, content.as_bytes()).map_err(|e| {
+            McpError::Config(format!("Failed to write MCP config to {}: {}", tmp_path.display(), e))
+        })?;
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::write(&tmp_path, &content).map_err(|e| {
+            McpError::Config(format!(
+                "Failed to write MCP config to {}: {}",
+                tmp_path.display(),
+                e
+            ))
+        })?;
+    }
+
+    std::fs::rename(&tmp_path, config_path).map_err(|e| {
         McpError::Config(format!(
-            "Failed to write MCP config to {}: {}",
+            "Failed to rename temp config file {}: {}",
             config_path.display(),
             e
         ))


### PR DESCRIPTION
Superseded. MCP config atomic write already on main via earlier merges.