### PR TITLE
🛡️ Sentinel: [HIGH] Fix insecure file permissions in MCP config save

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Time-of-Check to Time-of-Use (TOCTOU) vulnerability where sensitive files (like `auth.json`) were created with default permissions using `std::fs::write` and then restricted using `std::fs::set_permissions(..., 0o600)`. This leaves a brief window where the file is readable by others.
 **Learning:** Post-creation permission modification leaves a race condition window that can be exploited, especially for files storing API keys and credentials.
 **Prevention:** Always use `std::fs::OpenOptions` with `std::os::unix::fs::OpenOptionsExt::mode(0o600)` to securely and atomically create the file with restricted permissions before writing any data to it.
+## 2024-12-16 - Insecure File Permissions in Configuration Saves
+**Vulnerability:** The `save_config` function in `crates/opendev-mcp/src/config.rs` used `std::fs::write` to save MCP configurations, which could contain sensitive OAuth credentials, without explicitly enforcing secure file permissions. It was also not atomic.
+**Learning:** Using default file creation APIs can lead to files with sensitive content being accessible by other users on the system if default umask settings are permissive. In addition, direct writing to the target path is prone to partial writes.
+**Prevention:** Use an atomic write pattern with a temporary file, and on Unix-like systems, set explicitly restrictive permissions `0o600` via `OpenOptionsExt` before renaming the file to the final destination.

--- a/crates/opendev-mcp/src/config.rs
+++ b/crates/opendev-mcp/src/config.rs
@@ -165,9 +165,44 @@ pub fn save_config(config: &McpConfig, config_path: &Path) -> McpResult<()> {
     }
 
     let content = serde_json::to_string_pretty(config)?;
-    std::fs::write(config_path, content).map_err(|e| {
+    let tmp_path = config_path.with_extension("json.tmp");
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut opts = std::fs::OpenOptions::new();
+        opts.write(true).create(true).truncate(true).mode(0o600);
+
+        let mut file = opts.open(&tmp_path).map_err(|e| {
+            McpError::Config(format!(
+                "Failed to open tmp file {}: {}",
+                tmp_path.display(),
+                e
+            ))
+        })?;
+        std::io::Write::write_all(&mut file, content.as_bytes()).map_err(|e| {
+            McpError::Config(format!(
+                "Failed to write MCP config to {}: {}",
+                tmp_path.display(),
+                e
+            ))
+        })?;
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::write(&tmp_path, &content).map_err(|e| {
+            McpError::Config(format!(
+                "Failed to write MCP config to {}: {}",
+                tmp_path.display(),
+                e
+            ))
+        })?;
+    }
+
+    std::fs::rename(&tmp_path, config_path).map_err(|e| {
         McpError::Config(format!(
-            "Failed to write MCP config to {}: {}",
+            "Failed to rename tmp file {} to {}: {}",
+            tmp_path.display(),
             config_path.display(),
             e
         ))


### PR DESCRIPTION
🎯 **What**
Updates the MCP configuration saving mechanism to use secure file permissions (`0o600` on Unix systems) and an atomic write pattern using a temporary file.

⚠️ **Risk**
The previous implementation used standard `std::fs::write` to directly overwrite the configuration file. This was neither atomic (risking partial writes and corruption) nor did it enforce strict permissions, potentially leaving the file readable by other users on the system if default umask settings were permissive. Given that `mcp.json` can contain sensitive `McpOAuthConfig` data (like OAuth secrets), this constituted a local privilege escalation or data leak risk.

🛡️ **Solution**
Implemented a secure file saving pattern:
1. Serialize the configuration to a temporary `.tmp` file.
2. On Unix, use `std::fs::OpenOptions` with `OpenOptionsExt::mode(0o600)` to ensure the temporary file is created with restrictive permissions (read/write by owner only).
3. Atomically rename the temporary file to the final destination using `std::fs::rename`, which prevents TOCTOU vulnerabilities and partial reads during updates.

---
*PR created automatically by Jules for task [4163437861567483041](https://jules.google.com/task/4163437861567483041) started by @bdqnghi*