### PR TITLE
🛡️ Sentinel: [HIGH] Fix insecure permissions on MCP config files

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Time-of-Check to Time-of-Use (TOCTOU) vulnerability where sensitive files (like `auth.json`) were created with default permissions using `std::fs::write` and then restricted using `std::fs::set_permissions(..., 0o600)`. This leaves a brief window where the file is readable by others.
 **Learning:** Post-creation permission modification leaves a race condition window that can be exploited, especially for files storing API keys and credentials.
 **Prevention:** Always use `std::fs::OpenOptions` with `std::os::unix::fs::OpenOptionsExt::mode(0o600)` to securely and atomically create the file with restricted permissions before writing any data to it.
+## 2025-04-08 - Insecure File Permissions on MCP Configurations
+**Vulnerability:** The MCP configuration files (`mcp.json`), which can contain sensitive `oauth` client secrets, were being written using `std::fs::write`, which relies on the system's default `umask` (often `0644`). This allowed the sensitive secrets to be read by any local user on the machine.
+**Learning:** `std::fs::write` does not allow specifying file permissions on creation, making it unsuitable for writing sensitive configuration files or credentials.
+**Prevention:** Always use `std::fs::OpenOptions` with `.mode(0o600)` (on Unix) via `std::os::unix::fs::OpenOptionsExt` when writing files that contain sensitive configurations, combined with an atomic rename to prevent TOCTOU races.

--- a/crates/opendev-mcp/src/config.rs
+++ b/crates/opendev-mcp/src/config.rs
@@ -165,9 +165,31 @@ pub fn save_config(config: &McpConfig, config_path: &Path) -> McpResult<()> {
     }
 
     let content = serde_json::to_string_pretty(config)?;
-    std::fs::write(config_path, content).map_err(|e| {
+
+    let tmp_path = config_path.with_extension("json.tmp");
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut opts = std::fs::OpenOptions::new();
+        opts.write(true).create(true).truncate(true).mode(0o600);
+
+        let mut file = opts
+            .open(&tmp_path)
+            .map_err(|e| McpError::Config(format!("Failed to open tmp config file: {}", e)))?;
+        std::io::Write::write_all(&mut file, content.as_bytes())
+            .map_err(|e| McpError::Config(format!("Failed to write tmp config file: {}", e)))?;
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::write(&tmp_path, content)
+            .map_err(|e| McpError::Config(format!("Failed to write tmp config file: {}", e)))?;
+    }
+
+    std::fs::rename(&tmp_path, config_path).map_err(|e| {
+        let _ = std::fs::remove_file(&tmp_path);
         McpError::Config(format!(
-            "Failed to write MCP config to {}: {}",
+            "Failed to rename config file {}: {}",
             config_path.display(),
             e
         ))

--- a/crates/opendev-web/src/routes/mcp/io.rs
+++ b/crates/opendev-web/src/routes/mcp/io.rs
@@ -73,8 +73,7 @@ pub(super) fn save_server_to_config(
     let content = serde_json::to_string_pretty(&mcp_config)
         .map_err(|e| WebError::Internal(format!("Failed to serialize config: {}", e)))?;
 
-    std::fs::write(config_path, content)
-        .map_err(|e| WebError::Internal(format!("Failed to write config: {}", e)))?;
+    secure_atomic_write(config_path, &content)?;
 
     Ok(())
 }
@@ -96,11 +95,40 @@ pub(super) fn remove_server_from_config(name: &str, config_path: &Path) -> Resul
     if removed {
         let content = serde_json::to_string_pretty(&mcp_config)
             .map_err(|e| WebError::Internal(format!("Failed to serialize config: {}", e)))?;
-        std::fs::write(config_path, content)
-            .map_err(|e| WebError::Internal(format!("Failed to write config: {}", e)))?;
+        secure_atomic_write(config_path, &content)?;
     }
 
     Ok(removed)
+}
+
+/// Securely write to a file using a temporary file and atomic rename.
+fn secure_atomic_write(path: &Path, content: &str) -> Result<(), WebError> {
+    let tmp_path = path.with_extension("json.tmp");
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut opts = std::fs::OpenOptions::new();
+        opts.write(true).create(true).truncate(true).mode(0o600);
+
+        let mut file = opts
+            .open(&tmp_path)
+            .map_err(|e| WebError::Internal(format!("Failed to open tmp config file: {}", e)))?;
+        std::io::Write::write_all(&mut file, content.as_bytes())
+            .map_err(|e| WebError::Internal(format!("Failed to write tmp config file: {}", e)))?;
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::write(&tmp_path, content)
+            .map_err(|e| WebError::Internal(format!("Failed to write tmp config file: {}", e)))?;
+    }
+
+    std::fs::rename(&tmp_path, path).map_err(|e| {
+        let _ = std::fs::remove_file(&tmp_path);
+        WebError::Internal(format!("Failed to rename config file: {}", e))
+    })?;
+
+    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The MCP configuration files (`mcp.json`), which can contain sensitive `oauth` credentials, were being written using `std::fs::write`, which relies on the system default `umask` (often `0644`). This allowed any local user to read the sensitive secrets.
🎯 Impact: Local privilege escalation / credentials leak if another user on the same machine accesses the `.opendev/mcp.json` file.
🔧 Fix: Implemented a secure atomic write pattern using a temporary file with restrictive permissions (`0o600`) via `std::os::unix::fs::OpenOptionsExt` before renaming to the target destination.
✅ Verification: Ran `cargo test`, `cargo clippy`, and `cargo fmt`.

---
*PR created automatically by Jules for task [13180977119248223857](https://jules.google.com/task/13180977119248223857) started by @bdqnghi*