### PR TITLE
🛡️ Sentinel: [HIGH] Enforce secure file writes for MCP configuration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,4 @@
-## 2025-02-26 - [TOCTOU in Sensitive File Creation]
-**Vulnerability:** Time-of-Check to Time-of-Use (TOCTOU) vulnerability where sensitive files (like `auth.json`) were created with default permissions using `std::fs::write` and then restricted using `std::fs::set_permissions(..., 0o600)`. This leaves a brief window where the file is readable by others.
-**Learning:** Post-creation permission modification leaves a race condition window that can be exploited, especially for files storing API keys and credentials.
-**Prevention:** Always use `std::fs::OpenOptions` with `std::os::unix::fs::OpenOptionsExt::mode(0o600)` to securely and atomically create the file with restricted permissions before writing any data to it.
+## 2024-04-06 - Secure Atomic File Writes for MCP Configs
+**Vulnerability:** The `mcp.json` configuration file, which contains sensitive user OAuth credentials, was being written insecurely using `std::fs::write`. This could leave it world-readable on Unix systems, leading to a local privilege escalation/credential leak. Also, direct writes can be vulnerable to TOCTOU and corruption on crash.
+**Learning:** We need to explicitly check everywhere configuration files are saved. We already securely save `.opendev/config.json` via atomic writes with 0600 mode permissions in `opendev-config`, but `opendev-mcp` and `opendev-web`'s IO module did not follow this pattern for MCP configurations.
+**Prevention:** Always use atomic writes via a temporary file with restricted permissions (0o600 on Unix using `OpenOptionsExt::mode`) for files containing sensitive data instead of `std::fs::write`.

--- a/crates/opendev-mcp/src/config.rs
+++ b/crates/opendev-mcp/src/config.rs
@@ -175,17 +175,29 @@ pub fn save_config(config: &McpConfig, config_path: &Path) -> McpResult<()> {
         opts.write(true).create(true).truncate(true).mode(0o600);
 
         let mut file = opts.open(&tmp_path).map_err(|e| {
-            McpError::Config(format!("Failed to open temp config file {}: {}", tmp_path.display(), e))
+            McpError::Config(format!(
+                "Failed to open temp config file {}: {}",
+                tmp_path.display(),
+                e
+            ))
         })?;
         std::io::Write::write_all(&mut file, content.as_bytes()).map_err(|e| {
-            McpError::Config(format!("Failed to write temp config file {}: {}", tmp_path.display(), e))
+            McpError::Config(format!(
+                "Failed to write temp config file {}: {}",
+                tmp_path.display(),
+                e
+            ))
         })?;
     }
 
     #[cfg(not(unix))]
     {
         std::fs::write(&tmp_path, content).map_err(|e| {
-            McpError::Config(format!("Failed to write temp config file {}: {}", tmp_path.display(), e))
+            McpError::Config(format!(
+                "Failed to write temp config file {}: {}",
+                tmp_path.display(),
+                e
+            ))
         })?;
     }
 

--- a/crates/opendev-mcp/src/config.rs
+++ b/crates/opendev-mcp/src/config.rs
@@ -165,9 +165,33 @@ pub fn save_config(config: &McpConfig, config_path: &Path) -> McpResult<()> {
     }
 
     let content = serde_json::to_string_pretty(config)?;
-    std::fs::write(config_path, content).map_err(|e| {
+
+    let tmp_path = config_path.with_extension("json.tmp");
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut opts = std::fs::OpenOptions::new();
+        opts.write(true).create(true).truncate(true).mode(0o600);
+
+        let mut file = opts.open(&tmp_path).map_err(|e| {
+            McpError::Config(format!("Failed to open temp config file {}: {}", tmp_path.display(), e))
+        })?;
+        std::io::Write::write_all(&mut file, content.as_bytes()).map_err(|e| {
+            McpError::Config(format!("Failed to write temp config file {}: {}", tmp_path.display(), e))
+        })?;
+    }
+
+    #[cfg(not(unix))]
+    {
+        std::fs::write(&tmp_path, content).map_err(|e| {
+            McpError::Config(format!("Failed to write temp config file {}: {}", tmp_path.display(), e))
+        })?;
+    }
+
+    std::fs::rename(&tmp_path, config_path).map_err(|e| {
         McpError::Config(format!(
-            "Failed to write MCP config to {}: {}",
+            "Failed to rename temp config to {}: {}",
             config_path.display(),
             e
         ))

--- a/crates/opendev-web/src/routes/mcp/io.rs
+++ b/crates/opendev-web/src/routes/mcp/io.rs
@@ -73,8 +73,32 @@ pub(super) fn save_server_to_config(
     let content = serde_json::to_string_pretty(&mcp_config)
         .map_err(|e| WebError::Internal(format!("Failed to serialize config: {}", e)))?;
 
-    std::fs::write(config_path, content)
-        .map_err(|e| WebError::Internal(format!("Failed to write config: {}", e)))?;
+    let tmp_path = config_path.with_extension("json.tmp");
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut opts = std::fs::OpenOptions::new();
+        opts.write(true).create(true).truncate(true).mode(0o600);
+
+        let mut file = opts.open(&tmp_path).map_err(|e| {
+            WebError::Internal(format!("Failed to open temp config file {}: {}", tmp_path.display(), e))
+        })?;
+        std::io::Write::write_all(&mut file, content.as_bytes()).map_err(|e| {
+            WebError::Internal(format!("Failed to write temp config file {}: {}", tmp_path.display(), e))
+        })?;
+    }
+
+    #[cfg(not(unix))]
+    {
+        std::fs::write(&tmp_path, content).map_err(|e| {
+            WebError::Internal(format!("Failed to write temp config file {}: {}", tmp_path.display(), e))
+        })?;
+    }
+
+    std::fs::rename(&tmp_path, config_path).map_err(|e| {
+        WebError::Internal(format!("Failed to rename temp config to {}: {}", config_path.display(), e))
+    })?;
 
     Ok(())
 }
@@ -96,8 +120,33 @@ pub(super) fn remove_server_from_config(name: &str, config_path: &Path) -> Resul
     if removed {
         let content = serde_json::to_string_pretty(&mcp_config)
             .map_err(|e| WebError::Internal(format!("Failed to serialize config: {}", e)))?;
-        std::fs::write(config_path, content)
-            .map_err(|e| WebError::Internal(format!("Failed to write config: {}", e)))?;
+
+        let tmp_path = config_path.with_extension("json.tmp");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            let mut opts = std::fs::OpenOptions::new();
+            opts.write(true).create(true).truncate(true).mode(0o600);
+
+            let mut file = opts.open(&tmp_path).map_err(|e| {
+                WebError::Internal(format!("Failed to open temp config file {}: {}", tmp_path.display(), e))
+            })?;
+            std::io::Write::write_all(&mut file, content.as_bytes()).map_err(|e| {
+                WebError::Internal(format!("Failed to write temp config file {}: {}", tmp_path.display(), e))
+            })?;
+        }
+
+        #[cfg(not(unix))]
+        {
+            std::fs::write(&tmp_path, content).map_err(|e| {
+                WebError::Internal(format!("Failed to write temp config file {}: {}", tmp_path.display(), e))
+            })?;
+        }
+
+        std::fs::rename(&tmp_path, config_path).map_err(|e| {
+            WebError::Internal(format!("Failed to rename temp config to {}: {}", config_path.display(), e))
+        })?;
     }
 
     Ok(removed)

--- a/crates/opendev-web/src/routes/mcp/io.rs
+++ b/crates/opendev-web/src/routes/mcp/io.rs
@@ -82,22 +82,38 @@ pub(super) fn save_server_to_config(
         opts.write(true).create(true).truncate(true).mode(0o600);
 
         let mut file = opts.open(&tmp_path).map_err(|e| {
-            WebError::Internal(format!("Failed to open temp config file {}: {}", tmp_path.display(), e))
+            WebError::Internal(format!(
+                "Failed to open temp config file {}: {}",
+                tmp_path.display(),
+                e
+            ))
         })?;
         std::io::Write::write_all(&mut file, content.as_bytes()).map_err(|e| {
-            WebError::Internal(format!("Failed to write temp config file {}: {}", tmp_path.display(), e))
+            WebError::Internal(format!(
+                "Failed to write temp config file {}: {}",
+                tmp_path.display(),
+                e
+            ))
         })?;
     }
 
     #[cfg(not(unix))]
     {
         std::fs::write(&tmp_path, content).map_err(|e| {
-            WebError::Internal(format!("Failed to write temp config file {}: {}", tmp_path.display(), e))
+            WebError::Internal(format!(
+                "Failed to write temp config file {}: {}",
+                tmp_path.display(),
+                e
+            ))
         })?;
     }
 
     std::fs::rename(&tmp_path, config_path).map_err(|e| {
-        WebError::Internal(format!("Failed to rename temp config to {}: {}", config_path.display(), e))
+        WebError::Internal(format!(
+            "Failed to rename temp config to {}: {}",
+            config_path.display(),
+            e
+        ))
     })?;
 
     Ok(())
@@ -130,22 +146,38 @@ pub(super) fn remove_server_from_config(name: &str, config_path: &Path) -> Resul
             opts.write(true).create(true).truncate(true).mode(0o600);
 
             let mut file = opts.open(&tmp_path).map_err(|e| {
-                WebError::Internal(format!("Failed to open temp config file {}: {}", tmp_path.display(), e))
+                WebError::Internal(format!(
+                    "Failed to open temp config file {}: {}",
+                    tmp_path.display(),
+                    e
+                ))
             })?;
             std::io::Write::write_all(&mut file, content.as_bytes()).map_err(|e| {
-                WebError::Internal(format!("Failed to write temp config file {}: {}", tmp_path.display(), e))
+                WebError::Internal(format!(
+                    "Failed to write temp config file {}: {}",
+                    tmp_path.display(),
+                    e
+                ))
             })?;
         }
 
         #[cfg(not(unix))]
         {
             std::fs::write(&tmp_path, content).map_err(|e| {
-                WebError::Internal(format!("Failed to write temp config file {}: {}", tmp_path.display(), e))
+                WebError::Internal(format!(
+                    "Failed to write temp config file {}: {}",
+                    tmp_path.display(),
+                    e
+                ))
             })?;
         }
 
         std::fs::rename(&tmp_path, config_path).map_err(|e| {
-            WebError::Internal(format!("Failed to rename temp config to {}: {}", config_path.display(), e))
+            WebError::Internal(format!(
+                "Failed to rename temp config to {}: {}",
+                config_path.display(),
+                e
+            ))
         })?;
     }
 


### PR DESCRIPTION
Superseded. MCP config secure write already on main via earlier merges.