### PR TITLE
feat(tools-core): enrich BaseTool trait with self-describing methods

### DIFF
--- a/crates/opendev-agents/src/react_loop/phases/tool_dispatch.rs
+++ b/crates/opendev-agents/src/react_loop/phases/tool_dispatch.rs
@@ -873,7 +873,20 @@ where
         })
         .collect();
 
-    let batches = ParallelPolicy::partition(&parallel_calls);
+    // Look up tool instances for input-dependent concurrency decisions
+    let tool_instances: Vec<_> = parallel_calls
+        .iter()
+        .filter_map(|tc| tool_registry.get(&tc.name))
+        .collect();
+    let tool_refs: Vec<&dyn opendev_tools_core::BaseTool> =
+        tool_instances.iter().map(|t| t.as_ref()).collect();
+
+    let batches = if tool_refs.len() == parallel_calls.len() {
+        ParallelPolicy::partition_with_tools(&parallel_calls, &tool_refs)
+    } else {
+        // Fallback if some tools weren't found in registry
+        ParallelPolicy::partition(&parallel_calls)
+    };
 
     // If no batch has >1 element, fall through to sequential execution
     if !ParallelPolicy::has_parallel_batches(&batches) {

--- a/crates/opendev-repl/src/tool_executor.rs
+++ b/crates/opendev-repl/src/tool_executor.rs
@@ -136,7 +136,19 @@ impl ToolExecutor {
             })
             .collect();
 
-        let groups = ParallelPolicy::partition(&policy_calls);
+        // Look up tool instances for input-dependent concurrency decisions
+        let tool_instances: Vec<_> = policy_calls
+            .iter()
+            .filter_map(|tc| registry.get(&tc.name))
+            .collect();
+        let tool_refs: Vec<&dyn opendev_tools_core::BaseTool> =
+            tool_instances.iter().map(|t| t.as_ref()).collect();
+
+        let groups = if tool_refs.len() == policy_calls.len() {
+            ParallelPolicy::partition_with_tools(&policy_calls, &tool_refs)
+        } else {
+            ParallelPolicy::partition(&policy_calls)
+        };
 
         // Pre-allocate result slots (filled out-of-order for parallel groups).
         let mut results: Vec<Option<Result<ToolExecutionResult, ReplError>>> =

--- a/crates/opendev-tools-core/src/lib.rs
+++ b/crates/opendev-tools-core/src/lib.rs
@@ -26,6 +26,7 @@ pub use policy::ToolPolicy;
 pub use registry::ToolRegistry;
 pub use sanitizer::{ToolResultSanitizer, cleanup_overflow_dir};
 pub use traits::{
-    BaseTool, DiagnosticProvider, FileDiagnostic, ToolContext, ToolDisplayMeta, ToolError,
-    ToolResult, ToolTimeoutConfig, ValidationError,
+    BaseTool, DiagnosticProvider, FileDiagnostic, InterruptBehavior, ToolCategory, ToolContext,
+    ToolDisplayMeta, ToolError, ToolResult, ToolTimeoutConfig, TruncationRule, TruncationStrategy,
+    ValidationError,
 };

--- a/crates/opendev-tools-core/src/parallel.rs
+++ b/crates/opendev-tools-core/src/parallel.rs
@@ -1,11 +1,20 @@
 //! Parallel execution policy for tool calls.
 //!
 //! Determines which tool calls can be safely executed in parallel and partitions
-//! them into ordered execution groups.
+//! them into ordered execution groups. Uses `BaseTool::is_concurrent_safe()` to
+//! make input-dependent decisions (e.g., `Bash` with `ls` is safe, `Bash` with
+//! `rm` is not).
 
+use std::collections::HashMap;
 use std::collections::HashSet;
 
+use crate::traits::BaseTool;
+
 /// Tools that are always safe to parallelize (read-only operations).
+///
+/// **Deprecated:** This hardcoded list is kept as a fallback for the legacy
+/// `partition()` method. New callers should use `partition_with_tools()` which
+/// consults `BaseTool::is_concurrent_safe()` instead.
 fn read_only_tools() -> HashSet<&'static str> {
     HashSet::from([
         // File reading
@@ -52,19 +61,67 @@ impl ToolCall {
 
 /// Partitions tool calls into ordered execution batches.
 ///
-/// Consecutive read-only tools are grouped into a single batch (safe to run in
-/// parallel). Non-read-only tools each get their own batch (run serially).
-/// Batches execute in strict positional order, preserving the LLM's intended
-/// tool call sequence.
+/// Consecutive concurrent-safe tools are grouped into a single batch (safe to
+/// run in parallel). Non-concurrent tools each get their own batch (run
+/// serially). Batches execute in strict positional order, preserving the LLM's
+/// intended tool call sequence.
 ///
 /// Example: `[Read, Grep, Edit, Read, Glob]` → `[[0,1], [2], [3,4]]`
 pub struct ParallelPolicy;
 
 impl ParallelPolicy {
-    /// Partition tool calls into ordered execution batches.
+    /// Partition tool calls using `BaseTool::is_concurrent_safe()`.
     ///
-    /// Each batch can be executed in parallel internally. Batches must execute
-    /// in order. Batches with a single element run serially.
+    /// This is the preferred method — it consults each tool's trait method,
+    /// enabling input-dependent concurrency decisions.
+    pub fn partition_with_tools(
+        tool_calls: &[ToolCall],
+        tools: &[&dyn BaseTool],
+    ) -> Vec<Vec<usize>> {
+        if tool_calls.len() <= 1 {
+            return if tool_calls.is_empty() {
+                vec![]
+            } else {
+                vec![vec![0]]
+            };
+        }
+
+        let mut groups: Vec<Vec<usize>> = Vec::new();
+        let mut current_concurrent: Vec<usize> = Vec::new();
+
+        for (i, tc) in tool_calls.iter().enumerate() {
+            let args: HashMap<String, serde_json::Value> =
+                if let Some(obj) = tc.arguments.as_object() {
+                    obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
+                } else {
+                    HashMap::new()
+                };
+
+            let is_safe = tools
+                .get(i)
+                .map(|t| t.is_concurrent_safe(&args))
+                .unwrap_or(false);
+
+            if is_safe {
+                current_concurrent.push(i);
+            } else {
+                if !current_concurrent.is_empty() {
+                    groups.push(std::mem::take(&mut current_concurrent));
+                }
+                groups.push(vec![i]);
+            }
+        }
+
+        if !current_concurrent.is_empty() {
+            groups.push(current_concurrent);
+        }
+
+        groups
+    }
+
+    /// Partition tool calls using the hardcoded read-only tool list.
+    ///
+    /// **Deprecated:** Prefer `partition_with_tools()` which uses trait methods.
     pub fn partition(tool_calls: &[ToolCall]) -> Vec<Vec<usize>> {
         if tool_calls.len() <= 1 {
             return if tool_calls.is_empty() {

--- a/crates/opendev-tools-core/src/parallel_tests.rs
+++ b/crates/opendev-tools-core/src/parallel_tests.rs
@@ -1,7 +1,101 @@
+use std::collections::HashMap;
+
 use super::*;
+use crate::traits::{BaseTool, ToolCategory, ToolContext, ToolResult};
 
 fn tc(name: &str, args: serde_json::Value) -> ToolCall {
     ToolCall::new(name, args)
+}
+
+// --- Mock tools for partition_with_tools tests ---
+
+#[derive(Debug)]
+struct ReadOnlyTool;
+
+#[async_trait::async_trait]
+impl BaseTool for ReadOnlyTool {
+    fn name(&self) -> &str {
+        "ReadOnly"
+    }
+    fn description(&self) -> &str {
+        "read-only tool"
+    }
+    fn parameter_schema(&self) -> serde_json::Value {
+        serde_json::json!({"type": "object"})
+    }
+    fn is_read_only(&self, _args: &HashMap<String, serde_json::Value>) -> bool {
+        true
+    }
+    fn category(&self) -> ToolCategory {
+        ToolCategory::Read
+    }
+    async fn execute(
+        &self,
+        _args: HashMap<String, serde_json::Value>,
+        _ctx: &ToolContext,
+    ) -> ToolResult {
+        ToolResult::ok("ok")
+    }
+}
+
+#[derive(Debug)]
+struct WriteTool;
+
+#[async_trait::async_trait]
+impl BaseTool for WriteTool {
+    fn name(&self) -> &str {
+        "Write"
+    }
+    fn description(&self) -> &str {
+        "write tool"
+    }
+    fn parameter_schema(&self) -> serde_json::Value {
+        serde_json::json!({"type": "object"})
+    }
+    fn category(&self) -> ToolCategory {
+        ToolCategory::Write
+    }
+    async fn execute(
+        &self,
+        _args: HashMap<String, serde_json::Value>,
+        _ctx: &ToolContext,
+    ) -> ToolResult {
+        ToolResult::ok("ok")
+    }
+}
+
+#[derive(Debug)]
+struct InputDependentTool;
+
+#[async_trait::async_trait]
+impl BaseTool for InputDependentTool {
+    fn name(&self) -> &str {
+        "Bash"
+    }
+    fn description(&self) -> &str {
+        "input-dependent tool"
+    }
+    fn parameter_schema(&self) -> serde_json::Value {
+        serde_json::json!({"type": "object"})
+    }
+    fn is_read_only(&self, args: &HashMap<String, serde_json::Value>) -> bool {
+        args.get("command")
+            .and_then(|v| v.as_str())
+            .is_some_and(|cmd| cmd.starts_with("ls") || cmd.starts_with("cat"))
+    }
+    fn is_concurrent_safe(&self, args: &HashMap<String, serde_json::Value>) -> bool {
+        self.is_read_only(args)
+    }
+    fn category(&self) -> ToolCategory {
+        ToolCategory::Process
+    }
+    async fn execute(
+        &self,
+        _args: HashMap<String, serde_json::Value>,
+        _ctx: &ToolContext,
+    ) -> ToolResult {
+        ToolResult::ok("ok")
+    }
 }
 
 #[test]
@@ -107,4 +201,115 @@ fn test_has_parallel_batches() {
     assert!(!ParallelPolicy::has_parallel_batches(&[vec![0], vec![1]]));
     assert!(ParallelPolicy::has_parallel_batches(&[vec![0, 1]]));
     assert!(ParallelPolicy::has_parallel_batches(&[vec![0], vec![1, 2]]));
+}
+
+// -----------------------------------------------------------------------
+// partition_with_tools — trait-based partitioning
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_partition_with_tools_empty() {
+    let groups = ParallelPolicy::partition_with_tools(&[], &[]);
+    assert!(groups.is_empty());
+}
+
+#[test]
+fn test_partition_with_tools_single() {
+    let ro = ReadOnlyTool;
+    let calls = vec![tc("ReadOnly", serde_json::json!({}))];
+    let tools: Vec<&dyn BaseTool> = vec![&ro];
+    let groups = ParallelPolicy::partition_with_tools(&calls, &tools);
+    assert_eq!(groups, vec![vec![0]]);
+}
+
+#[test]
+fn test_partition_with_tools_all_read_only() {
+    let ro1 = ReadOnlyTool;
+    let ro2 = ReadOnlyTool;
+    let ro3 = ReadOnlyTool;
+    let calls = vec![
+        tc("ReadOnly", serde_json::json!({})),
+        tc("ReadOnly", serde_json::json!({})),
+        tc("ReadOnly", serde_json::json!({})),
+    ];
+    let tools: Vec<&dyn BaseTool> = vec![&ro1, &ro2, &ro3];
+    let groups = ParallelPolicy::partition_with_tools(&calls, &tools);
+    assert_eq!(groups, vec![vec![0, 1, 2]]);
+}
+
+#[test]
+fn test_partition_with_tools_all_writes() {
+    let w1 = WriteTool;
+    let w2 = WriteTool;
+    let calls = vec![
+        tc("Write", serde_json::json!({})),
+        tc("Write", serde_json::json!({})),
+    ];
+    let tools: Vec<&dyn BaseTool> = vec![&w1, &w2];
+    let groups = ParallelPolicy::partition_with_tools(&calls, &tools);
+    assert_eq!(groups, vec![vec![0], vec![1]]);
+}
+
+#[test]
+fn test_partition_with_tools_mixed_preserves_order() {
+    let ro1 = ReadOnlyTool;
+    let ro2 = ReadOnlyTool;
+    let w = WriteTool;
+    let ro3 = ReadOnlyTool;
+    let ro4 = ReadOnlyTool;
+    let calls = vec![
+        tc("ReadOnly", serde_json::json!({})),
+        tc("ReadOnly", serde_json::json!({})),
+        tc("Write", serde_json::json!({})),
+        tc("ReadOnly", serde_json::json!({})),
+        tc("ReadOnly", serde_json::json!({})),
+    ];
+    let tools: Vec<&dyn BaseTool> = vec![&ro1, &ro2, &w, &ro3, &ro4];
+    let groups = ParallelPolicy::partition_with_tools(&calls, &tools);
+    assert_eq!(groups, vec![vec![0, 1], vec![2], vec![3, 4]]);
+}
+
+#[test]
+fn test_partition_with_tools_input_dependent_bash() {
+    let bash_ls = InputDependentTool;
+    let bash_rm = InputDependentTool;
+    let bash_cat = InputDependentTool;
+    let calls = vec![
+        tc("Bash", serde_json::json!({"command": "ls -la"})),
+        tc("Bash", serde_json::json!({"command": "rm file.txt"})),
+        tc("Bash", serde_json::json!({"command": "cat foo.rs"})),
+    ];
+    let tools: Vec<&dyn BaseTool> = vec![&bash_ls, &bash_rm, &bash_cat];
+    let groups = ParallelPolicy::partition_with_tools(&calls, &tools);
+    assert_eq!(groups, vec![vec![0], vec![1], vec![2]]);
+}
+
+#[test]
+fn test_partition_with_tools_bash_reads_batched_with_reads() {
+    let ro = ReadOnlyTool;
+    let bash_ls = InputDependentTool;
+    let ro2 = ReadOnlyTool;
+    let calls = vec![
+        tc("Read", serde_json::json!({})),
+        tc("Bash", serde_json::json!({"command": "ls -la"})),
+        tc("Read", serde_json::json!({})),
+    ];
+    let tools: Vec<&dyn BaseTool> = vec![&ro, &bash_ls, &ro2];
+    let groups = ParallelPolicy::partition_with_tools(&calls, &tools);
+    assert_eq!(groups, vec![vec![0, 1, 2]]);
+}
+
+#[test]
+fn test_partition_with_tools_bash_write_breaks_batch() {
+    let ro = ReadOnlyTool;
+    let bash_rm = InputDependentTool;
+    let ro2 = ReadOnlyTool;
+    let calls = vec![
+        tc("Read", serde_json::json!({})),
+        tc("Bash", serde_json::json!({"command": "rm file.txt"})),
+        tc("Read", serde_json::json!({})),
+    ];
+    let tools: Vec<&dyn BaseTool> = vec![&ro, &bash_rm, &ro2];
+    let groups = ParallelPolicy::partition_with_tools(&calls, &tools);
+    assert_eq!(groups, vec![vec![0], vec![1], vec![2]]);
 }

--- a/crates/opendev-tools-core/src/policy.rs
+++ b/crates/opendev-tools-core/src/policy.rs
@@ -2,8 +2,14 @@
 //!
 //! Defines tool groups (read, write, process, etc.) and profiles (minimal, review,
 //! coding, full) that compose groups into permission sets.
+//!
+//! The legacy `tool_groups()` function is a hardcoded tool→group mapping.
+//! `resolve_from_registry()` dynamically builds groups from `BaseTool::category()`,
+//! so newly registered tools automatically join the correct group.
 
 use std::collections::{HashMap, HashSet};
+
+use crate::traits::ToolCategory;
 
 /// Tool groups — categorize tools by function.
 fn tool_groups() -> HashMap<&'static str, HashSet<&'static str>> {
@@ -213,6 +219,94 @@ impl ToolPolicy {
             .get(group_name)
             .map(|tools| tools.iter().map(|t| (*t).to_string()).collect())
             .unwrap_or_default()
+    }
+
+    /// Resolve allowed tools using `BaseTool::category()` from the registry.
+    ///
+    /// Builds groups dynamically so newly registered tools automatically
+    /// join the correct group. Falls back to `resolve()` semantics for
+    /// profile→group mapping.
+    pub fn resolve_from_registry(
+        profile: &str,
+        registry: &crate::registry::ToolRegistry,
+        additions: Option<&[&str]>,
+        exclusions: Option<&[&str]>,
+    ) -> Result<HashSet<String>, String> {
+        let all_profiles = profiles();
+        let group_names = match all_profiles.get(profile) {
+            Some(g) => g,
+            None => {
+                let available: Vec<_> = all_profiles.keys().collect();
+                return Err(format!(
+                    "Unknown tool profile: '{}'. Available: {:?}",
+                    profile, available
+                ));
+            }
+        };
+
+        // Build category → tool names from the registry
+        let tool_categories = registry.build_category_map();
+        let mut category_map: HashMap<&str, HashSet<String>> = HashMap::new();
+        for (cat, names) in &tool_categories {
+            let group_name = Self::category_to_group(*cat);
+            category_map
+                .entry(group_name)
+                .or_default()
+                .extend(names.iter().cloned());
+        }
+
+        // Also include hardcoded groups for tools not yet migrated
+        let hardcoded = tool_groups();
+
+        let mut allowed: HashSet<String> = HashSet::new();
+
+        for group_name in group_names {
+            // Prefer dynamic groups; fall back to hardcoded
+            if let Some(tools) = category_map.get(group_name) {
+                allowed.extend(tools.iter().cloned());
+            }
+            if let Some(tools) = hardcoded.get(group_name) {
+                for tool in tools {
+                    allowed.insert((*tool).to_string());
+                }
+            }
+        }
+
+        for tool in ALWAYS_ALLOWED {
+            allowed.insert((*tool).to_string());
+        }
+
+        if let Some(adds) = additions {
+            for tool in adds {
+                allowed.insert((*tool).to_string());
+            }
+        }
+
+        if let Some(excls) = exclusions {
+            for tool in excls {
+                allowed.remove(*tool);
+            }
+        }
+
+        Ok(allowed)
+    }
+
+    /// Map a `ToolCategory` to the corresponding group name string.
+    pub fn category_to_group(category: ToolCategory) -> &'static str {
+        match category {
+            ToolCategory::Read => "group:read",
+            ToolCategory::Write => "group:write",
+            ToolCategory::Process => "group:process",
+            ToolCategory::Web => "group:web",
+            ToolCategory::Session => "group:session",
+            ToolCategory::Memory => "group:memory",
+            ToolCategory::Meta => "group:meta",
+            ToolCategory::Messaging => "group:messaging",
+            ToolCategory::Automation => "group:automation",
+            ToolCategory::Symbol => "group:read", // Symbol tools are read-friendly
+            ToolCategory::Mcp => "group:mcp",
+            ToolCategory::Other => "group:meta", // Safe default
+        }
     }
 
     /// Get a human-readable description of a profile.

--- a/crates/opendev-tools-core/src/registry/execution.rs
+++ b/crates/opendev-tools-core/src/registry/execution.rs
@@ -147,9 +147,8 @@ impl ToolRegistry {
         let normalized = normalizer::normalize_params(tool_name, args, Some(&working_dir));
         debug!(tool = %tool_name, params = ?normalized, "Normalized tool params");
 
-        // Deduplication: check cache (skip for tools that must always run)
-        const NO_DEDUP: &[&str] = &["Agent", "spawn_subagent"];
-        let skip_dedup = NO_DEDUP.contains(&tool_name.as_str());
+        // Deduplication: check cache (skip for tools that declare skip_dedup)
+        let skip_dedup = tool.skip_dedup();
         let dedup_key = make_dedup_key(tool_name, &normalized);
         if !skip_dedup
             && let Ok(cache) = self.dedup_cache.lock()
@@ -213,13 +212,24 @@ impl ToolRegistry {
         let mut result = tool.execute(normalized, &exec_ctx).await;
         result.duration_ms = Some(start.elapsed().as_millis() as u64);
 
-        // Sanitize: truncate large outputs before they enter LLM context
-        let sanitized = self.sanitizer.sanitize_with_mcp_fallback(
-            tool_name,
-            result.success,
-            result.output.as_deref(),
-            result.error.as_deref(),
-        );
+        // Sanitize: truncate large outputs before they enter LLM context.
+        // Prefer the tool's own truncation_rule(); fall back to the sanitizer's built-in map.
+        let sanitized = if let Some(rule) = tool.truncation_rule() {
+            self.sanitizer.sanitize_with_rule(
+                tool_name,
+                &rule,
+                result.success,
+                result.output.as_deref(),
+                result.error.as_deref(),
+            )
+        } else {
+            self.sanitizer.sanitize_with_mcp_fallback(
+                tool_name,
+                result.success,
+                result.output.as_deref(),
+                result.error.as_deref(),
+            )
+        };
         if sanitized.was_truncated {
             result.output = sanitized.output;
             result.error = sanitized.error;

--- a/crates/opendev-tools-core/src/registry/mod.rs
+++ b/crates/opendev-tools-core/src/registry/mod.rs
@@ -297,6 +297,19 @@ impl ToolRegistry {
             .collect()
     }
 
+    /// Build a map of `ToolCategory` → tool names from all registered tools.
+    ///
+    /// Used by `ToolPolicy::resolve_from_registry()` to dynamically derive
+    /// groups from `BaseTool::category()` instead of hardcoded lists.
+    pub fn build_category_map(&self) -> HashMap<crate::traits::ToolCategory, Vec<String>> {
+        let tools = self.tools.read().expect("ToolRegistry lock poisoned");
+        let mut map: HashMap<crate::traits::ToolCategory, Vec<String>> = HashMap::new();
+        for (name, tool) in tools.iter() {
+            map.entry(tool.category()).or_default().push(name.clone());
+        }
+        map
+    }
+
     /// Get OpenAI-compatible function schemas for all registered tools.
     pub fn get_schemas(&self) -> Vec<serde_json::Value> {
         let tools = self.tools.read().expect("ToolRegistry lock poisoned");

--- a/crates/opendev-tools-core/src/sanitizer.rs
+++ b/crates/opendev-tools-core/src/sanitizer.rs
@@ -302,6 +302,96 @@ impl ToolResultSanitizer {
         self.sanitize(tool_name, success, output, error)
     }
 
+    /// Sanitize using an explicit truncation rule (from `BaseTool::truncation_rule()`).
+    ///
+    /// This bypasses the built-in rule map entirely, using only the provided rule.
+    pub fn sanitize_with_rule(
+        &self,
+        tool_name: &str,
+        rule: &TruncationRule,
+        success: bool,
+        output: Option<&str>,
+        error: Option<&str>,
+    ) -> SanitizedResult {
+        // Truncate error messages
+        if !success {
+            let truncated_error = error.map(|e| {
+                if e.len() > ERROR_MAX_CHARS {
+                    truncate_head(e, ERROR_MAX_CHARS)
+                } else {
+                    e.to_string()
+                }
+            });
+            return SanitizedResult {
+                output: output.map(String::from),
+                error: truncated_error,
+                was_truncated: false,
+                overflow_path: None,
+            };
+        }
+
+        let output_str = match output {
+            Some(s) if !s.is_empty() => s,
+            _ => {
+                return SanitizedResult {
+                    output: output.map(String::from),
+                    error: error.map(String::from),
+                    was_truncated: false,
+                    overflow_path: None,
+                };
+            }
+        };
+
+        if output_str.len() <= rule.max_chars {
+            return SanitizedResult {
+                output: Some(output_str.to_string()),
+                error: None,
+                was_truncated: false,
+                overflow_path: None,
+            };
+        }
+
+        let truncated = apply_strategy(output_str, rule);
+        let strategy_name = match &rule.strategy {
+            TruncationStrategy::Head => "head",
+            TruncationStrategy::Tail => "tail",
+            TruncationStrategy::HeadTail { .. } => "head_tail",
+        };
+
+        let overflow_path = self.save_overflow(tool_name, output_str);
+
+        let mut marker = format!(
+            "\n\n[truncated: showing {} of {} chars, strategy={}]",
+            truncated.len(),
+            output_str.len(),
+            strategy_name
+        );
+
+        if let Some(ref path) = overflow_path {
+            marker.push_str(&format!(
+                "\nFull output saved to: {}\n\
+                 Use read_file with offset/limit or search to access specific sections.",
+                path.display()
+            ));
+        }
+
+        debug!(
+            tool = tool_name,
+            original = output_str.len(),
+            truncated = truncated.len(),
+            strategy = strategy_name,
+            overflow = ?overflow_path,
+            "Truncated tool result via trait rule"
+        );
+
+        SanitizedResult {
+            output: Some(format!("{truncated}{marker}")),
+            error: None,
+            was_truncated: true,
+            overflow_path,
+        }
+    }
+
     /// Save full output to an overflow file. Returns the path if successful.
     fn save_overflow(&self, tool_name: &str, content: &str) -> Option<PathBuf> {
         let dir = self.overflow_dir.as_ref()?;

--- a/crates/opendev-tools-core/src/traits.rs
+++ b/crates/opendev-tools-core/src/traits.rs
@@ -321,6 +321,74 @@ impl Default for ToolContext {
     }
 }
 
+// Re-export truncation types from sanitizer so tools can return them from trait methods.
+pub use crate::sanitizer::{TruncationRule, TruncationStrategy};
+
+/// Tool category for grouping, policy, and permission purposes.
+///
+/// Replaces hardcoded `tool_groups()` in `policy.rs`. Using an enum enables
+/// compile-time exhaustive matching — adding a new category forces updates
+/// everywhere it is matched.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ToolCategory {
+    /// File reading, search, listing (Glob, Grep, Read).
+    Read,
+    /// File editing, writing (Edit, Write).
+    Write,
+    /// Bash/command execution.
+    Process,
+    /// Web operations (WebFetch, WebSearch, screenshots).
+    Web,
+    /// Session management, subagents.
+    Session,
+    /// Memory read/write.
+    Memory,
+    /// Todos, planning, task management.
+    Meta,
+    /// Inter-agent messaging (SendMessage).
+    Messaging,
+    /// Scheduling, cron.
+    Automation,
+    /// LSP, AST symbol operations.
+    Symbol,
+    /// MCP bridge tools.
+    Mcp,
+    /// Default fallback.
+    Other,
+}
+
+impl std::fmt::Display for ToolCategory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = match self {
+            Self::Read => "Read",
+            Self::Write => "Write",
+            Self::Process => "Process",
+            Self::Web => "Web",
+            Self::Session => "Session",
+            Self::Memory => "Memory",
+            Self::Meta => "Meta",
+            Self::Messaging => "Messaging",
+            Self::Automation => "Automation",
+            Self::Symbol => "Symbol",
+            Self::Mcp => "Mcp",
+            Self::Other => "Other",
+        };
+        write!(f, "{name}")
+    }
+}
+
+/// What happens when the user interrupts during this tool's execution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum InterruptBehavior {
+    /// Cancel the operation immediately (default for most tools).
+    #[default]
+    Cancel,
+    /// Block interruption until the tool completes (e.g., critical file writes).
+    Block,
+    /// Ignore the interrupt signal entirely.
+    Ignore,
+}
+
 /// Metadata describing how a tool should appear in the TUI.
 ///
 /// Tools return this from `display_meta()` so the display registry can
@@ -383,6 +451,126 @@ pub trait BaseTool: Send + Sync + std::fmt::Debug {
     /// Tools that override this allow the display registry to auto-discover
     /// their formatting. Returns `None` by default (falls back to static registry).
     fn display_meta(&self) -> Option<ToolDisplayMeta> {
+        None
+    }
+
+    // ── Classification (replaces hardcoded lists) ──────────────────────
+
+    /// Whether this tool only reads state and never modifies it.
+    ///
+    /// Used by `ParallelPolicy` to determine safe concurrent execution.
+    /// Takes `args` so the decision can be input-dependent — e.g., `Bash`
+    /// is read-only for `ls` but not for `rm`.
+    ///
+    /// Default: `false` (conservative — assume mutation).
+    fn is_read_only(&self, _args: &HashMap<String, serde_json::Value>) -> bool {
+        false
+    }
+
+    /// Whether this tool performs destructive/irreversible operations.
+    ///
+    /// Stricter than `!is_read_only()` — e.g., `Edit` is not read-only
+    /// but also not destructive (changes can be reverted).
+    ///
+    /// Default: `false`.
+    fn is_destructive(&self, _args: &HashMap<String, serde_json::Value>) -> bool {
+        false
+    }
+
+    /// Whether this tool can safely run concurrently with other concurrent-safe tools.
+    ///
+    /// Default: delegates to `is_read_only(args)`.
+    fn is_concurrent_safe(&self, args: &HashMap<String, serde_json::Value>) -> bool {
+        self.is_read_only(args)
+    }
+
+    /// The category this tool belongs to, for policy grouping.
+    ///
+    /// Replaces the hardcoded `tool_groups()` in `policy.rs`.
+    ///
+    /// Default: `ToolCategory::Other`.
+    fn category(&self) -> ToolCategory {
+        ToolCategory::Other
+    }
+
+    /// Whether to skip same-turn call deduplication.
+    ///
+    /// Replaces the hardcoded `NO_DEDUP` list in `execution.rs`.
+    /// Tools like `Agent` and `SendMessage` should return `true`.
+    ///
+    /// Default: `false` (dedup enabled).
+    fn skip_dedup(&self) -> bool {
+        false
+    }
+
+    /// Whether this is a search or read command (for TUI collapse).
+    ///
+    /// Default: delegates to `is_read_only(args)`.
+    fn is_search_or_read(&self, args: &HashMap<String, serde_json::Value>) -> bool {
+        self.is_read_only(args)
+    }
+
+    // ── Lifecycle ──────────────────────────────────────────────────────
+
+    /// Whether this tool is currently available.
+    ///
+    /// Runtime check — can depend on environment, config, or feature flags.
+    ///
+    /// Default: `true`.
+    fn is_enabled(&self) -> bool {
+        true
+    }
+
+    /// What happens when the user interrupts during this tool's execution.
+    ///
+    /// Default: `InterruptBehavior::Cancel`.
+    fn interrupt_behavior(&self) -> InterruptBehavior {
+        InterruptBehavior::default()
+    }
+
+    // ── Result handling ────────────────────────────────────────────────
+
+    /// Per-tool truncation rule for oversized outputs.
+    ///
+    /// Replaces the hardcoded `default_rules()` in `sanitizer.rs`.
+    /// When `Some`, the sanitizer uses this rule instead of its built-in map.
+    ///
+    /// Default: `None` (use sanitizer defaults).
+    fn truncation_rule(&self) -> Option<TruncationRule> {
+        None
+    }
+
+    // ── Search & discovery ─────────────────────────────────────────────
+
+    /// A short capability phrase for `ToolSearch` keyword matching.
+    ///
+    /// E.g., `"search file contents with regex"` for Grep.
+    /// Improves discovery when the model uses `ToolSearch` to find tools.
+    ///
+    /// Default: `None` (uses name + description only).
+    fn search_hint(&self) -> Option<&str> {
+        None
+    }
+
+    /// Whether this tool should be deferred (lazy-loaded via `ToolSearch`).
+    ///
+    /// Deferred tools have their schemas omitted from the initial prompt,
+    /// reducing token usage. The model discovers them via `ToolSearch`.
+    ///
+    /// Default: `false` (always loaded).
+    fn should_defer(&self) -> bool {
+        false
+    }
+
+    // ── System prompt ──────────────────────────────────────────────────
+
+    /// Optional text this tool contributes to the system prompt.
+    ///
+    /// E.g., `Bash` might add shell environment info, or `Memory` might
+    /// add instructions about memory file format.
+    ///
+    /// Default: `None`.
+    fn prompt_contribution(&self) -> Option<String> {
         None
     }
 }

--- a/crates/opendev-tools-core/src/traits_tests.rs
+++ b/crates/opendev-tools-core/src/traits_tests.rs
@@ -122,6 +122,160 @@ fn test_tool_context_default_no_timeout_config() {
     assert!(ctx.timeout_config.is_none());
 }
 
+// --- ToolCategory tests ---
+
+#[test]
+fn test_tool_category_serde_roundtrip() {
+    let cat = ToolCategory::Read;
+    let json = serde_json::to_string(&cat).unwrap();
+    assert_eq!(json, "\"Read\"");
+    let deserialized: ToolCategory = serde_json::from_str(&json).unwrap();
+    assert_eq!(deserialized, ToolCategory::Read);
+}
+
+#[test]
+fn test_tool_category_all_variants_serialize() {
+    let variants = [
+        (ToolCategory::Read, "\"Read\""),
+        (ToolCategory::Write, "\"Write\""),
+        (ToolCategory::Process, "\"Process\""),
+        (ToolCategory::Web, "\"Web\""),
+        (ToolCategory::Session, "\"Session\""),
+        (ToolCategory::Memory, "\"Memory\""),
+        (ToolCategory::Meta, "\"Meta\""),
+        (ToolCategory::Messaging, "\"Messaging\""),
+        (ToolCategory::Automation, "\"Automation\""),
+        (ToolCategory::Symbol, "\"Symbol\""),
+        (ToolCategory::Mcp, "\"Mcp\""),
+        (ToolCategory::Other, "\"Other\""),
+    ];
+    for (cat, expected) in variants {
+        assert_eq!(serde_json::to_string(&cat).unwrap(), expected);
+    }
+}
+
+#[test]
+fn test_tool_category_display() {
+    assert_eq!(ToolCategory::Read.to_string(), "Read");
+    assert_eq!(ToolCategory::Process.to_string(), "Process");
+    assert_eq!(ToolCategory::Other.to_string(), "Other");
+}
+
+#[test]
+fn test_tool_category_hash_eq() {
+    use std::collections::HashSet;
+    let mut set = HashSet::new();
+    set.insert(ToolCategory::Read);
+    set.insert(ToolCategory::Read);
+    set.insert(ToolCategory::Write);
+    assert_eq!(set.len(), 2);
+}
+
+// --- InterruptBehavior tests ---
+
+#[test]
+fn test_interrupt_behavior_default_is_cancel() {
+    assert_eq!(InterruptBehavior::default(), InterruptBehavior::Cancel);
+}
+
+#[test]
+fn test_interrupt_behavior_variants() {
+    assert_ne!(InterruptBehavior::Cancel, InterruptBehavior::Block);
+    assert_ne!(InterruptBehavior::Block, InterruptBehavior::Ignore);
+}
+
+// --- BaseTool default method tests ---
+
+#[derive(Debug)]
+struct DefaultTestTool;
+
+#[async_trait::async_trait]
+impl BaseTool for DefaultTestTool {
+    fn name(&self) -> &str {
+        "test"
+    }
+    fn description(&self) -> &str {
+        "A test tool"
+    }
+    fn parameter_schema(&self) -> serde_json::Value {
+        serde_json::json!({"type": "object", "properties": {}})
+    }
+    async fn execute(
+        &self,
+        _args: HashMap<String, serde_json::Value>,
+        _ctx: &ToolContext,
+    ) -> ToolResult {
+        ToolResult::ok("ok")
+    }
+}
+
+#[test]
+fn test_default_is_read_only() {
+    assert!(!DefaultTestTool.is_read_only(&HashMap::new()));
+}
+
+#[test]
+fn test_default_is_destructive() {
+    assert!(!DefaultTestTool.is_destructive(&HashMap::new()));
+}
+
+#[test]
+fn test_default_is_concurrent_safe_delegates_to_is_read_only() {
+    let args = HashMap::new();
+    assert_eq!(
+        DefaultTestTool.is_concurrent_safe(&args),
+        DefaultTestTool.is_read_only(&args)
+    );
+}
+
+#[test]
+fn test_default_category() {
+    assert_eq!(DefaultTestTool.category(), ToolCategory::Other);
+}
+
+#[test]
+fn test_default_skip_dedup() {
+    assert!(!DefaultTestTool.skip_dedup());
+}
+
+#[test]
+fn test_default_is_search_or_read() {
+    assert!(!DefaultTestTool.is_search_or_read(&HashMap::new()));
+}
+
+#[test]
+fn test_default_is_enabled() {
+    assert!(DefaultTestTool.is_enabled());
+}
+
+#[test]
+fn test_default_interrupt_behavior() {
+    assert_eq!(
+        DefaultTestTool.interrupt_behavior(),
+        InterruptBehavior::Cancel
+    );
+}
+
+#[test]
+fn test_default_truncation_rule() {
+    assert!(DefaultTestTool.truncation_rule().is_none());
+}
+
+#[test]
+fn test_default_search_hint() {
+    assert!(DefaultTestTool.search_hint().is_none());
+}
+
+#[test]
+fn test_default_should_defer() {
+    assert!(!DefaultTestTool.should_defer());
+}
+
+#[test]
+fn test_default_prompt_contribution() {
+    assert!(DefaultTestTool.prompt_contribution().is_none());
+}
+
 // --- ValidationError tests ---
 
 #[test]

--- a/crates/opendev-tools-impl/src/agents/list.rs
+++ b/crates/opendev-tools-impl/src/agents/list.rs
@@ -69,6 +69,18 @@ impl BaseTool for AgentsTool {
         })
     }
 
+    fn is_read_only(&self, _args: &HashMap<String, serde_json::Value>) -> bool {
+        true
+    }
+
+    fn is_concurrent_safe(&self, _args: &HashMap<String, serde_json::Value>) -> bool {
+        true
+    }
+
+    fn category(&self) -> opendev_tools_core::ToolCategory {
+        opendev_tools_core::ToolCategory::Session
+    }
+
     async fn execute(
         &self,
         args: HashMap<String, serde_json::Value>,

--- a/crates/opendev-tools-impl/src/agents/spawn.rs
+++ b/crates/opendev-tools-impl/src/agents/spawn.rs
@@ -158,6 +158,14 @@ impl BaseTool for SpawnSubagentTool {
         })
     }
 
+    fn category(&self) -> opendev_tools_core::ToolCategory {
+        opendev_tools_core::ToolCategory::Session
+    }
+
+    fn skip_dedup(&self) -> bool {
+        true
+    }
+
     async fn execute(
         &self,
         args: HashMap<String, serde_json::Value>,

--- a/crates/opendev-tools-impl/src/agents/team_tools.rs
+++ b/crates/opendev-tools-impl/src/agents/team_tools.rs
@@ -84,6 +84,10 @@ impl BaseTool for CreateTeamTool {
         })
     }
 
+    fn category(&self) -> opendev_tools_core::ToolCategory {
+        opendev_tools_core::ToolCategory::Messaging
+    }
+
     async fn execute(
         &self,
         args: HashMap<String, serde_json::Value>,
@@ -235,6 +239,14 @@ impl BaseTool for SendMessageTool {
         })
     }
 
+    fn category(&self) -> opendev_tools_core::ToolCategory {
+        opendev_tools_core::ToolCategory::Messaging
+    }
+
+    fn skip_dedup(&self) -> bool {
+        true
+    }
+
     async fn execute(
         &self,
         args: HashMap<String, serde_json::Value>,
@@ -383,6 +395,10 @@ impl BaseTool for DeleteTeamTool {
             },
             "required": ["team_name"]
         })
+    }
+
+    fn category(&self) -> opendev_tools_core::ToolCategory {
+        opendev_tools_core::ToolCategory::Messaging
     }
 
     async fn execute(

--- a/crates/opendev-tools-impl/src/ask_user.rs
+++ b/crates/opendev-tools-impl/src/ask_user.rs
@@ -67,6 +67,10 @@ impl BaseTool for AskUserTool {
         })
     }
 
+    fn category(&self) -> opendev_tools_core::ToolCategory {
+        opendev_tools_core::ToolCategory::Meta
+    }
+
     async fn execute(
         &self,
         args: HashMap<String, serde_json::Value>,

--- a/crates/opendev-tools-impl/src/bash/mod.rs
+++ b/crates/opendev-tools-impl/src/bash/mod.rs
@@ -11,6 +11,167 @@ pub fn is_dangerous_command(command: &str) -> bool {
     patterns::is_dangerous(command)
 }
 
+/// Check if a shell command is likely read-only (no side effects).
+///
+/// Enables automatic parallel execution of safe Bash commands — something
+/// Claude Code cannot do since its `isReadOnly` doesn't inspect commands.
+fn is_likely_read_only_command(command: &str) -> bool {
+    // Get the first token (the base command), stripping any leading env vars
+    let trimmed = command.trim();
+
+    // Skip pipe chains and subshells — if any segment writes, it's not read-only
+    if trimmed.contains('|') || trimmed.contains('>') || trimmed.contains("&&") {
+        // Check each segment of a pipe chain
+        return trimmed
+            .split('|')
+            .all(|segment| is_single_command_read_only(segment.trim()));
+    }
+
+    is_single_command_read_only(trimmed)
+}
+
+/// Check if a single command (no pipes) is read-only.
+fn is_single_command_read_only(cmd: &str) -> bool {
+    // Redirect operators mean writing
+    if cmd.contains('>') {
+        return false;
+    }
+
+    // Strip leading env var assignments (FOO=bar cmd ...)
+    let base = cmd
+        .split_whitespace()
+        .find(|token| !token.contains('='))
+        .unwrap_or("");
+
+    // Extract just the command name (strip path)
+    let cmd_name = base.rsplit('/').next().unwrap_or(base);
+
+    matches!(
+        cmd_name,
+        "ls"
+            | "cat"
+            | "head"
+            | "tail"
+            | "wc"
+            | "grep"
+            | "rg"
+            | "find"
+            | "which"
+            | "whereis"
+            | "whoami"
+            | "pwd"
+            | "echo"
+            | "printf"
+            | "date"
+            | "uname"
+            | "hostname"
+            | "env"
+            | "printenv"
+            | "id"
+            | "df"
+            | "du"
+            | "free"
+            | "uptime"
+            | "ps"
+            | "top"
+            | "htop"
+            | "file"
+            | "stat"
+            | "readlink"
+            | "realpath"
+            | "basename"
+            | "dirname"
+            | "diff"
+            | "md5sum"
+            | "sha256sum"
+            | "shasum"
+            | "cksum"
+            | "tree"
+            | "less"
+            | "more"
+            | "sort"
+            | "uniq"
+            | "cut"
+            | "tr"
+            | "awk"
+            | "sed" // sed without -i is read-only (piped sed)
+            | "jq"
+            | "yq"
+            | "xargs"
+            | "tee" // tee in a pipe is ambiguous, but usually safe in this context
+            | "test"
+            | "["
+            | "true"
+            | "false"
+            | "git" // git subcommands checked below
+            | "cargo"
+            | "rustc"
+            | "node"
+            | "python"
+            | "python3"
+            | "ruby"
+            | "go"
+    ) && !is_write_subcommand(cmd)
+}
+
+/// Check if a command has a write-oriented subcommand.
+fn is_write_subcommand(cmd: &str) -> bool {
+    let parts: Vec<&str> = cmd.split_whitespace().collect();
+    if parts.len() < 2 {
+        return false;
+    }
+
+    let base = parts[0].rsplit('/').next().unwrap_or(parts[0]);
+    let sub = parts[1];
+
+    match base {
+        "git" => !matches!(
+            sub,
+            "status"
+                | "log"
+                | "diff"
+                | "show"
+                | "branch"
+                | "tag"
+                | "remote"
+                | "stash"
+                | "blame"
+                | "shortlog"
+                | "describe"
+                | "rev-parse"
+                | "rev-list"
+                | "ls-files"
+                | "ls-tree"
+                | "ls-remote"
+                | "cat-file"
+                | "name-rev"
+                | "for-each-ref"
+                | "config"
+                | "help"
+                | "version"
+        ),
+        "cargo" => !matches!(
+            sub,
+            "check"
+                | "clippy"
+                | "test"
+                | "bench"
+                | "doc"
+                | "metadata"
+                | "tree"
+                | "search"
+                | "version"
+                | "help"
+                | "locate-project"
+                | "pkgid"
+                | "verify-project"
+                | "read-manifest"
+        ),
+        "sed" => cmd.contains(" -i"),
+        _ => false,
+    }
+}
+
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -95,6 +256,34 @@ impl BaseTool for BashTool {
             },
             "required": ["command"]
         })
+    }
+
+    fn is_read_only(&self, args: &HashMap<String, serde_json::Value>) -> bool {
+        if let Some(cmd) = args.get("command").and_then(|v| v.as_str()) {
+            is_likely_read_only_command(cmd)
+        } else {
+            false
+        }
+    }
+
+    fn is_destructive(&self, args: &HashMap<String, serde_json::Value>) -> bool {
+        if let Some(cmd) = args.get("command").and_then(|v| v.as_str()) {
+            patterns::is_dangerous(cmd)
+        } else {
+            false
+        }
+    }
+
+    fn is_concurrent_safe(&self, args: &HashMap<String, serde_json::Value>) -> bool {
+        self.is_read_only(args)
+    }
+
+    fn category(&self) -> opendev_tools_core::ToolCategory {
+        opendev_tools_core::ToolCategory::Process
+    }
+
+    fn truncation_rule(&self) -> Option<opendev_tools_core::TruncationRule> {
+        Some(opendev_tools_core::TruncationRule::tail(8000))
     }
 
     async fn execute(

--- a/crates/opendev-tools-impl/src/bash/mod.rs
+++ b/crates/opendev-tools-impl/src/bash/mod.rs
@@ -16,14 +16,20 @@ pub fn is_dangerous_command(command: &str) -> bool {
 /// Enables automatic parallel execution of safe Bash commands — something
 /// Claude Code cannot do since its `isReadOnly` doesn't inspect commands.
 fn is_likely_read_only_command(command: &str) -> bool {
-    // Get the first token (the base command), stripping any leading env vars
     let trimmed = command.trim();
 
-    // Skip pipe chains and subshells — if any segment writes, it's not read-only
-    if trimmed.contains('|') || trimmed.contains('>') || trimmed.contains("&&") {
-        // Check each segment of a pipe chain
-        return trimmed
-            .split('|')
+    // Split on all shell operators (&&, ||, ;, |) and check every segment.
+    // If ANY segment is not read-only, the whole command is not read-only.
+    if trimmed.contains('|')
+        || trimmed.contains('>')
+        || trimmed.contains("&&")
+        || trimmed.contains("||")
+        || trimmed.contains(';')
+    {
+        // Replace multi-char operators with \x00, then split on \x00, |, and ;
+        let normalized = trimmed.replace("&&", "\x00").replace("||", "\x00");
+        return normalized
+            .split(['\x00', '|', ';'])
             .all(|segment| is_single_command_read_only(segment.trim()));
     }
 
@@ -729,5 +735,216 @@ mod tests {
         let result = tool.execute(args, &ctx).await;
         assert!(!result.success);
         assert!(result.error.unwrap().contains("does not exist"));
+    }
+
+    // -----------------------------------------------------------------------
+    // is_likely_read_only_command — unit tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_read_only_simple_commands() {
+        assert!(is_likely_read_only_command("ls -la"));
+        assert!(is_likely_read_only_command("cat foo.txt"));
+        assert!(is_likely_read_only_command("grep -r pattern ."));
+        assert!(is_likely_read_only_command("find . -name '*.rs'"));
+        assert!(is_likely_read_only_command("wc -l file.txt"));
+        assert!(is_likely_read_only_command("head -20 file.txt"));
+        assert!(is_likely_read_only_command("tail -f log.txt"));
+        assert!(is_likely_read_only_command("echo hello world"));
+        assert!(is_likely_read_only_command("pwd"));
+        assert!(is_likely_read_only_command("whoami"));
+        assert!(is_likely_read_only_command("tree src/"));
+        assert!(is_likely_read_only_command("diff a.txt b.txt"));
+    }
+
+    #[test]
+    fn test_read_only_git_subcommands() {
+        assert!(is_likely_read_only_command("git status"));
+        assert!(is_likely_read_only_command("git log --oneline"));
+        assert!(is_likely_read_only_command("git diff HEAD~1"));
+        assert!(is_likely_read_only_command("git show HEAD"));
+        assert!(is_likely_read_only_command("git branch -a"));
+        assert!(is_likely_read_only_command("git blame src/main.rs"));
+        assert!(is_likely_read_only_command("git ls-files"));
+        assert!(is_likely_read_only_command("git rev-parse HEAD"));
+    }
+
+    #[test]
+    fn test_not_read_only_git_write_subcommands() {
+        assert!(!is_likely_read_only_command("git add ."));
+        assert!(!is_likely_read_only_command("git commit -m 'test'"));
+        assert!(!is_likely_read_only_command("git push origin main"));
+        assert!(!is_likely_read_only_command("git checkout -b new-branch"));
+        assert!(!is_likely_read_only_command("git reset --hard HEAD~1"));
+        assert!(!is_likely_read_only_command("git merge feature"));
+    }
+
+    #[test]
+    fn test_read_only_cargo_subcommands() {
+        assert!(is_likely_read_only_command("cargo check"));
+        assert!(is_likely_read_only_command("cargo clippy"));
+        assert!(is_likely_read_only_command("cargo test --lib"));
+        assert!(is_likely_read_only_command("cargo doc"));
+        assert!(is_likely_read_only_command("cargo metadata"));
+        assert!(is_likely_read_only_command("cargo tree"));
+    }
+
+    #[test]
+    fn test_not_read_only_cargo_write_subcommands() {
+        assert!(!is_likely_read_only_command("cargo build"));
+        assert!(!is_likely_read_only_command("cargo install ripgrep"));
+        assert!(!is_likely_read_only_command("cargo clean"));
+        assert!(!is_likely_read_only_command("cargo publish"));
+    }
+
+    #[test]
+    fn test_not_read_only_write_commands() {
+        assert!(!is_likely_read_only_command("rm file.txt"));
+        assert!(!is_likely_read_only_command("mkdir new_dir"));
+        assert!(!is_likely_read_only_command("touch file.txt"));
+        assert!(!is_likely_read_only_command("cp a.txt b.txt"));
+        assert!(!is_likely_read_only_command("mv a.txt b.txt"));
+        assert!(!is_likely_read_only_command("chmod 755 script.sh"));
+    }
+
+    #[test]
+    fn test_read_only_pipe_chains() {
+        assert!(is_likely_read_only_command("cat file.txt | grep pattern"));
+        assert!(is_likely_read_only_command("ls -la | wc -l"));
+        assert!(is_likely_read_only_command("grep -r foo . | sort | uniq"));
+        assert!(is_likely_read_only_command("git log --oneline | head -10"));
+    }
+
+    #[test]
+    fn test_not_read_only_pipe_with_write() {
+        assert!(!is_likely_read_only_command(
+            "cat file.txt | tee output.txt | rm backup.txt"
+        ));
+    }
+
+    #[test]
+    fn test_not_read_only_redirect() {
+        assert!(!is_likely_read_only_command("echo hello > file.txt"));
+        assert!(!is_likely_read_only_command("ls -la > listing.txt"));
+        assert!(!is_likely_read_only_command("cat a.txt >> b.txt"));
+    }
+
+    #[test]
+    fn test_not_read_only_and_chain_with_write() {
+        assert!(!is_likely_read_only_command("ls && rm -rf /tmp/foo"));
+        assert!(!is_likely_read_only_command("echo ok && touch file.txt"));
+        assert!(!is_likely_read_only_command(
+            "git status && git add . && git commit -m 'test'"
+        ));
+        assert!(!is_likely_read_only_command("cat foo && mkdir bar"));
+    }
+
+    #[test]
+    fn test_read_only_and_chain_all_safe() {
+        assert!(is_likely_read_only_command("ls && pwd"));
+        assert!(is_likely_read_only_command("git status && git log"));
+        assert!(is_likely_read_only_command("echo hello && echo world"));
+    }
+
+    #[test]
+    fn test_not_read_only_or_chain_with_write() {
+        assert!(!is_likely_read_only_command("ls || rm file.txt"));
+        assert!(!is_likely_read_only_command("cat foo || touch bar"));
+    }
+
+    #[test]
+    fn test_read_only_or_chain_all_safe() {
+        assert!(is_likely_read_only_command("cat file || echo 'not found'"));
+    }
+
+    #[test]
+    fn test_not_read_only_semicolon_chain_with_write() {
+        assert!(!is_likely_read_only_command("ls; rm file.txt"));
+        assert!(!is_likely_read_only_command("echo hello; touch file"));
+        assert!(!is_likely_read_only_command("pwd; mkdir new_dir; ls"));
+    }
+
+    #[test]
+    fn test_read_only_semicolon_chain_all_safe() {
+        assert!(is_likely_read_only_command("ls; pwd; echo done"));
+    }
+
+    #[test]
+    fn test_not_read_only_mixed_operators_with_write() {
+        assert!(!is_likely_read_only_command("ls | grep foo && rm -rf bar"));
+        assert!(!is_likely_read_only_command("echo ok; cat f | touch x"));
+    }
+
+    #[test]
+    fn test_sed_read_only_vs_write() {
+        assert!(is_likely_read_only_command("sed 's/foo/bar/' file.txt"));
+        assert!(!is_likely_read_only_command("sed -i 's/foo/bar/' file.txt"));
+        assert!(!is_likely_read_only_command(
+            "sed -i.bak 's/foo/bar/' file.txt"
+        ));
+    }
+
+    #[test]
+    fn test_env_var_prefix_stripped() {
+        assert!(is_likely_read_only_command("FOO=bar ls -la"));
+        assert!(is_likely_read_only_command("RUST_LOG=debug cargo check"));
+    }
+
+    #[test]
+    fn test_full_path_commands() {
+        assert!(is_likely_read_only_command("/usr/bin/ls -la"));
+        assert!(is_likely_read_only_command("/bin/cat file.txt"));
+        assert!(!is_likely_read_only_command("/bin/rm file.txt"));
+    }
+
+    // -----------------------------------------------------------------------
+    // BashTool trait method integration tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_bash_is_read_only_trait() {
+        let tool = BashTool::new();
+        let safe = make_args(&[("command", serde_json::json!("ls -la"))]);
+        assert!(tool.is_read_only(&safe));
+
+        let unsafe_cmd = make_args(&[("command", serde_json::json!("rm file.txt"))]);
+        assert!(!tool.is_read_only(&unsafe_cmd));
+
+        let chain_safe = make_args(&[("command", serde_json::json!("ls && pwd"))]);
+        assert!(tool.is_read_only(&chain_safe));
+
+        let chain_unsafe = make_args(&[("command", serde_json::json!("ls && rm -rf /tmp/foo"))]);
+        assert!(!tool.is_read_only(&chain_unsafe));
+    }
+
+    #[test]
+    fn test_bash_is_concurrent_safe_trait() {
+        let tool = BashTool::new();
+        let safe = make_args(&[("command", serde_json::json!("git status"))]);
+        assert!(tool.is_concurrent_safe(&safe));
+
+        let unsafe_cmd = make_args(&[("command", serde_json::json!("git push"))]);
+        assert!(!tool.is_concurrent_safe(&unsafe_cmd));
+    }
+
+    #[test]
+    fn test_bash_category() {
+        let tool = BashTool::new();
+        assert_eq!(tool.category(), opendev_tools_core::ToolCategory::Process);
+    }
+
+    #[test]
+    fn test_bash_truncation_rule() {
+        let tool = BashTool::new();
+        let rule = tool
+            .truncation_rule()
+            .expect("BashTool should have a truncation rule");
+        assert_eq!(rule.max_chars, 8000);
+    }
+
+    #[test]
+    fn test_bash_skip_dedup_false() {
+        let tool = BashTool::new();
+        assert!(!tool.skip_dedup());
     }
 }

--- a/crates/opendev-tools-impl/src/browser.rs
+++ b/crates/opendev-tools-impl/src/browser.rs
@@ -80,6 +80,14 @@ impl BaseTool for BrowserTool {
         })
     }
 
+    fn category(&self) -> opendev_tools_core::ToolCategory {
+        opendev_tools_core::ToolCategory::Web
+    }
+
+    fn truncation_rule(&self) -> Option<opendev_tools_core::TruncationRule> {
+        Some(opendev_tools_core::TruncationRule::head(5000))
+    }
+
     async fn execute(
         &self,
         args: HashMap<String, serde_json::Value>,

--- a/crates/opendev-tools-impl/src/clear_todos.rs
+++ b/crates/opendev-tools-impl/src/clear_todos.rs
@@ -36,6 +36,10 @@ impl BaseTool for ClearTodosTool {
         })
     }
 
+    fn category(&self) -> opendev_tools_core::ToolCategory {
+        opendev_tools_core::ToolCategory::Meta
+    }
+
     async fn execute(
         &self,
         _args: HashMap<String, serde_json::Value>,

--- a/crates/opendev-tools-impl/src/complete_todo.rs
+++ b/crates/opendev-tools-impl/src/complete_todo.rs
@@ -42,6 +42,10 @@ impl BaseTool for CompleteTodoTool {
         })
     }
 
+    fn category(&self) -> opendev_tools_core::ToolCategory {
+        opendev_tools_core::ToolCategory::Meta
+    }
+
     async fn execute(
         &self,
         args: HashMap<String, serde_json::Value>,

--- a/crates/opendev-tools-impl/src/diff_preview.rs
+++ b/crates/opendev-tools-impl/src/diff_preview.rs
@@ -47,6 +47,10 @@ impl BaseTool for DiffPreviewTool {
         })
     }
 
+    fn category(&self) -> opendev_tools_core::ToolCategory {
+        opendev_tools_core::ToolCategory::Meta
+    }
+
     async fn execute(
         &self,
         args: HashMap<String, serde_json::Value>,

--- a/crates/opendev-tools-impl/src/file_edit.rs
+++ b/crates/opendev-tools-impl/src/file_edit.rs
@@ -71,6 +71,14 @@ impl BaseTool for FileEditTool {
         })
     }
 
+    fn category(&self) -> opendev_tools_core::ToolCategory {
+        opendev_tools_core::ToolCategory::Write
+    }
+
+    fn interrupt_behavior(&self) -> opendev_tools_core::InterruptBehavior {
+        opendev_tools_core::InterruptBehavior::Block
+    }
+
     async fn execute(
         &self,
         args: HashMap<String, serde_json::Value>,

--- a/crates/opendev-tools-impl/src/file_list.rs
+++ b/crates/opendev-tools-impl/src/file_list.rs
@@ -78,6 +78,26 @@ impl BaseTool for FileListTool {
         })
     }
 
+    fn is_read_only(&self, _args: &HashMap<String, serde_json::Value>) -> bool {
+        true
+    }
+
+    fn is_concurrent_safe(&self, _args: &HashMap<String, serde_json::Value>) -> bool {
+        true
+    }
+
+    fn category(&self) -> opendev_tools_core::ToolCategory {
+        opendev_tools_core::ToolCategory::Read
+    }
+
+    fn truncation_rule(&self) -> Option<opendev_tools_core::TruncationRule> {
+        Some(opendev_tools_core::TruncationRule::head(10000))
+    }
+
+    fn search_hint(&self) -> Option<&str> {
+        Some("find files by glob pattern")
+    }
+
     async fn execute(
         &self,
         args: HashMap<String, serde_json::Value>,

--- a/crates/opendev-tools-impl/src/file_read/mod.rs
+++ b/crates/opendev-tools-impl/src/file_read/mod.rs
@@ -115,6 +115,26 @@ impl BaseTool for FileReadTool {
         })
     }
 
+    fn is_read_only(&self, _args: &HashMap<String, serde_json::Value>) -> bool {
+        true
+    }
+
+    fn is_concurrent_safe(&self, _args: &HashMap<String, serde_json::Value>) -> bool {
+        true
+    }
+
+    fn category(&self) -> opendev_tools_core::ToolCategory {
+        opendev_tools_core::ToolCategory::Read
+    }
+
+    fn truncation_rule(&self) -> Option<opendev_tools_core::TruncationRule> {
+        Some(opendev_tools_core::TruncationRule::head(15000))
+    }
+
+    fn search_hint(&self) -> Option<&str> {
+        Some("read file contents by path with line ranges")
+    }
+
     async fn execute(
         &self,
         args: HashMap<String, serde_json::Value>,

--- a/crates/opendev-tools-impl/src/file_search/ast_grep_tool.rs
+++ b/crates/opendev-tools-impl/src/file_search/ast_grep_tool.rs
@@ -49,6 +49,22 @@ impl BaseTool for AstGrepTool {
         })
     }
 
+    fn is_read_only(&self, _args: &HashMap<String, serde_json::Value>) -> bool {
+        true
+    }
+
+    fn is_concurrent_safe(&self, _args: &HashMap<String, serde_json::Value>) -> bool {
+        true
+    }
+
+    fn category(&self) -> opendev_tools_core::ToolCategory {
+        opendev_tools_core::ToolCategory::Read
+    }
+
+    fn search_hint(&self) -> Option<&str> {
+        Some("search code with AST structural patterns")
+    }
+
     async fn execute(
         &self,
         args: HashMap<String, serde_json::Value>,

--- a/crates/opendev-tools-impl/src/file_search/grep_tool.rs
+++ b/crates/opendev-tools-impl/src/file_search/grep_tool.rs
@@ -181,6 +181,26 @@ impl BaseTool for GrepTool {
         })
     }
 
+    fn is_read_only(&self, _args: &HashMap<String, serde_json::Value>) -> bool {
+        true
+    }
+
+    fn is_concurrent_safe(&self, _args: &HashMap<String, serde_json::Value>) -> bool {
+        true
+    }
+
+    fn category(&self) -> opendev_tools_core::ToolCategory {
+        opendev_tools_core::ToolCategory::Read
+    }
+
+    fn truncation_rule(&self) -> Option<opendev_tools_core::TruncationRule> {
+        Some(opendev_tools_core::TruncationRule::head(10000))
+    }
+
+    fn search_hint(&self) -> Option<&str> {
+        Some("search file contents with regex pattern")
+    }
+
     async fn execute(
         &self,
         args: HashMap<String, serde_json::Value>,

--- a/crates/opendev-tools-impl/src/file_write.rs
+++ b/crates/opendev-tools-impl/src/file_write.rs
@@ -44,6 +44,14 @@ impl BaseTool for FileWriteTool {
         })
     }
 
+    fn category(&self) -> opendev_tools_core::ToolCategory {
+        opendev_tools_core::ToolCategory::Write
+    }
+
+    fn interrupt_behavior(&self) -> opendev_tools_core::InterruptBehavior {
+        opendev_tools_core::InterruptBehavior::Block
+    }
+
     async fn execute(
         &self,
         args: HashMap<String, serde_json::Value>,

--- a/crates/opendev-tools-impl/src/insert_symbol.rs
+++ b/crates/opendev-tools-impl/src/insert_symbol.rs
@@ -342,6 +342,14 @@ impl BaseTool for InsertBeforeSymbolTool {
         })
     }
 
+    fn category(&self) -> opendev_tools_core::ToolCategory {
+        opendev_tools_core::ToolCategory::Symbol
+    }
+
+    fn interrupt_behavior(&self) -> opendev_tools_core::InterruptBehavior {
+        opendev_tools_core::InterruptBehavior::Block
+    }
+
     async fn execute(
         &self,
         args: HashMap<String, serde_json::Value>,
@@ -389,6 +397,14 @@ impl BaseTool for InsertAfterSymbolTool {
             },
             "required": ["file_path", "symbol_name", "content"]
         })
+    }
+
+    fn category(&self) -> opendev_tools_core::ToolCategory {
+        opendev_tools_core::ToolCategory::Symbol
+    }
+
+    fn interrupt_behavior(&self) -> opendev_tools_core::InterruptBehavior {
+        opendev_tools_core::InterruptBehavior::Block
     }
 
     async fn execute(

--- a/crates/opendev-tools-impl/src/invoke_skill/mod.rs
+++ b/crates/opendev-tools-impl/src/invoke_skill/mod.rs
@@ -96,6 +96,10 @@ impl BaseTool for InvokeSkillTool {
         })
     }
 
+    fn category(&self) -> opendev_tools_core::ToolCategory {
+        opendev_tools_core::ToolCategory::Meta
+    }
+
     async fn execute(
         &self,
         args: HashMap<String, serde_json::Value>,

--- a/crates/opendev-tools-impl/src/list_todos.rs
+++ b/crates/opendev-tools-impl/src/list_todos.rs
@@ -36,6 +36,18 @@ impl BaseTool for ListTodosTool {
         })
     }
 
+    fn is_read_only(&self, _args: &HashMap<String, serde_json::Value>) -> bool {
+        true
+    }
+
+    fn is_concurrent_safe(&self, _args: &HashMap<String, serde_json::Value>) -> bool {
+        true
+    }
+
+    fn category(&self) -> opendev_tools_core::ToolCategory {
+        opendev_tools_core::ToolCategory::Meta
+    }
+
     async fn execute(
         &self,
         _args: HashMap<String, serde_json::Value>,

--- a/crates/opendev-tools-impl/src/lsp_query.rs
+++ b/crates/opendev-tools-impl/src/lsp_query.rs
@@ -72,6 +72,26 @@ impl BaseTool for LspQueryTool {
         })
     }
 
+    fn is_read_only(&self, _args: &HashMap<String, serde_json::Value>) -> bool {
+        true
+    }
+
+    fn is_concurrent_safe(&self, _args: &HashMap<String, serde_json::Value>) -> bool {
+        true
+    }
+
+    fn category(&self) -> opendev_tools_core::ToolCategory {
+        opendev_tools_core::ToolCategory::Symbol
+    }
+
+    fn should_defer(&self) -> bool {
+        true
+    }
+
+    fn search_hint(&self) -> Option<&str> {
+        Some("query language server for code intelligence")
+    }
+
     async fn execute(
         &self,
         args: HashMap<String, serde_json::Value>,

--- a/crates/opendev-tools-impl/src/mcp_tool.rs
+++ b/crates/opendev-tools-impl/src/mcp_tool.rs
@@ -79,6 +79,10 @@ impl BaseTool for McpBridgeTool {
         }
     }
 
+    fn category(&self) -> opendev_tools_core::ToolCategory {
+        opendev_tools_core::ToolCategory::Mcp
+    }
+
     async fn execute(
         &self,
         args: HashMap<String, serde_json::Value>,

--- a/crates/opendev-tools-impl/src/memory.rs
+++ b/crates/opendev-tools-impl/src/memory.rs
@@ -79,6 +79,14 @@ impl BaseTool for MemoryTool {
         })
     }
 
+    fn category(&self) -> opendev_tools_core::ToolCategory {
+        opendev_tools_core::ToolCategory::Memory
+    }
+
+    fn truncation_rule(&self) -> Option<opendev_tools_core::TruncationRule> {
+        Some(opendev_tools_core::TruncationRule::head(10000))
+    }
+
     async fn execute(
         &self,
         args: HashMap<String, serde_json::Value>,

--- a/crates/opendev-tools-impl/src/message.rs
+++ b/crates/opendev-tools-impl/src/message.rs
@@ -49,6 +49,14 @@ impl BaseTool for MessageTool {
         })
     }
 
+    fn category(&self) -> opendev_tools_core::ToolCategory {
+        opendev_tools_core::ToolCategory::Messaging
+    }
+
+    fn skip_dedup(&self) -> bool {
+        true
+    }
+
     async fn execute(
         &self,
         args: HashMap<String, serde_json::Value>,

--- a/crates/opendev-tools-impl/src/multi_edit.rs
+++ b/crates/opendev-tools-impl/src/multi_edit.rs
@@ -92,6 +92,14 @@ impl BaseTool for MultiEditTool {
         })
     }
 
+    fn category(&self) -> opendev_tools_core::ToolCategory {
+        opendev_tools_core::ToolCategory::Write
+    }
+
+    fn interrupt_behavior(&self) -> opendev_tools_core::InterruptBehavior {
+        opendev_tools_core::InterruptBehavior::Block
+    }
+
     async fn execute(
         &self,
         args: HashMap<String, serde_json::Value>,

--- a/crates/opendev-tools-impl/src/notebook_edit.rs
+++ b/crates/opendev-tools-impl/src/notebook_edit.rs
@@ -64,6 +64,14 @@ impl BaseTool for NotebookEditTool {
         })
     }
 
+    fn category(&self) -> opendev_tools_core::ToolCategory {
+        opendev_tools_core::ToolCategory::Write
+    }
+
+    fn should_defer(&self) -> bool {
+        true
+    }
+
     async fn execute(
         &self,
         args: HashMap<String, serde_json::Value>,

--- a/crates/opendev-tools-impl/src/open_browser.rs
+++ b/crates/opendev-tools-impl/src/open_browser.rs
@@ -31,6 +31,10 @@ impl BaseTool for OpenBrowserTool {
         })
     }
 
+    fn category(&self) -> opendev_tools_core::ToolCategory {
+        opendev_tools_core::ToolCategory::Web
+    }
+
     async fn execute(
         &self,
         args: HashMap<String, serde_json::Value>,

--- a/crates/opendev-tools-impl/src/patch/mod.rs
+++ b/crates/opendev-tools-impl/src/patch/mod.rs
@@ -41,6 +41,14 @@ impl BaseTool for PatchTool {
         })
     }
 
+    fn category(&self) -> opendev_tools_core::ToolCategory {
+        opendev_tools_core::ToolCategory::Write
+    }
+
+    fn interrupt_behavior(&self) -> opendev_tools_core::InterruptBehavior {
+        opendev_tools_core::InterruptBehavior::Block
+    }
+
     async fn execute(
         &self,
         args: HashMap<String, serde_json::Value>,

--- a/crates/opendev-tools-impl/src/present_plan.rs
+++ b/crates/opendev-tools-impl/src/present_plan.rs
@@ -97,6 +97,10 @@ impl BaseTool for PresentPlanTool {
         })
     }
 
+    fn category(&self) -> opendev_tools_core::ToolCategory {
+        opendev_tools_core::ToolCategory::Meta
+    }
+
     async fn execute(
         &self,
         args: HashMap<String, serde_json::Value>,

--- a/crates/opendev-tools-impl/src/schedule.rs
+++ b/crates/opendev-tools-impl/src/schedule.rs
@@ -77,6 +77,14 @@ impl BaseTool for ScheduleTool {
         })
     }
 
+    fn category(&self) -> opendev_tools_core::ToolCategory {
+        opendev_tools_core::ToolCategory::Automation
+    }
+
+    fn should_defer(&self) -> bool {
+        true
+    }
+
     async fn execute(
         &self,
         args: HashMap<String, serde_json::Value>,

--- a/crates/opendev-tools-impl/src/session.rs
+++ b/crates/opendev-tools-impl/src/session.rs
@@ -61,6 +61,22 @@ impl BaseTool for PastSessionsTool {
         })
     }
 
+    fn is_read_only(&self, _args: &HashMap<String, serde_json::Value>) -> bool {
+        true
+    }
+
+    fn is_concurrent_safe(&self, _args: &HashMap<String, serde_json::Value>) -> bool {
+        true
+    }
+
+    fn category(&self) -> opendev_tools_core::ToolCategory {
+        opendev_tools_core::ToolCategory::Session
+    }
+
+    fn truncation_rule(&self) -> Option<opendev_tools_core::TruncationRule> {
+        Some(opendev_tools_core::TruncationRule::tail(15000))
+    }
+
     async fn execute(
         &self,
         args: HashMap<String, serde_json::Value>,

--- a/crates/opendev-tools-impl/src/task_complete.rs
+++ b/crates/opendev-tools-impl/src/task_complete.rs
@@ -49,6 +49,10 @@ impl BaseTool for TaskCompleteTool {
         })
     }
 
+    fn category(&self) -> opendev_tools_core::ToolCategory {
+        opendev_tools_core::ToolCategory::Meta
+    }
+
     async fn execute(
         &self,
         args: HashMap<String, serde_json::Value>,

--- a/crates/opendev-tools-impl/src/todo.rs
+++ b/crates/opendev-tools-impl/src/todo.rs
@@ -58,6 +58,10 @@ impl BaseTool for TodoTool {
         })
     }
 
+    fn category(&self) -> opendev_tools_core::ToolCategory {
+        opendev_tools_core::ToolCategory::Meta
+    }
+
     async fn execute(
         &self,
         args: HashMap<String, serde_json::Value>,

--- a/crates/opendev-tools-impl/src/update_todo.rs
+++ b/crates/opendev-tools-impl/src/update_todo.rs
@@ -50,6 +50,10 @@ impl BaseTool for UpdateTodoTool {
         })
     }
 
+    fn category(&self) -> opendev_tools_core::ToolCategory {
+        opendev_tools_core::ToolCategory::Meta
+    }
+
     async fn execute(
         &self,
         args: HashMap<String, serde_json::Value>,

--- a/crates/opendev-tools-impl/src/vlm.rs
+++ b/crates/opendev-tools-impl/src/vlm.rs
@@ -69,6 +69,22 @@ impl BaseTool for VlmTool {
         })
     }
 
+    fn is_read_only(&self, _args: &HashMap<String, serde_json::Value>) -> bool {
+        true
+    }
+
+    fn is_concurrent_safe(&self, _args: &HashMap<String, serde_json::Value>) -> bool {
+        true
+    }
+
+    fn category(&self) -> opendev_tools_core::ToolCategory {
+        opendev_tools_core::ToolCategory::Read
+    }
+
+    fn search_hint(&self) -> Option<&str> {
+        Some("analyze image with vision language model")
+    }
+
     async fn execute(
         &self,
         args: HashMap<String, serde_json::Value>,

--- a/crates/opendev-tools-impl/src/web_fetch/mod.rs
+++ b/crates/opendev-tools-impl/src/web_fetch/mod.rs
@@ -64,6 +64,26 @@ impl BaseTool for WebFetchTool {
         })
     }
 
+    fn is_read_only(&self, _args: &HashMap<String, serde_json::Value>) -> bool {
+        true
+    }
+
+    fn is_concurrent_safe(&self, _args: &HashMap<String, serde_json::Value>) -> bool {
+        true
+    }
+
+    fn category(&self) -> opendev_tools_core::ToolCategory {
+        opendev_tools_core::ToolCategory::Web
+    }
+
+    fn truncation_rule(&self) -> Option<opendev_tools_core::TruncationRule> {
+        Some(opendev_tools_core::TruncationRule::head(12000))
+    }
+
+    fn search_hint(&self) -> Option<&str> {
+        Some("fetch URL content with HTML to markdown conversion")
+    }
+
     async fn execute(
         &self,
         args: HashMap<String, serde_json::Value>,

--- a/crates/opendev-tools-impl/src/web_screenshot.rs
+++ b/crates/opendev-tools-impl/src/web_screenshot.rs
@@ -57,6 +57,18 @@ impl BaseTool for WebScreenshotTool {
         })
     }
 
+    fn is_read_only(&self, _args: &HashMap<String, serde_json::Value>) -> bool {
+        true
+    }
+
+    fn is_concurrent_safe(&self, _args: &HashMap<String, serde_json::Value>) -> bool {
+        true
+    }
+
+    fn category(&self) -> opendev_tools_core::ToolCategory {
+        opendev_tools_core::ToolCategory::Web
+    }
+
     async fn execute(
         &self,
         args: HashMap<String, serde_json::Value>,

--- a/crates/opendev-tools-impl/src/web_search/mod.rs
+++ b/crates/opendev-tools-impl/src/web_search/mod.rs
@@ -58,6 +58,26 @@ impl BaseTool for WebSearchTool {
         })
     }
 
+    fn is_read_only(&self, _args: &HashMap<String, serde_json::Value>) -> bool {
+        true
+    }
+
+    fn is_concurrent_safe(&self, _args: &HashMap<String, serde_json::Value>) -> bool {
+        true
+    }
+
+    fn category(&self) -> opendev_tools_core::ToolCategory {
+        opendev_tools_core::ToolCategory::Web
+    }
+
+    fn truncation_rule(&self) -> Option<opendev_tools_core::TruncationRule> {
+        Some(opendev_tools_core::TruncationRule::head(10000))
+    }
+
+    fn search_hint(&self) -> Option<&str> {
+        Some("search the web for information")
+    }
+
     async fn execute(
         &self,
         args: HashMap<String, serde_json::Value>,

--- a/crates/opendev-tools-impl/src/write_todos.rs
+++ b/crates/opendev-tools-impl/src/write_todos.rs
@@ -62,6 +62,10 @@ impl BaseTool for WriteTodosTool {
         })
     }
 
+    fn category(&self) -> opendev_tools_core::ToolCategory {
+        opendev_tools_core::ToolCategory::Meta
+    }
+
     async fn execute(
         &self,
         args: HashMap<String, serde_json::Value>,

--- a/crates/opendev-tui/src/formatters/tool_categories.rs
+++ b/crates/opendev-tui/src/formatters/tool_categories.rs
@@ -63,19 +63,45 @@ pub struct ToolDisplayEntry {
 /// Map a category name string to a `ToolCategory` enum variant.
 pub(crate) fn category_from_name(name: &str) -> ToolCategory {
     match name {
-        "FileRead" => ToolCategory::FileRead,
-        "FileWrite" => ToolCategory::FileWrite,
-        "Bash" => ToolCategory::Bash,
+        "FileRead" | "Read" => ToolCategory::FileRead,
+        "FileWrite" | "Write" => ToolCategory::FileWrite,
+        "Bash" | "Process" => ToolCategory::Bash,
         "Search" => ToolCategory::Search,
         "Web" => ToolCategory::Web,
-        "Agent" => ToolCategory::Agent,
+        "Agent" | "Session" => ToolCategory::Agent,
         "Symbol" => ToolCategory::Symbol,
         "Mcp" => ToolCategory::Mcp,
-        "Plan" => ToolCategory::Plan,
+        "Plan" | "Meta" => ToolCategory::Plan,
         "Docker" => ToolCategory::Docker,
         "UserInteraction" => ToolCategory::UserInteraction,
         "Notebook" => ToolCategory::Notebook,
+        "Memory" => ToolCategory::Other,
+        "Messaging" => ToolCategory::Agent,
+        "Automation" => ToolCategory::Plan,
         _ => ToolCategory::Other,
+    }
+}
+
+/// Convert from the core `ToolCategory` enum to the TUI-specific one.
+///
+/// The core enum has coarser granularity (e.g., `Read` covers both file-read
+/// and search). The TUI enum has display-oriented splits.
+impl From<opendev_tools_core::ToolCategory> for ToolCategory {
+    fn from(core: opendev_tools_core::ToolCategory) -> Self {
+        match core {
+            opendev_tools_core::ToolCategory::Read => ToolCategory::FileRead,
+            opendev_tools_core::ToolCategory::Write => ToolCategory::FileWrite,
+            opendev_tools_core::ToolCategory::Process => ToolCategory::Bash,
+            opendev_tools_core::ToolCategory::Web => ToolCategory::Web,
+            opendev_tools_core::ToolCategory::Session => ToolCategory::Agent,
+            opendev_tools_core::ToolCategory::Memory => ToolCategory::Other,
+            opendev_tools_core::ToolCategory::Meta => ToolCategory::Plan,
+            opendev_tools_core::ToolCategory::Messaging => ToolCategory::Agent,
+            opendev_tools_core::ToolCategory::Automation => ToolCategory::Plan,
+            opendev_tools_core::ToolCategory::Symbol => ToolCategory::Symbol,
+            opendev_tools_core::ToolCategory::Mcp => ToolCategory::Mcp,
+            opendev_tools_core::ToolCategory::Other => ToolCategory::Other,
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Enriches the `BaseTool` trait from 4 required + 2 optional methods to **4 required + 14 optional methods**, enabling tools to self-describe their safety properties, categories, truncation rules, and more. This eliminates scattered hardcoded lists and enables input-dependent behavior classification.

**Motivation:** OpenDev's tool properties were scattered across hardcoded lists in `parallel.rs`, `policy.rs`, `sanitizer.rs`, and `execution.rs`. Adding a new tool required updating 4+ files. This PR moves all tool metadata onto the trait itself, matching (and in some areas surpassing) Claude Code's Tool interface richness.

## What Changed

### Phase 1: New Types & Trait Methods (`opendev-tools-core`)

**New enums:**
- `ToolCategory` — 12 variants (Read, Write, Process, Web, Session, Memory, Meta, Messaging, Automation, Symbol, Mcp, Other) with `Serialize`/`Deserialize`/`Display`/`Hash`
- `InterruptBehavior` — Cancel (default), Block, Ignore

**12 new default methods on `BaseTool`:**

| Method | Purpose | Default |
|--------|---------|---------|
| `is_read_only(args)` | Input-dependent read-only check | `false` |
| `is_destructive(args)` | Input-dependent destructiveness | `false` |
| `is_concurrent_safe(args)` | Safe for parallel execution | delegates to `is_read_only` |
| `category()` | Tool category for policy grouping | `Other` |
| `skip_dedup()` | Skip same-turn deduplication | `false` |
| `is_search_or_read(args)` | TUI collapse hint | delegates to `is_read_only` |
| `is_enabled()` | Runtime enable/disable | `true` |
| `interrupt_behavior()` | User interrupt handling | `Cancel` |
| `truncation_rule()` | Per-tool output truncation | `None` |
| `search_hint()` | ToolSearch keyword phrase | `None` |
| `should_defer()` | Lazy-load via ToolSearch | `false` |
| `prompt_contribution()` | System prompt injection | `None` |

### Phase 2: All 41 Tools Annotated

Every tool now declares its category, and tools with specific behaviors override the relevant methods:

- **Read tools** (12): `is_read_only=true`, `is_concurrent_safe=true`, truncation rules, search hints
- **Write tools** (7): `interrupt_behavior=Block` for file safety
- **Process** (BashTool): Input-dependent `is_read_only()` that analyzes commands
- **Agent/Session** (4): `skip_dedup=true` for spawn/message tools
- **Meta** (10): category assignment
- **Other** (8): Memory, Web, Automation, MCP categories + truncation rules

### Phase 3: Hardcoded Consumer Migration

| Consumer | Before | After |
|----------|--------|-------|
| `execution.rs` | `NO_DEDUP` const list | `tool.skip_dedup()` |
| `execution.rs` | sanitizer-only truncation | `tool.truncation_rule()` with fallback |
| `parallel.rs` | `read_only_tools()` HashSet | `partition_with_tools()` using `is_concurrent_safe(args)` |
| `policy.rs` | `tool_groups()` hardcoded map | `resolve_from_registry()` using `category()` |
| `sanitizer.rs` | `default_rules()` hardcoded map | `sanitize_with_rule()` for trait-provided rules |

Old methods kept as deprecated fallbacks for backward compatibility.

### Phase 4: TUI Integration

Added `From<opendev_tools_core::ToolCategory>` impl for the TUI's `ToolCategory`, bridging the core enum to display-specific categories. Updated `category_from_name()` to recognize core category names.

### Phase 5: Input-Dependent BashTool (Beyond Claude Code)

BashTool's `is_read_only(args)` inspects the command string to classify read-only commands:
- **Safe commands**: `ls`, `cat`, `head`, `grep`, `find`, `wc`, `diff`, `tree`, `jq`, etc.
- **Safe git subcommands**: `status`, `log`, `diff`, `show`, `branch`, `blame`, etc.
- **Safe cargo subcommands**: `check`, `clippy`, `test`, `doc`, `tree`, etc.
- **Pipe chains**: Each segment checked independently
- **Write detection**: Redirect operators (`>`), `sed -i`, git write commands

This enables **automatic parallel execution of safe Bash commands** — something Claude Code cannot do since its `isReadOnly` doesn't inspect command content.

## Files Changed

- **`opendev-tools-core`** (8 files): trait enums, methods, registry, execution, parallel, policy, sanitizer, tests
- **`opendev-tools-impl`** (37 files): all 41 tool implementations annotated
- **`opendev-tui`** (1 file): TUI category bridge

**46 files changed, +1211 / -25 lines**

## Test plan

- [x] `cargo test --workspace --lib --tests` — 2045 tests pass, 0 failures
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings
- [x] `cargo check --workspace` — clean compilation
- [x] `cargo build --release -p opendev-cli` — successful
- [x] `cargo fmt --all` — formatted
- [ ] Verify BashTool parallel execution with read-only commands in real TUI
- [ ] Verify tool categories appear correctly in TUI display