### PR TITLE
feat(context): enhance project instruction system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4097,6 +4097,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -5973,6 +5974,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7123,6 +7137,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ lto = "thin"
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_yaml = "0.9"
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/opendev-agents/src/react_loop/loop_state.rs
+++ b/crates/opendev-agents/src/react_loop/loop_state.rs
@@ -56,10 +56,11 @@ pub(super) struct LoopState {
 impl LoopState {
     /// Create a new `LoopState` for a fresh react loop execution.
     pub fn new(working_dir: &std::path::Path) -> Self {
-        let startup_paths: Vec<PathBuf> = opendev_context::discover_instruction_files(working_dir)
-            .into_iter()
-            .map(|f| f.path)
-            .collect();
+        let startup_paths: Vec<PathBuf> =
+            opendev_context::discover_instruction_files(working_dir, &[], &[])
+                .into_iter()
+                .map(|f| f.path)
+                .collect();
         let subdir_tracker = opendev_context::SubdirInstructionTracker::new(
             working_dir.to_path_buf(),
             &startup_paths,

--- a/crates/opendev-agents/src/subagents/manager/spawn.rs
+++ b/crates/opendev-agents/src/subagents/manager/spawn.rs
@@ -161,7 +161,7 @@ impl SubagentManager {
                 }
             }
 
-            let instructions = opendev_context::discover_instruction_files(wd);
+            let instructions = opendev_context::discover_instruction_files(wd, &[], &[]);
             if !instructions.is_empty() {
                 parts.push("\n\n# Project Instructions\n".to_string());
                 for instr in &instructions {

--- a/crates/opendev-config/src/loader/mod.rs
+++ b/crates/opendev-config/src/loader/mod.rs
@@ -118,6 +118,7 @@ impl ConfigLoader {
     fn merge(base: AppConfig, overrides: serde_json::Value) -> AppConfig {
         // Extract array fields that should be concatenated before the general merge.
         let base_instructions = base.instructions.clone();
+        let base_instruction_excludes = base.instruction_excludes.clone();
         let base_skill_paths = base.skill_paths.clone();
         let base_skill_urls = base.skill_urls.clone();
 
@@ -141,6 +142,17 @@ impl ConfigLoader {
                     }
                 }
                 merged.instructions = combined;
+            }
+            if override_obj.contains_key("instruction_excludes")
+                && !base_instruction_excludes.is_empty()
+            {
+                let mut combined = base_instruction_excludes;
+                for item in &merged.instruction_excludes {
+                    if !combined.contains(item) {
+                        combined.push(item.clone());
+                    }
+                }
+                merged.instruction_excludes = combined;
             }
             if override_obj.contains_key("skill_paths") && !base_skill_paths.is_empty() {
                 let mut combined = base_skill_paths;

--- a/crates/opendev-config/src/loader/validation.rs
+++ b/crates/opendev-config/src/loader/validation.rs
@@ -83,6 +83,7 @@ impl ConfigLoader {
             "plan_mode_plan_agent_count",
             "plan_mode_explore_variant",
             "instructions",
+            "instruction_excludes",
             "skill_paths",
             "skill_urls",
             "model_variants",

--- a/crates/opendev-context/Cargo.toml
+++ b/crates/opendev-context/Cargo.toml
@@ -10,6 +10,7 @@ opendev-config = { workspace = true }
 opendev-models = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 chrono = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/crates/opendev-context/src/environment/conditional.rs
+++ b/crates/opendev-context/src/environment/conditional.rs
@@ -1,0 +1,55 @@
+//! Conditional rule evaluation for instruction files.
+//!
+//! Rules in `.opendev/rules/` can have YAML frontmatter with a `paths` field
+//! containing glob patterns. These rules only apply when the agent is working
+//! with files that match at least one of the patterns.
+
+use std::path::{Path, PathBuf};
+
+/// Check if a conditional rule applies to the given set of active file paths.
+///
+/// - `None` path_globs means the rule always applies (unconditional).
+/// - Empty globs vec means the rule always applies.
+/// - Otherwise, returns true if any active file matches any of the glob patterns.
+///
+/// Patterns are matched against relative paths from `working_dir`.
+pub fn rule_applies(
+    path_globs: Option<&[String]>,
+    active_files: &[PathBuf],
+    working_dir: &Path,
+) -> bool {
+    let globs = match path_globs {
+        None | Some([]) => return true,
+        Some(g) => g,
+    };
+
+    if active_files.is_empty() {
+        return false;
+    }
+
+    let canon_wd = working_dir
+        .canonicalize()
+        .unwrap_or_else(|_| working_dir.to_path_buf());
+
+    for file in active_files {
+        let canon_file = file.canonicalize().unwrap_or_else(|_| file.clone());
+        let relative = canon_file
+            .strip_prefix(&canon_wd)
+            .unwrap_or(&canon_file)
+            .to_string_lossy();
+
+        for glob_str in globs {
+            if let Ok(pattern) = glob::Pattern::new(glob_str)
+                && pattern.matches(relative.as_ref())
+            {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
+#[cfg(test)]
+#[path = "conditional_tests.rs"]
+mod tests;

--- a/crates/opendev-context/src/environment/conditional_tests.rs
+++ b/crates/opendev-context/src/environment/conditional_tests.rs
@@ -1,0 +1,67 @@
+use std::path::PathBuf;
+
+use tempfile::TempDir;
+
+use super::*;
+
+#[test]
+fn test_none_globs_always_applies() {
+    assert!(rule_applies(None, &[], std::path::Path::new("/tmp")));
+}
+
+#[test]
+fn test_empty_globs_always_applies() {
+    let globs: Vec<String> = vec![];
+    assert!(rule_applies(
+        Some(&globs),
+        &[],
+        std::path::Path::new("/tmp")
+    ));
+}
+
+#[test]
+fn test_matching_file() {
+    let dir = TempDir::new().unwrap();
+    let dir_path = dir.path().canonicalize().unwrap();
+    let file = dir_path.join("src").join("main.rs");
+    std::fs::create_dir_all(file.parent().unwrap()).unwrap();
+    std::fs::write(&file, "fn main() {}").unwrap();
+
+    let globs = vec!["src/**/*.rs".to_string()];
+    assert!(rule_applies(Some(&globs), &[file], &dir_path));
+}
+
+#[test]
+fn test_non_matching_file() {
+    let dir = TempDir::new().unwrap();
+    let dir_path = dir.path().canonicalize().unwrap();
+    let file = dir_path.join("docs").join("README.md");
+    std::fs::create_dir_all(file.parent().unwrap()).unwrap();
+    std::fs::write(&file, "# README").unwrap();
+
+    let globs = vec!["src/**/*.rs".to_string()];
+    assert!(!rule_applies(Some(&globs), &[file], &dir_path));
+}
+
+#[test]
+fn test_multiple_globs_one_matches() {
+    let dir = TempDir::new().unwrap();
+    let dir_path = dir.path().canonicalize().unwrap();
+    let file = dir_path.join("tests").join("test_main.rs");
+    std::fs::create_dir_all(file.parent().unwrap()).unwrap();
+    std::fs::write(&file, "// test").unwrap();
+
+    let globs = vec!["src/**/*.rs".to_string(), "tests/**/*.rs".to_string()];
+    assert!(rule_applies(Some(&globs), &[file], &dir_path));
+}
+
+#[test]
+fn test_no_active_files_returns_false() {
+    let globs = vec!["src/**/*.rs".to_string()];
+    let files: Vec<PathBuf> = vec![];
+    assert!(!rule_applies(
+        Some(&globs),
+        &files,
+        std::path::Path::new("/tmp")
+    ));
+}

--- a/crates/opendev-context/src/environment/exclusions.rs
+++ b/crates/opendev-context/src/environment/exclusions.rs
@@ -1,0 +1,69 @@
+//! Instruction file exclusion by glob patterns.
+//!
+//! Allows users to configure `instruction_excludes` in settings to skip
+//! specific instruction files from being loaded. Managed instructions
+//! (from /etc/opendev/) are never excludable.
+
+use std::path::Path;
+
+/// Check if an instruction file should be excluded based on glob patterns.
+///
+/// Managed instructions (paths under `/etc/opendev/`) are never excluded.
+/// Each pattern is resolved relative to `working_dir` and matched against
+/// the file's canonical path and its relative path from working_dir.
+pub fn is_excluded(path: &Path, working_dir: &Path, patterns: &[String]) -> bool {
+    if patterns.is_empty() {
+        return false;
+    }
+
+    // Managed instructions are never excludable
+    let path_str = path.display().to_string();
+    if path_str.starts_with("/etc/opendev/") {
+        return false;
+    }
+
+    let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    let canonical_str = canonical.display().to_string();
+
+    // Compute relative path from working_dir for pattern matching
+    let canon_wd = working_dir
+        .canonicalize()
+        .unwrap_or_else(|_| working_dir.to_path_buf());
+    let relative = canonical
+        .strip_prefix(working_dir)
+        .or_else(|_| canonical.strip_prefix(&canon_wd))
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|_| canonical.clone())
+        .to_string_lossy()
+        .to_string();
+
+    for pattern in patterns {
+        // Expand pattern relative to working_dir
+        let expanded = if pattern.starts_with('/') || pattern.starts_with("~/") {
+            pattern.clone()
+        } else {
+            working_dir.join(pattern).to_string_lossy().to_string()
+        };
+
+        // Try matching as a glob pattern against both canonical and relative paths
+        if let Ok(glob_pattern) = glob::Pattern::new(&expanded)
+            && (glob_pattern.matches(&canonical_str) || glob_pattern.matches(&relative))
+        {
+            return true;
+        }
+
+        // Also try the raw pattern against the relative path (for simple globs like "*.md")
+        if let Ok(glob_pattern) = glob::Pattern::new(pattern) {
+            let filename = canonical.file_name().unwrap_or_default().to_string_lossy();
+            if glob_pattern.matches(&relative) || glob_pattern.matches(filename.as_ref()) {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
+#[cfg(test)]
+#[path = "exclusions_tests.rs"]
+mod tests;

--- a/crates/opendev-context/src/environment/exclusions_tests.rs
+++ b/crates/opendev-context/src/environment/exclusions_tests.rs
@@ -1,0 +1,52 @@
+use tempfile::TempDir;
+
+use super::*;
+
+#[test]
+fn test_no_patterns_not_excluded() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("AGENTS.md");
+    std::fs::write(&file, "content").unwrap();
+
+    assert!(!is_excluded(&file, dir.path(), &[]));
+}
+
+#[test]
+fn test_filename_glob_match() {
+    let dir = TempDir::new().unwrap();
+    let dir_path = dir.path().canonicalize().unwrap();
+    let file = dir_path.join("AGENTS.md");
+    std::fs::write(&file, "content").unwrap();
+
+    assert!(is_excluded(&file, &dir_path, &["AGENTS.md".to_string()]));
+}
+
+#[test]
+fn test_wildcard_glob_match() {
+    let dir = TempDir::new().unwrap();
+    let dir_path = dir.path().canonicalize().unwrap();
+    let file = dir_path.join("test.md");
+    std::fs::write(&file, "content").unwrap();
+
+    assert!(is_excluded(&file, &dir_path, &["*.md".to_string()]));
+}
+
+#[test]
+fn test_no_match_returns_false() {
+    let dir = TempDir::new().unwrap();
+    let dir_path = dir.path().canonicalize().unwrap();
+    let file = dir_path.join("AGENTS.md");
+    std::fs::write(&file, "content").unwrap();
+
+    assert!(!is_excluded(&file, &dir_path, &["*.txt".to_string()]));
+}
+
+#[test]
+fn test_managed_never_excluded() {
+    let path = std::path::Path::new("/etc/opendev/AGENTS.md");
+    assert!(!is_excluded(
+        path,
+        std::path::Path::new("/tmp"),
+        &["*.md".to_string()]
+    ));
+}

--- a/crates/opendev-context/src/environment/frontmatter.rs
+++ b/crates/opendev-context/src/environment/frontmatter.rs
@@ -1,0 +1,126 @@
+//! YAML frontmatter parsing and HTML comment stripping for instruction files.
+//!
+//! Rule files in `.opendev/rules/` can have YAML frontmatter with a `paths` field
+//! that makes them conditional. HTML block comments (`<!-- ... -->`) are stripped
+//! from instruction content while preserving comments inside fenced code blocks.
+
+use regex::Regex;
+use serde::Deserialize;
+
+/// Parsed YAML frontmatter from a rule file.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct Frontmatter {
+    /// Glob patterns that make this rule conditional.
+    /// When present, the rule only applies to files matching at least one pattern.
+    #[serde(default)]
+    pub paths: Option<Vec<String>>,
+}
+
+/// Parse YAML frontmatter from instruction content.
+///
+/// Frontmatter is delimited by `---` lines at the start of the file.
+/// Returns `(parsed_frontmatter, remaining_content)`.
+pub fn parse_frontmatter(content: &str) -> (Option<Frontmatter>, String) {
+    let trimmed = content.trim_start();
+    if !trimmed.starts_with("---") {
+        return (None, content.to_string());
+    }
+
+    // Find the opening delimiter line end
+    let after_open = match trimmed.find('\n') {
+        Some(i) => i + 1,
+        None => return (None, content.to_string()),
+    };
+
+    // Find the closing `---` delimiter
+    let rest = &trimmed[after_open..];
+    let close_pos = rest
+        .lines()
+        .enumerate()
+        .find(|(_, line)| line.trim() == "---")
+        .map(|(i, _)| {
+            // Calculate byte offset of the closing delimiter line
+            rest.lines()
+                .take(i)
+                .map(|l| l.len() + 1) // +1 for newline
+                .sum::<usize>()
+        });
+
+    let close_pos = match close_pos {
+        Some(p) => p,
+        None => return (None, content.to_string()),
+    };
+
+    let yaml_str = &rest[..close_pos];
+    let remaining = &rest[close_pos..];
+    // Skip the closing `---` line itself
+    let remaining = match remaining.find('\n') {
+        Some(i) => &remaining[i + 1..],
+        None => "",
+    };
+
+    let frontmatter: Option<Frontmatter> = serde_yaml::from_str(yaml_str).ok();
+
+    (frontmatter, remaining.to_string())
+}
+
+/// Strip block-level HTML comments from instruction content.
+///
+/// Removes `<!-- ... -->` patterns from content while preserving
+/// comments inside fenced code blocks (` ``` `).
+pub fn strip_html_comments(content: &str) -> String {
+    let comment_re = Regex::new(r"<!--[\s\S]*?-->").expect("valid regex");
+
+    let mut result = String::with_capacity(content.len());
+    let mut in_code_block = false;
+    let mut current_block = String::new();
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("```") {
+            if in_code_block {
+                // Closing code block — flush block content as-is
+                current_block.push_str(line);
+                current_block.push('\n');
+                result.push_str(&current_block);
+                current_block.clear();
+                in_code_block = false;
+            } else {
+                // Opening code block — flush any pending non-code content
+                if !current_block.is_empty() {
+                    let stripped = comment_re.replace_all(&current_block, "");
+                    result.push_str(&stripped);
+                    current_block.clear();
+                }
+                in_code_block = true;
+                current_block.push_str(line);
+                current_block.push('\n');
+            }
+        } else {
+            current_block.push_str(line);
+            current_block.push('\n');
+        }
+    }
+
+    // Flush remaining content
+    if !current_block.is_empty() {
+        if in_code_block {
+            // Unclosed code block — preserve as-is
+            result.push_str(&current_block);
+        } else {
+            let stripped = comment_re.replace_all(&current_block, "");
+            result.push_str(&stripped);
+        }
+    }
+
+    // Remove trailing newline added by our line iteration if original didn't have one
+    if !content.ends_with('\n') && result.ends_with('\n') {
+        result.pop();
+    }
+
+    result
+}
+
+#[cfg(test)]
+#[path = "frontmatter_tests.rs"]
+mod tests;

--- a/crates/opendev-context/src/environment/frontmatter_tests.rs
+++ b/crates/opendev-context/src/environment/frontmatter_tests.rs
@@ -1,0 +1,90 @@
+use super::*;
+
+#[test]
+fn test_parse_frontmatter_with_paths() {
+    let content =
+        "---\npaths:\n  - \"src/**/*.rs\"\n  - \"tests/**/*.rs\"\n---\nRule content here.";
+    let (fm, remaining) = parse_frontmatter(content);
+    assert!(fm.is_some());
+    let fm = fm.unwrap();
+    let paths = fm.paths.unwrap();
+    assert_eq!(paths.len(), 2);
+    assert_eq!(paths[0], "src/**/*.rs");
+    assert_eq!(paths[1], "tests/**/*.rs");
+    assert_eq!(remaining.trim(), "Rule content here.");
+}
+
+#[test]
+fn test_parse_frontmatter_no_frontmatter() {
+    let content = "Just regular content\nwith multiple lines.";
+    let (fm, remaining) = parse_frontmatter(content);
+    assert!(fm.is_none());
+    assert_eq!(remaining, content);
+}
+
+#[test]
+fn test_parse_frontmatter_empty() {
+    let content = "---\n---\nContent after empty frontmatter.";
+    let (fm, remaining) = parse_frontmatter(content);
+    assert!(fm.is_some());
+    assert!(fm.unwrap().paths.is_none());
+    assert_eq!(remaining.trim(), "Content after empty frontmatter.");
+}
+
+#[test]
+fn test_parse_frontmatter_without_paths() {
+    let content = "---\nname: my-rule\ndescription: A rule\n---\nContent.";
+    let (fm, remaining) = parse_frontmatter(content);
+    assert!(fm.is_some());
+    assert!(fm.unwrap().paths.is_none());
+    assert_eq!(remaining.trim(), "Content.");
+}
+
+#[test]
+fn test_parse_frontmatter_no_closing_delimiter() {
+    let content = "---\npaths:\n  - \"*.rs\"\nContent without closing delimiter.";
+    let (fm, remaining) = parse_frontmatter(content);
+    assert!(fm.is_none());
+    assert_eq!(remaining, content);
+}
+
+#[test]
+fn test_strip_html_comments_basic() {
+    let content = "Before\n<!-- This is a comment -->\nAfter";
+    let result = strip_html_comments(content);
+    assert!(result.contains("Before"));
+    assert!(result.contains("After"));
+    assert!(!result.contains("This is a comment"));
+}
+
+#[test]
+fn test_strip_html_comments_multiline() {
+    let content = "Before\n<!--\nMulti\nline\ncomment\n-->\nAfter";
+    let result = strip_html_comments(content);
+    assert!(result.contains("Before"));
+    assert!(result.contains("After"));
+    assert!(!result.contains("Multi"));
+}
+
+#[test]
+fn test_strip_html_comments_in_code_block_preserved() {
+    let content = "Before\n```html\n<!-- This should stay -->\n```\nAfter";
+    let result = strip_html_comments(content);
+    assert!(result.contains("This should stay"));
+    assert!(result.contains("Before"));
+    assert!(result.contains("After"));
+}
+
+#[test]
+fn test_strip_html_comments_no_comments() {
+    let content = "Just regular content\nNo comments here.";
+    let result = strip_html_comments(content);
+    assert_eq!(result, content);
+}
+
+#[test]
+fn test_strip_html_comments_multiple() {
+    let content = "A<!-- one -->B<!-- two -->C";
+    let result = strip_html_comments(content);
+    assert_eq!(result, "ABC");
+}

--- a/crates/opendev-context/src/environment/include_parser.rs
+++ b/crates/opendev-context/src/environment/include_parser.rs
@@ -1,0 +1,221 @@
+//! @include directive parser for instruction files.
+//!
+//! Supports `@path`, `@./relative`, `@~/home`, `@/absolute` syntax inside
+//! instruction files to compose instructions from multiple sources.
+//! Maximum include depth is 5 levels with circular reference prevention.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use tracing::debug;
+
+use super::{InstructionFile, InstructionSource};
+
+/// Maximum depth for recursive @include directives.
+const MAX_INCLUDE_DEPTH: usize = 5;
+
+/// Maximum content size per included file (50 KB).
+const MAX_INCLUDE_BYTES: usize = 50 * 1024;
+
+/// File extensions allowed for @include directives.
+const INCLUDABLE_EXTENSIONS: &[&str] = &[
+    "md",
+    "txt",
+    "rs",
+    "py",
+    "js",
+    "ts",
+    "tsx",
+    "jsx",
+    "toml",
+    "yaml",
+    "yml",
+    "json",
+    "sh",
+    "bash",
+    "zsh",
+    "go",
+    "c",
+    "h",
+    "cpp",
+    "hpp",
+    "java",
+    "kt",
+    "rb",
+    "sql",
+    "swift",
+    "css",
+    "html",
+    "xml",
+    "proto",
+    "graphql",
+    "cfg",
+    "ini",
+    "conf",
+    "env",
+    "makefile",
+    "dockerfile",
+    "cmake",
+];
+
+/// Process @include directives in instruction content.
+///
+/// Extracts `@path` directives from non-code-block lines and recursively
+/// loads the referenced files. Returns the cleaned content (with @directives
+/// removed) and a list of included instruction files.
+///
+/// Included files appear BEFORE the including file for correct priority ordering
+/// (later content has higher effective priority with LLMs).
+pub fn process_includes(
+    content: &str,
+    base_dir: &Path,
+    working_dir: &Path,
+    depth: usize,
+    visited: &mut HashSet<PathBuf>,
+    parent_path: Option<&Path>,
+) -> (String, Vec<InstructionFile>) {
+    if depth >= MAX_INCLUDE_DEPTH {
+        debug!(
+            depth,
+            "Max @include depth reached, skipping further includes"
+        );
+        return (content.to_string(), Vec::new());
+    }
+
+    let mut included_files = Vec::new();
+    let mut cleaned_lines = Vec::new();
+    let mut in_code_block = false;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+
+        // Track fenced code blocks
+        if trimmed.starts_with("```") {
+            in_code_block = !in_code_block;
+            cleaned_lines.push(line.to_string());
+            continue;
+        }
+
+        // Only process @directives outside code blocks
+        if !in_code_block
+            && trimmed.starts_with('@')
+            && !trimmed.starts_with("@@")
+            && let Some(included) =
+                resolve_include(trimmed, base_dir, working_dir, depth, visited, parent_path)
+        {
+            included_files.extend(included);
+            // Replace the @directive line with an empty line to preserve line numbers
+            cleaned_lines.push(String::new());
+            continue;
+        }
+
+        cleaned_lines.push(line.to_string());
+    }
+
+    let cleaned_content = cleaned_lines.join("\n");
+    (cleaned_content, included_files)
+}
+
+/// Resolve a single @include directive into instruction files.
+fn resolve_include(
+    directive: &str,
+    base_dir: &Path,
+    working_dir: &Path,
+    depth: usize,
+    visited: &mut HashSet<PathBuf>,
+    parent_path: Option<&Path>,
+) -> Option<Vec<InstructionFile>> {
+    // Extract the path from `@path` or `@path#fragment`
+    let raw_path = directive.trim_start_matches('@');
+    if raw_path.is_empty() {
+        return None;
+    }
+
+    // Strip fragment identifier (e.g., #heading)
+    let raw_path = raw_path.split('#').next().unwrap_or(raw_path);
+    if raw_path.is_empty() {
+        return None;
+    }
+
+    // Resolve the path
+    let resolved = if raw_path.starts_with('/') {
+        PathBuf::from(raw_path)
+    } else if let Some(rest) = raw_path.strip_prefix("~/") {
+        dirs_next::home_dir()?.join(rest)
+    } else {
+        // Relative to the including file's directory (or base_dir)
+        let rel = raw_path.strip_prefix("./").unwrap_or(raw_path);
+        base_dir.join(rel)
+    };
+
+    // Canonicalize and check for circular references
+    let canonical = resolved.canonicalize().ok()?;
+
+    if !canonical.is_file() {
+        return None;
+    }
+
+    // Check extension allowlist
+    if let Some(ext) = canonical.extension().and_then(|e| e.to_str()) {
+        if !INCLUDABLE_EXTENSIONS.contains(&ext.to_lowercase().as_str()) {
+            debug!(path = %canonical.display(), ext, "Skipping @include: non-text file extension");
+            return None;
+        }
+    } else {
+        // Special case: extensionless files with known names
+        let name = canonical.file_name().and_then(|n| n.to_str()).unwrap_or("");
+        let name_lower = name.to_lowercase();
+        if !["makefile", "dockerfile"].contains(&name_lower.as_str()) {
+            debug!(path = %canonical.display(), "Skipping @include: no file extension");
+            return None;
+        }
+    }
+
+    if !visited.insert(canonical.clone()) {
+        debug!(path = %canonical.display(), "Skipping @include: circular reference");
+        return None;
+    }
+
+    // Read and truncate
+    let content = std::fs::read_to_string(&canonical).ok()?;
+    if content.trim().is_empty() {
+        return Some(Vec::new());
+    }
+
+    let content = if content.len() > MAX_INCLUDE_BYTES {
+        let truncated = &content[..MAX_INCLUDE_BYTES];
+        format!(
+            "{truncated}\n\n... (truncated, included file is {} KB)",
+            content.len() / 1024
+        )
+    } else {
+        content
+    };
+
+    // Recursively process includes in the included file
+    let include_dir = canonical.parent().unwrap_or(base_dir);
+    let (processed_content, nested_includes) = process_includes(
+        &content,
+        include_dir,
+        working_dir,
+        depth + 1,
+        visited,
+        Some(&canonical),
+    );
+
+    let mut result = nested_includes;
+    result.push(InstructionFile {
+        scope: "include".to_string(),
+        path: canonical,
+        content: processed_content,
+        source: InstructionSource::Include,
+        path_globs: None,
+        included_from: parent_path.map(|p| p.to_path_buf()),
+    });
+
+    Some(result)
+}
+
+#[cfg(test)]
+#[path = "include_parser_tests.rs"]
+mod tests;

--- a/crates/opendev-context/src/environment/include_parser_tests.rs
+++ b/crates/opendev-context/src/environment/include_parser_tests.rs
@@ -1,0 +1,206 @@
+use std::collections::HashSet;
+
+use tempfile::TempDir;
+
+use super::*;
+
+#[test]
+fn test_basic_relative_include() {
+    let dir = TempDir::new().unwrap();
+    let dir_path = dir.path().canonicalize().unwrap();
+
+    std::fs::write(dir_path.join("included.md"), "Included content").unwrap();
+    let content = "@./included.md\nMain content";
+
+    let mut visited = HashSet::new();
+    let (cleaned, included) =
+        process_includes(content, &dir_path, &dir_path, 0, &mut visited, None);
+
+    assert_eq!(included.len(), 1);
+    assert!(included[0].content.contains("Included content"));
+    assert_eq!(included[0].source, InstructionSource::Include);
+    assert!(cleaned.contains("Main content"));
+    assert!(!cleaned.contains("@./included.md"));
+}
+
+#[test]
+fn test_include_without_dot_slash() {
+    let dir = TempDir::new().unwrap();
+    let dir_path = dir.path().canonicalize().unwrap();
+
+    std::fs::write(dir_path.join("rules.md"), "Rule content").unwrap();
+    let content = "@rules.md\nMain";
+
+    let mut visited = HashSet::new();
+    let (_, included) = process_includes(content, &dir_path, &dir_path, 0, &mut visited, None);
+
+    assert_eq!(included.len(), 1);
+    assert!(included[0].content.contains("Rule content"));
+}
+
+#[test]
+fn test_include_absolute_path() {
+    let dir = TempDir::new().unwrap();
+    let dir_path = dir.path().canonicalize().unwrap();
+
+    let file_path = dir_path.join("absolute.md");
+    std::fs::write(&file_path, "Absolute content").unwrap();
+    let content = format!("@{}\nMain", file_path.display());
+
+    let mut visited = HashSet::new();
+    let (_, included) = process_includes(&content, &dir_path, &dir_path, 0, &mut visited, None);
+
+    assert_eq!(included.len(), 1);
+    assert!(included[0].content.contains("Absolute content"));
+}
+
+#[test]
+fn test_max_depth_prevents_infinite_recursion() {
+    let dir = TempDir::new().unwrap();
+    let dir_path = dir.path().canonicalize().unwrap();
+
+    // Create file that includes itself (shouldn't recurse past MAX_INCLUDE_DEPTH)
+    std::fs::write(dir_path.join("self.md"), "@./self.md\nContent").unwrap();
+
+    let mut visited = HashSet::new();
+    let (_, included) = process_includes(
+        "@./self.md\nMain",
+        &dir_path,
+        &dir_path,
+        0,
+        &mut visited,
+        None,
+    );
+
+    // Should include the file once (circular ref prevention)
+    assert_eq!(included.len(), 1);
+}
+
+#[test]
+fn test_circular_reference_detected() {
+    let dir = TempDir::new().unwrap();
+    let dir_path = dir.path().canonicalize().unwrap();
+
+    std::fs::write(dir_path.join("a.md"), "@./b.md\nFile A").unwrap();
+    std::fs::write(dir_path.join("b.md"), "@./a.md\nFile B").unwrap();
+
+    let mut visited = HashSet::new();
+    let (_, included) =
+        process_includes("@./a.md\nMain", &dir_path, &dir_path, 0, &mut visited, None);
+
+    // a.md includes b.md, but b.md trying to include a.md should be skipped
+    assert_eq!(included.len(), 2); // b.md and a.md
+}
+
+#[test]
+fn test_binary_file_skipped() {
+    let dir = TempDir::new().unwrap();
+    let dir_path = dir.path().canonicalize().unwrap();
+
+    std::fs::write(dir_path.join("image.png"), "fake png").unwrap();
+    let content = "@./image.png\nMain content";
+
+    let mut visited = HashSet::new();
+    let (_, included) = process_includes(content, &dir_path, &dir_path, 0, &mut visited, None);
+
+    assert!(included.is_empty());
+}
+
+#[test]
+fn test_include_in_code_block_ignored() {
+    let dir = TempDir::new().unwrap();
+    let dir_path = dir.path().canonicalize().unwrap();
+
+    std::fs::write(dir_path.join("should_not_include.md"), "Oops").unwrap();
+    let content = "Before\n```\n@./should_not_include.md\n```\nAfter";
+
+    let mut visited = HashSet::new();
+    let (cleaned, included) =
+        process_includes(content, &dir_path, &dir_path, 0, &mut visited, None);
+
+    assert!(included.is_empty());
+    assert!(cleaned.contains("@./should_not_include.md"));
+}
+
+#[test]
+fn test_multiple_includes() {
+    let dir = TempDir::new().unwrap();
+    let dir_path = dir.path().canonicalize().unwrap();
+
+    std::fs::write(dir_path.join("first.md"), "First").unwrap();
+    std::fs::write(dir_path.join("second.md"), "Second").unwrap();
+    let content = "@./first.md\n@./second.md\nMain";
+
+    let mut visited = HashSet::new();
+    let (_, included) = process_includes(content, &dir_path, &dir_path, 0, &mut visited, None);
+
+    assert_eq!(included.len(), 2);
+}
+
+#[test]
+fn test_nonexistent_include_skipped() {
+    let dir = TempDir::new().unwrap();
+    let dir_path = dir.path().canonicalize().unwrap();
+
+    let content = "@./does_not_exist.md\nMain content";
+
+    let mut visited = HashSet::new();
+    let (cleaned, included) =
+        process_includes(content, &dir_path, &dir_path, 0, &mut visited, None);
+
+    assert!(included.is_empty());
+    assert!(cleaned.contains("Main content"));
+}
+
+#[test]
+fn test_include_with_fragment_stripped() {
+    let dir = TempDir::new().unwrap();
+    let dir_path = dir.path().canonicalize().unwrap();
+
+    std::fs::write(dir_path.join("doc.md"), "Doc content").unwrap();
+    let content = "@./doc.md#section-1\nMain";
+
+    let mut visited = HashSet::new();
+    let (_, included) = process_includes(content, &dir_path, &dir_path, 0, &mut visited, None);
+
+    assert_eq!(included.len(), 1);
+    assert!(included[0].content.contains("Doc content"));
+}
+
+#[test]
+fn test_double_at_not_treated_as_include() {
+    let dir = TempDir::new().unwrap();
+    let dir_path = dir.path().canonicalize().unwrap();
+
+    let content = "@@not-an-include\nMain";
+
+    let mut visited = HashSet::new();
+    let (cleaned, included) =
+        process_includes(content, &dir_path, &dir_path, 0, &mut visited, None);
+
+    assert!(included.is_empty());
+    assert!(cleaned.contains("@@not-an-include"));
+}
+
+#[test]
+fn test_included_from_field_set() {
+    let dir = TempDir::new().unwrap();
+    let dir_path = dir.path().canonicalize().unwrap();
+
+    let parent = dir_path.join("parent.md");
+    std::fs::write(dir_path.join("child.md"), "Child").unwrap();
+    std::fs::write(&parent, "@./child.md\nParent content").unwrap();
+
+    let mut visited = HashSet::new();
+    let (_, included) = process_includes(
+        "@./child.md\nMain",
+        &dir_path,
+        &dir_path,
+        0,
+        &mut visited,
+        Some(&parent),
+    );
+
+    assert_eq!(included.len(), 1);
+    assert_eq!(included[0].included_from.as_ref().unwrap(), &parent);
+}

--- a/crates/opendev-context/src/environment/instructions.rs
+++ b/crates/opendev-context/src/environment/instructions.rs
@@ -3,14 +3,30 @@
 //! Discovers project instruction files (AGENTS.md, CLAUDE.md, etc.) by walking
 //! the directory hierarchy, and resolves config-specified instruction paths
 //! (globs, URLs, ~/paths).
+//!
+//! Enhanced features:
+//! - `.opendev/rules/` directory with conditional frontmatter
+//! - Local overrides (`AGENTS.local.md`, `CLAUDE.local.md`)
+//! - Managed/enterprise instructions (`/etc/opendev/`)
+//! - `@include` directive processing
+//! - HTML comment stripping
+//! - Instruction exclusion via glob patterns
+//! - Additional directories for discovery
 
-use std::path::Path;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use super::InstructionFile;
+use super::exclusions::is_excluded;
+use super::frontmatter::{parse_frontmatter, strip_html_comments};
+use super::include_parser::process_includes;
+use super::{InstructionFile, InstructionSource};
 
 /// Instruction file names to search for, in priority order.
 const INSTRUCTION_FILENAMES: &[&str] = &["AGENTS.md", "CLAUDE.md"];
+
+/// Local override variants (gitignored, highest priority).
+const LOCAL_INSTRUCTION_FILENAMES: &[&str] = &["AGENTS.local.md", "CLAUDE.local.md"];
 
 /// Additional instruction file patterns from other AI tools.
 /// These are checked per-directory alongside the standard filenames.
@@ -27,63 +43,29 @@ const REMOTE_INSTRUCTION_TIMEOUT_SECS: u64 = 5;
 
 /// Discover project instruction files by walking up from `working_dir`.
 ///
-/// Searches for `AGENTS.md` and `CLAUDE.md` in the working directory
-/// and each parent up to the filesystem root (or git root). Also checks
-/// `.opendev/instructions.md` in each directory,
-/// and global config at `~/.opendev/instructions.md` and `~/.config/opendev/AGENTS.md`.
+/// Searches for `AGENTS.md`, `CLAUDE.md`, local overrides, `.opendev/rules/`,
+/// compatibility files, and more. Also checks global and managed locations.
 ///
 /// Files found closer to `working_dir` have higher priority and are listed first.
-pub fn discover_instruction_files(working_dir: &Path) -> Vec<InstructionFile> {
+/// Local overrides are listed after their non-local counterparts for highest priority.
+///
+/// `exclude_patterns` filters out instruction files matching any glob pattern.
+/// `additional_dirs` adds extra directories for discovery.
+pub fn discover_instruction_files(
+    working_dir: &Path,
+    exclude_patterns: &[String],
+    additional_dirs: &[PathBuf],
+) -> Vec<InstructionFile> {
     let mut files = Vec::new();
-    let mut seen = std::collections::HashSet::new();
+    let mut seen = HashSet::new();
 
-    // Walk up the directory tree from working_dir
-    let mut current = working_dir.to_path_buf();
-    loop {
-        // Check each instruction filename
-        for filename in INSTRUCTION_FILENAMES {
-            let candidate = current.join(filename);
-            try_add_instruction(&candidate, &current, working_dir, &mut files, &mut seen);
-        }
+    // Walk the primary working directory
+    walk_directory_tree(working_dir, exclude_patterns, &mut files, &mut seen);
 
-        // Check .opendev/instructions.md
-        let opendev_instr = current.join(".opendev").join("instructions.md");
-        try_add_instruction(&opendev_instr, &current, working_dir, &mut files, &mut seen);
-
-        // Check compatibility files from other AI tools (.cursorrules, copilot, etc.)
-        for compat_path in COMPAT_INSTRUCTION_FILES {
-            let candidate = current.join(compat_path);
-            try_add_instruction(&candidate, &current, working_dir, &mut files, &mut seen);
-        }
-
-        // Check .cursor/rules/ directory for individual rule files
-        let cursor_rules_dir = current.join(".cursor").join("rules");
-        if cursor_rules_dir.is_dir()
-            && let Ok(entries) = std::fs::read_dir(&cursor_rules_dir)
-        {
-            let mut rule_files: Vec<_> = entries
-                .flatten()
-                .filter(|e| {
-                    let name = e.file_name();
-                    let name_str = name.to_string_lossy();
-                    e.file_type().map(|ft| ft.is_file()).unwrap_or(false)
-                        && (name_str.ends_with(".md")
-                            || name_str.ends_with(".txt")
-                            || name_str.ends_with(".mdc"))
-                })
-                .collect();
-            rule_files.sort_by_key(|e| e.file_name());
-            for entry in rule_files {
-                try_add_instruction(&entry.path(), &current, working_dir, &mut files, &mut seen);
-            }
-        }
-
-        // Stop at git root or filesystem root
-        if current.join(".git").exists() {
-            break;
-        }
-        if !current.pop() {
-            break;
+    // Walk additional directories
+    for dir in additional_dirs {
+        if dir.is_dir() {
+            walk_directory_tree(dir, exclude_patterns, &mut files, &mut seen);
         }
     }
 
@@ -99,13 +81,208 @@ pub fn discover_instruction_files(working_dir: &Path) -> Vec<InstructionFile> {
                 path,
                 path.parent().unwrap_or(path),
                 working_dir,
+                exclude_patterns,
+                InstructionSource::Discovery,
                 &mut files,
                 &mut seen,
             );
         }
     }
 
+    // Check managed/enterprise instructions (never excludable)
+    let managed_paths = [
+        PathBuf::from("/etc/opendev/AGENTS.md"),
+        PathBuf::from("/etc/opendev/instructions.md"),
+    ];
+    for path in &managed_paths {
+        try_add_managed_instruction(path, &mut files, &mut seen);
+    }
+
     files
+}
+
+/// Walk the directory tree upward from `start_dir`, collecting instruction files.
+fn walk_directory_tree(
+    start_dir: &Path,
+    exclude_patterns: &[String],
+    files: &mut Vec<InstructionFile>,
+    seen: &mut HashSet<PathBuf>,
+) {
+    let working_dir = start_dir;
+    let mut current = start_dir.to_path_buf();
+
+    loop {
+        // Check each instruction filename
+        for filename in INSTRUCTION_FILENAMES {
+            let candidate = current.join(filename);
+            try_add_instruction(
+                &candidate,
+                &current,
+                working_dir,
+                exclude_patterns,
+                InstructionSource::Discovery,
+                files,
+                seen,
+            );
+        }
+
+        // Check local overrides (AGENTS.local.md, CLAUDE.local.md)
+        for filename in LOCAL_INSTRUCTION_FILENAMES {
+            let candidate = current.join(filename);
+            try_add_instruction(
+                &candidate,
+                &current,
+                working_dir,
+                exclude_patterns,
+                InstructionSource::Local,
+                files,
+                seen,
+            );
+        }
+
+        // Check .opendev/instructions.md
+        let opendev_instr = current.join(".opendev").join("instructions.md");
+        try_add_instruction(
+            &opendev_instr,
+            &current,
+            working_dir,
+            exclude_patterns,
+            InstructionSource::Discovery,
+            files,
+            seen,
+        );
+
+        // Check .opendev/rules/ directory for individual rule files
+        discover_rules_dir(
+            &current.join(".opendev").join("rules"),
+            &current,
+            working_dir,
+            exclude_patterns,
+            files,
+            seen,
+        );
+
+        // Check compatibility files from other AI tools (.cursorrules, copilot, etc.)
+        for compat_path in COMPAT_INSTRUCTION_FILES {
+            let candidate = current.join(compat_path);
+            try_add_instruction(
+                &candidate,
+                &current,
+                working_dir,
+                exclude_patterns,
+                InstructionSource::Discovery,
+                files,
+                seen,
+            );
+        }
+
+        // Check .cursor/rules/ directory for individual rule files
+        discover_rules_dir(
+            &current.join(".cursor").join("rules"),
+            &current,
+            working_dir,
+            exclude_patterns,
+            files,
+            seen,
+        );
+
+        // Stop at git root or filesystem root
+        if current.join(".git").exists() {
+            break;
+        }
+        if !current.pop() {
+            break;
+        }
+    }
+}
+
+/// Discover rule files in a rules directory (.opendev/rules/ or .cursor/rules/).
+///
+/// Rule files can have YAML frontmatter with `paths` globs for conditional loading.
+/// Files are sorted alphabetically for deterministic ordering.
+fn discover_rules_dir(
+    rules_dir: &Path,
+    dir: &Path,
+    working_dir: &Path,
+    exclude_patterns: &[String],
+    files: &mut Vec<InstructionFile>,
+    seen: &mut HashSet<PathBuf>,
+) {
+    if !rules_dir.is_dir() {
+        return;
+    }
+
+    let Ok(entries) = std::fs::read_dir(rules_dir) else {
+        return;
+    };
+
+    let mut rule_files: Vec<_> = entries
+        .flatten()
+        .filter(|e| {
+            let name = e.file_name();
+            let name_str = name.to_string_lossy();
+            e.file_type().map(|ft| ft.is_file()).unwrap_or(false)
+                && (name_str.ends_with(".md")
+                    || name_str.ends_with(".txt")
+                    || name_str.ends_with(".mdc"))
+        })
+        .collect();
+    rule_files.sort_by_key(|e| e.file_name());
+
+    for entry in rule_files {
+        let path = entry.path();
+        let canonical = match path.canonicalize() {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+
+        if !seen.insert(canonical.clone()) {
+            continue;
+        }
+
+        if is_excluded(&canonical, working_dir, exclude_patterns) {
+            continue;
+        }
+
+        let content = match std::fs::read_to_string(&canonical) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        if content.trim().is_empty() {
+            continue;
+        }
+
+        let content = truncate_content(content);
+
+        // Parse frontmatter for conditional path globs
+        let (frontmatter, remaining_content) = parse_frontmatter(&content);
+        let path_globs = frontmatter.and_then(|fm| fm.paths);
+
+        // Strip HTML comments and process includes
+        let cleaned = strip_html_comments(&remaining_content);
+        let include_dir = canonical.parent().unwrap_or(working_dir);
+        let (processed, mut included_files) = process_includes(
+            &cleaned,
+            include_dir,
+            working_dir,
+            0,
+            seen,
+            Some(&canonical),
+        );
+
+        // Add included files first (lower priority)
+        files.append(&mut included_files);
+
+        let scope = compute_scope(dir, working_dir);
+        files.push(InstructionFile {
+            scope,
+            path: canonical,
+            content: processed,
+            source: InstructionSource::Rules,
+            path_globs,
+            included_from: None,
+        });
+    }
 }
 
 /// Try to read an instruction file and add it to the list if it exists.
@@ -113,8 +290,10 @@ fn try_add_instruction(
     path: &Path,
     dir: &Path,
     working_dir: &Path,
+    exclude_patterns: &[String],
+    source: InstructionSource,
     files: &mut Vec<InstructionFile>,
-    seen: &mut std::collections::HashSet<std::path::PathBuf>,
+    seen: &mut HashSet<PathBuf>,
 ) {
     let canonical = match path.canonicalize() {
         Ok(c) => c,
@@ -122,6 +301,10 @@ fn try_add_instruction(
     };
     if !seen.insert(canonical.clone()) {
         return; // Already seen (e.g. symlink or parent overlap)
+    }
+
+    if is_excluded(&canonical, working_dir, exclude_patterns) {
+        return;
     }
 
     let content = match std::fs::read_to_string(&canonical) {
@@ -132,18 +315,79 @@ fn try_add_instruction(
         return;
     }
 
-    // Truncate if too large
-    let content = if content.len() > MAX_INSTRUCTION_BYTES {
-        let truncated = &content[..MAX_INSTRUCTION_BYTES];
-        format!(
-            "{truncated}\n\n... (truncated, file is {} KB)",
-            content.len() / 1024
-        )
-    } else {
-        content
+    let content = truncate_content(content);
+
+    // Strip HTML comments
+    let cleaned = strip_html_comments(&content);
+
+    // Process @include directives
+    let include_dir = canonical.parent().unwrap_or(working_dir);
+    let (processed, mut included_files) = process_includes(
+        &cleaned,
+        include_dir,
+        working_dir,
+        0,
+        seen,
+        Some(&canonical),
+    );
+
+    // Add included files first (lower priority)
+    files.append(&mut included_files);
+
+    let scope = match source {
+        InstructionSource::Local => "local".to_string(),
+        InstructionSource::Managed => "managed".to_string(),
+        _ => compute_scope(dir, working_dir),
     };
 
-    let scope = if dir == working_dir || dir.starts_with(working_dir) {
+    files.push(InstructionFile {
+        scope,
+        path: canonical,
+        content: processed,
+        source,
+        path_globs: None,
+        included_from: None,
+    });
+}
+
+/// Add a managed instruction file (never subject to exclusion).
+fn try_add_managed_instruction(
+    path: &Path,
+    files: &mut Vec<InstructionFile>,
+    seen: &mut HashSet<PathBuf>,
+) {
+    let canonical = match path.canonicalize() {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+    if !seen.insert(canonical.clone()) {
+        return;
+    }
+
+    let content = match std::fs::read_to_string(&canonical) {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+    if content.trim().is_empty() {
+        return;
+    }
+
+    let content = truncate_content(content);
+    let cleaned = strip_html_comments(&content);
+
+    files.push(InstructionFile {
+        scope: "managed".to_string(),
+        path: canonical,
+        content: cleaned,
+        source: InstructionSource::Managed,
+        path_globs: None,
+        included_from: None,
+    });
+}
+
+/// Compute scope label for a directory relative to working_dir.
+fn compute_scope(dir: &Path, working_dir: &Path) -> String {
+    if dir == working_dir || dir.starts_with(working_dir) {
         "project".to_string()
     } else if dir.to_string_lossy().contains(".opendev")
         || dir.to_string_lossy().contains(".config")
@@ -151,13 +395,20 @@ fn try_add_instruction(
         "global".to_string()
     } else {
         "parent".to_string()
-    };
+    }
+}
 
-    files.push(InstructionFile {
-        scope,
-        path: canonical,
-        content,
-    });
+/// Truncate content to MAX_INSTRUCTION_BYTES with a note.
+fn truncate_content(content: String) -> String {
+    if content.len() > MAX_INSTRUCTION_BYTES {
+        let truncated = &content[..MAX_INSTRUCTION_BYTES];
+        format!(
+            "{truncated}\n\n... (truncated, file is {} KB)",
+            content.len() / 1024
+        )
+    } else {
+        content
+    }
 }
 
 /// Resolve config `instructions` entries (file paths, glob patterns, `~/` paths, URLs)
@@ -173,8 +424,8 @@ fn try_add_instruction(
 /// Duplicate files (by canonical path) and duplicate URLs are skipped.
 pub fn resolve_instruction_paths(patterns: &[String], working_dir: &Path) -> Vec<InstructionFile> {
     let mut files = Vec::new();
-    let mut seen = std::collections::HashSet::new();
-    let mut seen_urls = std::collections::HashSet::new();
+    let mut seen = HashSet::new();
+    let mut seen_urls = HashSet::new();
 
     for pattern in patterns {
         // Handle remote URLs.
@@ -233,20 +484,28 @@ pub fn resolve_instruction_paths(patterns: &[String], working_dir: &Path) -> Vec
                 continue;
             }
 
-            let content = if content.len() > MAX_INSTRUCTION_BYTES {
-                let truncated = &content[..MAX_INSTRUCTION_BYTES];
-                format!(
-                    "{truncated}\n\n... (truncated, file is {} KB)",
-                    content.len() / 1024
-                )
-            } else {
-                content
-            };
+            let content = truncate_content(content);
 
+            // Strip HTML comments and process includes
+            let cleaned = strip_html_comments(&content);
+            let include_dir = canonical.parent().unwrap_or(working_dir);
+            let (processed, mut included_files) = process_includes(
+                &cleaned,
+                include_dir,
+                working_dir,
+                0,
+                &mut seen,
+                Some(&canonical),
+            );
+
+            files.append(&mut included_files);
             files.push(InstructionFile {
                 scope: "config".to_string(),
                 path: canonical,
-                content,
+                content: processed,
+                source: InstructionSource::Config,
+                path_globs: None,
+                included_from: None,
             });
         }
     }
@@ -279,19 +538,14 @@ pub(super) fn fetch_remote_instruction(url: &str) -> Option<InstructionFile> {
         return None;
     }
 
-    let content = if content.len() > MAX_INSTRUCTION_BYTES {
-        let truncated = &content[..MAX_INSTRUCTION_BYTES];
-        format!(
-            "{truncated}\n\n... (truncated, remote file is {} KB)",
-            content.len() / 1024
-        )
-    } else {
-        content
-    };
+    let content = truncate_content(content);
 
     Some(InstructionFile {
         scope: "remote".to_string(),
-        path: std::path::PathBuf::from(url),
+        path: PathBuf::from(url),
         content,
+        source: InstructionSource::Remote,
+        path_globs: None,
+        included_from: None,
     })
 }

--- a/crates/opendev-context/src/environment/mod.rs
+++ b/crates/opendev-context/src/environment/mod.rs
@@ -4,12 +4,39 @@
 //! Collects git status, tech stack, and project structure at startup,
 //! then formats it for inclusion in the system prompt.
 
+mod conditional;
+mod exclusions;
+pub(crate) mod frontmatter;
+mod include_parser;
 mod instructions;
 mod project;
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
+pub use conditional::rule_applies;
+pub use exclusions::is_excluded;
+pub use frontmatter::{Frontmatter, parse_frontmatter, strip_html_comments};
+pub use include_parser::process_includes;
 pub use instructions::{discover_instruction_files, resolve_instruction_paths};
+
+/// How an instruction file was loaded.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InstructionSource {
+    /// Found via directory walk (AGENTS.md, CLAUDE.md, etc.).
+    Discovery,
+    /// From settings.json `instructions` array.
+    Config,
+    /// Fetched via HTTP(S) URL.
+    Remote,
+    /// Loaded via @include directive inside another instruction file.
+    Include,
+    /// Enterprise managed instruction (/etc/opendev/).
+    Managed,
+    /// Local override (AGENTS.local.md / CLAUDE.local.md), gitignored.
+    Local,
+    /// From .opendev/rules/*.md directory.
+    Rules,
+}
 
 /// A project instruction file discovered from the hierarchy.
 #[derive(Debug, Clone)]
@@ -20,6 +47,27 @@ pub struct InstructionFile {
     pub path: std::path::PathBuf,
     /// File contents (truncated to 50 KB to avoid prompt bloat).
     pub content: String,
+    /// How this file was loaded.
+    pub source: InstructionSource,
+    /// For conditional rules: glob patterns from frontmatter `paths` field.
+    /// `None` means the rule always applies.
+    pub path_globs: Option<Vec<String>>,
+    /// The parent file that @included this file, if any.
+    pub included_from: Option<PathBuf>,
+}
+
+impl InstructionFile {
+    /// Create a new instruction file with default source fields.
+    pub fn new(scope: impl Into<String>, path: PathBuf, content: String) -> Self {
+        Self {
+            scope: scope.into(),
+            path,
+            content,
+            source: InstructionSource::Discovery,
+            path_globs: None,
+            included_from: None,
+        }
+    }
 }
 
 /// Maximum memory content size to inject (25 KB).
@@ -66,7 +114,18 @@ impl EnvironmentContext {
     /// Collect environment context from the working directory.
     ///
     /// Git commands and directory scanning run in parallel to minimize startup latency.
+    /// `exclude_patterns` filters out instruction files matching any glob pattern.
+    /// `additional_dirs` adds extra directories for instruction discovery.
     pub fn collect(working_dir: &Path) -> Self {
+        Self::collect_with_options(working_dir, &[], &[])
+    }
+
+    /// Collect with instruction filtering options.
+    pub fn collect_with_options(
+        working_dir: &Path,
+        exclude_patterns: &[String],
+        additional_dirs: &[PathBuf],
+    ) -> Self {
         let is_git = working_dir.join(".git").exists();
 
         // Run all git commands and directory scanning in parallel using scoped threads.
@@ -92,7 +151,13 @@ impl EnvironmentContext {
                 let h_remote =
                     s.spawn(|| project::git_cmd(working_dir, &["remote", "get-url", "origin"]));
                 let h_tree = s.spawn(|| project::build_directory_tree(working_dir, 2));
-                let h_instr = s.spawn(|| instructions::discover_instruction_files(working_dir));
+                let h_instr = s.spawn(|| {
+                    instructions::discover_instruction_files(
+                        working_dir,
+                        exclude_patterns,
+                        additional_dirs,
+                    )
+                });
                 let h_memory = s.spawn(|| load_project_memory(working_dir));
 
                 (
@@ -108,7 +173,11 @@ impl EnvironmentContext {
             })
         } else {
             let directory_tree = project::build_directory_tree(working_dir, 2);
-            let instruction_files = instructions::discover_instruction_files(working_dir);
+            let instruction_files = instructions::discover_instruction_files(
+                working_dir,
+                exclude_patterns,
+                additional_dirs,
+            );
             let memory_content = load_project_memory(working_dir);
             (
                 None,
@@ -150,6 +219,14 @@ impl EnvironmentContext {
 
     /// Format the environment context as a system prompt block.
     pub fn format_prompt_block(&self) -> String {
+        self.format_prompt_block_with_context(&[])
+    }
+
+    /// Format the environment context, filtering conditional rules by active files.
+    ///
+    /// Instructions with `path_globs` are only included if at least one active file
+    /// matches their glob patterns. Instructions without `path_globs` are always included.
+    pub fn format_prompt_block_with_context(&self, active_files: &[PathBuf]) -> String {
         let mut sections = Vec::new();
 
         // Environment section
@@ -225,14 +302,23 @@ impl EnvironmentContext {
         }
 
         // Project instructions section
-        if !self.instruction_files.is_empty() {
+        // Filter conditional rules by active files.
+        let working_dir = PathBuf::from(&self.working_dir);
+        let applicable: Vec<_> = self
+            .instruction_files
+            .iter()
+            .filter(|instr| {
+                conditional::rule_applies(instr.path_globs.as_deref(), active_files, &working_dir)
+            })
+            .collect();
+        if !applicable.is_empty() {
             let mut instr_lines = vec!["# Project Instructions".to_string()];
             instr_lines.push(
                 "The following instruction files were found in the project hierarchy. \
                  Follow these instructions when working in this project."
                     .to_string(),
             );
-            for instr in &self.instruction_files {
+            for instr in &applicable {
                 instr_lines.push(String::new());
                 instr_lines.push(format!(
                     "## {} ({})",

--- a/crates/opendev-context/src/environment/tests.rs
+++ b/crates/opendev-context/src/environment/tests.rs
@@ -133,7 +133,7 @@ fn test_discover_agents_md() {
     // Add .git so discovery stops here
     std::fs::create_dir(dir_path.join(".git")).unwrap();
 
-    let files = discover_instruction_files(&dir_path);
+    let files = discover_instruction_files(&dir_path, &[], &[]);
     assert_eq!(files.len(), 1);
     assert_eq!(files[0].scope, "project");
     assert!(files[0].content.contains("Do X."));
@@ -146,7 +146,7 @@ fn test_discover_claude_md() {
     std::fs::write(dir_path.join("CLAUDE.md"), "# Claude\nBe helpful.").unwrap();
     std::fs::create_dir(dir_path.join(".git")).unwrap();
 
-    let files = discover_instruction_files(&dir_path);
+    let files = discover_instruction_files(&dir_path, &[], &[]);
     assert_eq!(files.len(), 1);
     assert!(files[0].content.contains("Be helpful."));
 }
@@ -163,7 +163,7 @@ fn test_discover_opendev_instructions() {
     .unwrap();
     std::fs::create_dir(dir_path.join(".git")).unwrap();
 
-    let files = discover_instruction_files(&dir_path);
+    let files = discover_instruction_files(&dir_path, &[], &[]);
     assert_eq!(files.len(), 1);
     assert!(files[0].content.contains("Custom instructions"));
 }
@@ -176,7 +176,7 @@ fn test_discover_multiple_instruction_files() {
     std::fs::write(dir_path.join("CLAUDE.md"), "claude").unwrap();
     std::fs::create_dir(dir_path.join(".git")).unwrap();
 
-    let files = discover_instruction_files(&dir_path);
+    let files = discover_instruction_files(&dir_path, &[], &[]);
     assert_eq!(files.len(), 2);
 }
 
@@ -191,7 +191,7 @@ fn test_discover_walks_up_to_git_root() {
     let child = dir_path.join("sub");
     std::fs::create_dir(&child).unwrap();
 
-    let files = discover_instruction_files(&child);
+    let files = discover_instruction_files(&child, &[], &[]);
     assert_eq!(files.len(), 1);
     assert_eq!(files[0].scope, "parent");
     assert!(files[0].content.contains("parent rules"));
@@ -204,7 +204,7 @@ fn test_discover_empty_file_skipped() {
     std::fs::write(dir_path.join("AGENTS.md"), "  \n  ").unwrap();
     std::fs::create_dir(dir_path.join(".git")).unwrap();
 
-    let files = discover_instruction_files(&dir_path);
+    let files = discover_instruction_files(&dir_path, &[], &[]);
     assert!(files.is_empty());
 }
 
@@ -216,7 +216,7 @@ fn test_discover_no_duplicates() {
     // No .git, so it would walk up — but the same file shouldn't appear twice
     std::fs::create_dir(dir_path.join(".git")).unwrap();
 
-    let files = discover_instruction_files(&dir_path);
+    let files = discover_instruction_files(&dir_path, &[], &[]);
     assert_eq!(files.len(), 1);
 }
 
@@ -232,7 +232,7 @@ fn test_claude_instructions_dir_not_loaded() {
     .unwrap();
     std::fs::create_dir(dir_path.join(".git")).unwrap();
 
-    let files = discover_instruction_files(&dir_path);
+    let files = discover_instruction_files(&dir_path, &[], &[]);
     // .claude/instructions.md should not be loaded
     assert_eq!(files.len(), 0);
 }
@@ -247,7 +247,7 @@ fn test_only_opendev_instructions_loaded() {
     std::fs::write(dir_path.join(".claude/instructions.md"), "Claude rules").unwrap();
     std::fs::create_dir(dir_path.join(".git")).unwrap();
 
-    let files = discover_instruction_files(&dir_path);
+    let files = discover_instruction_files(&dir_path, &[], &[]);
     assert_eq!(files.len(), 1);
     assert!(files[0].content.contains("OpenDev rules"));
 }
@@ -257,11 +257,11 @@ fn test_instruction_in_prompt_block() {
     let ctx = EnvironmentContext {
         platform: "test".to_string(),
         current_date: "2026-03-15".to_string(),
-        instruction_files: vec![InstructionFile {
-            scope: "project".to_string(),
-            path: std::path::PathBuf::from("/project/AGENTS.md"),
-            content: "# Build rules\nRun cargo test.".to_string(),
-        }],
+        instruction_files: vec![InstructionFile::new(
+            "project",
+            std::path::PathBuf::from("/project/AGENTS.md"),
+            "# Build rules\nRun cargo test.".to_string(),
+        )],
         ..Default::default()
     };
 
@@ -400,11 +400,11 @@ fn test_remote_instruction_scope_is_remote() {
     // Verify that if we had a successful fetch, the scope would be "remote".
     // We can't easily test a real URL in unit tests, but we test the function contract:
     // scope for remote files is "remote", path is the URL.
-    let file = InstructionFile {
-        scope: "remote".to_string(),
-        path: std::path::PathBuf::from("https://example.com/rules.md"),
-        content: "test content".to_string(),
-    };
+    let file = InstructionFile::new(
+        "remote",
+        std::path::PathBuf::from("https://example.com/rules.md"),
+        "test content".to_string(),
+    );
     assert_eq!(file.scope, "remote");
     assert_eq!(file.path.to_string_lossy(), "https://example.com/rules.md");
 }
@@ -420,7 +420,7 @@ fn test_discover_cursorrules() {
     // Create .cursorrules file
     std::fs::write(dir_path.join(".cursorrules"), "Use strict TypeScript").unwrap();
 
-    let files = discover_instruction_files(&dir_path);
+    let files = discover_instruction_files(&dir_path, &[], &[]);
     assert!(
         files
             .iter()
@@ -448,7 +448,7 @@ fn test_discover_copilot_instructions() {
     )
     .unwrap();
 
-    let files = discover_instruction_files(&dir_path);
+    let files = discover_instruction_files(&dir_path, &[], &[]);
     assert!(
         files
             .iter()
@@ -472,7 +472,7 @@ fn test_discover_cursor_rules_directory() {
     // Non-rule file should be ignored
     std::fs::write(rules_dir.join("README"), "Ignore this").unwrap();
 
-    let files = discover_instruction_files(&dir_path);
+    let files = discover_instruction_files(&dir_path, &[], &[]);
     assert!(
         files.iter().any(|f| f.content.contains("validate input")),
         "Should discover .cursor/rules/security.md"
@@ -481,4 +481,199 @@ fn test_discover_cursor_rules_directory() {
         files.iter().any(|f| f.content.contains("4-space")),
         "Should discover .cursor/rules/style.md"
     );
+}
+
+// --- New features ---
+
+#[test]
+fn test_discover_opendev_rules_directory() {
+    let dir = TempDir::new().unwrap();
+    let dir_path = dir.path().canonicalize().unwrap();
+    std::fs::create_dir(dir_path.join(".git")).unwrap();
+
+    let rules_dir = dir_path.join(".opendev").join("rules");
+    std::fs::create_dir_all(&rules_dir).unwrap();
+    std::fs::write(rules_dir.join("rust.md"), "Use snake_case").unwrap();
+    std::fs::write(rules_dir.join("testing.md"), "Write unit tests").unwrap();
+
+    let files = discover_instruction_files(&dir_path, &[], &[]);
+    assert!(
+        files.iter().any(|f| f.content.contains("snake_case")),
+        "Should discover .opendev/rules/rust.md"
+    );
+    assert!(
+        files.iter().any(|f| f.content.contains("unit tests")),
+        "Should discover .opendev/rules/testing.md"
+    );
+}
+
+#[test]
+fn test_discover_opendev_rules_with_frontmatter() {
+    let dir = TempDir::new().unwrap();
+    let dir_path = dir.path().canonicalize().unwrap();
+    std::fs::create_dir(dir_path.join(".git")).unwrap();
+
+    let rules_dir = dir_path.join(".opendev").join("rules");
+    std::fs::create_dir_all(&rules_dir).unwrap();
+    std::fs::write(
+        rules_dir.join("rust.md"),
+        "---\npaths:\n  - \"src/**/*.rs\"\n---\nUse snake_case",
+    )
+    .unwrap();
+
+    let files = discover_instruction_files(&dir_path, &[], &[]);
+    let rust_rule = files.iter().find(|f| f.content.contains("snake_case"));
+    assert!(rust_rule.is_some());
+    let rust_rule = rust_rule.unwrap();
+    assert!(rust_rule.path_globs.is_some());
+    assert_eq!(rust_rule.path_globs.as_ref().unwrap()[0], "src/**/*.rs");
+    assert_eq!(rust_rule.source, InstructionSource::Rules);
+}
+
+#[test]
+fn test_discover_local_overrides() {
+    let dir = TempDir::new().unwrap();
+    let dir_path = dir.path().canonicalize().unwrap();
+    std::fs::create_dir(dir_path.join(".git")).unwrap();
+
+    std::fs::write(dir_path.join("AGENTS.md"), "shared rules").unwrap();
+    std::fs::write(dir_path.join("AGENTS.local.md"), "my local overrides").unwrap();
+
+    let files = discover_instruction_files(&dir_path, &[], &[]);
+    assert!(
+        files.iter().any(|f| f.content.contains("shared rules")),
+        "Should discover AGENTS.md"
+    );
+    assert!(
+        files
+            .iter()
+            .any(|f| f.content.contains("my local overrides")),
+        "Should discover AGENTS.local.md"
+    );
+    let local = files
+        .iter()
+        .find(|f| f.content.contains("my local overrides"))
+        .unwrap();
+    assert_eq!(local.scope, "local");
+    assert_eq!(local.source, InstructionSource::Local);
+}
+
+#[test]
+fn test_discover_with_exclusion() {
+    let dir = TempDir::new().unwrap();
+    let dir_path = dir.path().canonicalize().unwrap();
+    std::fs::create_dir(dir_path.join(".git")).unwrap();
+
+    std::fs::write(dir_path.join("AGENTS.md"), "included").unwrap();
+    std::fs::write(dir_path.join("CLAUDE.md"), "excluded").unwrap();
+
+    let files = discover_instruction_files(&dir_path, &["CLAUDE.md".to_string()], &[]);
+    assert!(files.iter().any(|f| f.content.contains("included")));
+    assert!(
+        !files.iter().any(|f| f.content.contains("excluded")),
+        "CLAUDE.md should be excluded"
+    );
+}
+
+#[test]
+fn test_discover_additional_dirs() {
+    let dir1 = TempDir::new().unwrap();
+    let dir1_path = dir1.path().canonicalize().unwrap();
+    std::fs::create_dir(dir1_path.join(".git")).unwrap();
+    std::fs::write(dir1_path.join("AGENTS.md"), "dir1 rules").unwrap();
+
+    let dir2 = TempDir::new().unwrap();
+    let dir2_path = dir2.path().canonicalize().unwrap();
+    std::fs::create_dir(dir2_path.join(".git")).unwrap();
+    std::fs::write(dir2_path.join("AGENTS.md"), "dir2 rules").unwrap();
+
+    let files = discover_instruction_files(&dir1_path, &[], &[dir2_path]);
+    assert!(files.iter().any(|f| f.content.contains("dir1 rules")));
+    assert!(files.iter().any(|f| f.content.contains("dir2 rules")));
+}
+
+#[test]
+fn test_html_comments_stripped_from_discovered_files() {
+    let dir = TempDir::new().unwrap();
+    let dir_path = dir.path().canonicalize().unwrap();
+    std::fs::create_dir(dir_path.join(".git")).unwrap();
+
+    std::fs::write(
+        dir_path.join("AGENTS.md"),
+        "Visible content\n<!-- Hidden comment -->\nMore visible",
+    )
+    .unwrap();
+
+    let files = discover_instruction_files(&dir_path, &[], &[]);
+    assert_eq!(files.len(), 1);
+    assert!(files[0].content.contains("Visible content"));
+    assert!(files[0].content.contains("More visible"));
+    assert!(!files[0].content.contains("Hidden comment"));
+}
+
+#[test]
+fn test_includes_processed_in_discovered_files() {
+    let dir = TempDir::new().unwrap();
+    let dir_path = dir.path().canonicalize().unwrap();
+    std::fs::create_dir(dir_path.join(".git")).unwrap();
+
+    std::fs::write(dir_path.join("shared.md"), "Shared rules").unwrap();
+    std::fs::write(
+        dir_path.join("AGENTS.md"),
+        "@./shared.md\nMain agents rules",
+    )
+    .unwrap();
+
+    let files = discover_instruction_files(&dir_path, &[], &[]);
+    // Should have both the included file and the AGENTS.md
+    assert!(files.iter().any(|f| f.content.contains("Shared rules")));
+    assert!(
+        files
+            .iter()
+            .any(|f| f.content.contains("Main agents rules"))
+    );
+}
+
+#[test]
+fn test_conditional_rules_filtered_in_prompt() {
+    let dir = TempDir::new().unwrap();
+    let dir_path = dir.path().canonicalize().unwrap();
+
+    let ctx = EnvironmentContext {
+        working_dir: dir_path.display().to_string(),
+        platform: "test".to_string(),
+        current_date: "2026-04-09".to_string(),
+        instruction_files: vec![
+            InstructionFile {
+                scope: "project".to_string(),
+                path: std::path::PathBuf::from("unconditional.md"),
+                content: "Always shown".to_string(),
+                source: InstructionSource::Rules,
+                path_globs: None,
+                included_from: None,
+            },
+            InstructionFile {
+                scope: "project".to_string(),
+                path: std::path::PathBuf::from("rust-only.md"),
+                content: "Rust rules".to_string(),
+                source: InstructionSource::Rules,
+                path_globs: Some(vec!["**/*.rs".to_string()]),
+                included_from: None,
+            },
+        ],
+        ..Default::default()
+    };
+
+    // Without active files, conditional rule should be excluded
+    let block = ctx.format_prompt_block_with_context(&[]);
+    assert!(block.contains("Always shown"));
+    assert!(!block.contains("Rust rules"));
+
+    // With matching active file, conditional rule should be included
+    let rust_file = dir_path.join("src/main.rs");
+    std::fs::create_dir_all(rust_file.parent().unwrap()).unwrap();
+    std::fs::write(&rust_file, "fn main() {}").unwrap();
+    let block = ctx.format_prompt_block_with_context(&[rust_file]);
+    assert!(block.contains("Always shown"));
+    assert!(block.contains("Rust rules"));
 }

--- a/crates/opendev-context/src/lib.rs
+++ b/crates/opendev-context/src/lib.rs
@@ -21,7 +21,9 @@ pub use compaction::{
 };
 pub use context_picker::{AssembledContext, ContextCategory, ContextPiece, ContextReason};
 pub use environment::{
-    EnvironmentContext, InstructionFile, discover_instruction_files, resolve_instruction_paths,
+    EnvironmentContext, Frontmatter, InstructionFile, InstructionSource,
+    discover_instruction_files, is_excluded, parse_frontmatter, process_includes,
+    resolve_instruction_paths, rule_applies, strip_html_comments,
 };
 pub use pair_validator::{MessagePairValidator, ValidationResult, ViolationType};
 pub use retrieval::{

--- a/crates/opendev-context/src/subdir_instructions.rs
+++ b/crates/opendev-context/src/subdir_instructions.rs
@@ -11,6 +11,8 @@ use std::path::{Path, PathBuf};
 
 use tracing::debug;
 
+use crate::environment::frontmatter::{parse_frontmatter, strip_html_comments};
+
 /// Recognized instruction file names (same order as environment.rs).
 const INSTRUCTION_FILENAMES: &[&str] = &["AGENTS.md", "CLAUDE.md", "CONTEXT.md"];
 
@@ -40,6 +42,8 @@ pub struct SubdirInstruction {
     pub relative_path: String,
     /// File contents.
     pub content: String,
+    /// For conditional rules: glob patterns from frontmatter `paths` field.
+    pub path_globs: Option<Vec<String>>,
 }
 
 impl SubdirInstructionTracker {
@@ -84,94 +88,32 @@ impl SubdirInstructionTracker {
             // Check each instruction filename in this directory
             for filename in INSTRUCTION_FILENAMES {
                 let candidate = current.join(filename);
-                if let Ok(canonical) = candidate.canonicalize() {
-                    if self.injected.contains(&canonical) {
-                        continue; // Already injected
-                    }
-
-                    // Read the file
-                    if let Ok(content) = std::fs::read_to_string(&canonical) {
-                        let content = if content.len() > MAX_INSTRUCTION_SIZE {
-                            content[..MAX_INSTRUCTION_SIZE].to_string()
-                        } else {
-                            content
-                        };
-
-                        let relative = canonical
-                            .strip_prefix(&canonical_root)
-                            .unwrap_or(&canonical)
-                            .display()
-                            .to_string();
-
-                        debug!(path = %relative, "Injecting subdirectory instruction file");
-
-                        self.injected.insert(canonical.clone());
-                        results.push(SubdirInstruction {
-                            path: canonical,
-                            relative_path: relative,
-                            content,
-                        });
-                    }
-                }
+                self.try_inject(&candidate, &canonical_root, &mut results, None);
             }
 
             // Also check .opendev/instructions.md
-            for subdir in &[".opendev"] {
-                let candidate = current.join(subdir).join("instructions.md");
-                if let Ok(canonical) = candidate.canonicalize() {
-                    if self.injected.contains(&canonical) {
-                        continue;
-                    }
-                    if let Ok(content) = std::fs::read_to_string(&canonical) {
-                        let content = if content.len() > MAX_INSTRUCTION_SIZE {
-                            content[..MAX_INSTRUCTION_SIZE].to_string()
-                        } else {
-                            content
-                        };
-                        let relative = canonical
-                            .strip_prefix(&canonical_root)
-                            .unwrap_or(&canonical)
-                            .display()
-                            .to_string();
-                        debug!(path = %relative, "Injecting subdirectory instruction file");
-                        self.injected.insert(canonical.clone());
-                        results.push(SubdirInstruction {
-                            path: canonical,
-                            relative_path: relative,
-                            content,
-                        });
-                    }
-                }
-            }
+            let opendev_instr = current.join(".opendev").join("instructions.md");
+            self.try_inject(&opendev_instr, &canonical_root, &mut results, None);
+
+            // Check .opendev/rules/ directory
+            self.discover_rules_in_dir(
+                &current.join(".opendev").join("rules"),
+                &canonical_root,
+                &mut results,
+            );
 
             // Check compatibility instruction files (.cursorrules, copilot, etc.)
             for compat_path in COMPAT_INSTRUCTION_FILES {
                 let candidate = current.join(compat_path);
-                if let Ok(canonical) = candidate.canonicalize() {
-                    if self.injected.contains(&canonical) {
-                        continue;
-                    }
-                    if let Ok(content) = std::fs::read_to_string(&canonical) {
-                        let content = if content.len() > MAX_INSTRUCTION_SIZE {
-                            content[..MAX_INSTRUCTION_SIZE].to_string()
-                        } else {
-                            content
-                        };
-                        let relative = canonical
-                            .strip_prefix(&canonical_root)
-                            .unwrap_or(&canonical)
-                            .display()
-                            .to_string();
-                        debug!(path = %relative, "Injecting compatibility instruction file");
-                        self.injected.insert(canonical.clone());
-                        results.push(SubdirInstruction {
-                            path: canonical,
-                            relative_path: relative,
-                            content,
-                        });
-                    }
-                }
+                self.try_inject(&candidate, &canonical_root, &mut results, None);
             }
+
+            // Check .cursor/rules/ directory
+            self.discover_rules_in_dir(
+                &current.join(".cursor").join("rules"),
+                &canonical_root,
+                &mut results,
+            );
 
             // Stop at project root
             let canonical_current = current.canonicalize().unwrap_or_else(|_| current.clone());
@@ -186,6 +128,125 @@ impl SubdirInstructionTracker {
         }
 
         results
+    }
+
+    /// Try to inject a single instruction file.
+    fn try_inject(
+        &mut self,
+        candidate: &Path,
+        canonical_root: &Path,
+        results: &mut Vec<SubdirInstruction>,
+        path_globs: Option<Vec<String>>,
+    ) {
+        let Ok(canonical) = candidate.canonicalize() else {
+            return;
+        };
+        if self.injected.contains(&canonical) {
+            return;
+        }
+
+        let Ok(content) = std::fs::read_to_string(&canonical) else {
+            return;
+        };
+
+        let content = if content.len() > MAX_INSTRUCTION_SIZE {
+            content[..MAX_INSTRUCTION_SIZE].to_string()
+        } else {
+            content
+        };
+
+        // Strip HTML comments
+        let content = strip_html_comments(&content);
+
+        let relative = canonical
+            .strip_prefix(canonical_root)
+            .unwrap_or(&canonical)
+            .display()
+            .to_string();
+
+        debug!(path = %relative, "Injecting subdirectory instruction file");
+
+        self.injected.insert(canonical.clone());
+        results.push(SubdirInstruction {
+            path: canonical,
+            relative_path: relative,
+            content,
+            path_globs,
+        });
+    }
+
+    /// Discover rule files in a rules directory (.opendev/rules/ or .cursor/rules/).
+    fn discover_rules_in_dir(
+        &mut self,
+        rules_dir: &Path,
+        canonical_root: &Path,
+        results: &mut Vec<SubdirInstruction>,
+    ) {
+        if !rules_dir.is_dir() {
+            return;
+        }
+        let Ok(entries) = std::fs::read_dir(rules_dir) else {
+            return;
+        };
+
+        let mut rule_files: Vec<_> = entries
+            .flatten()
+            .filter(|e| {
+                let name = e.file_name();
+                let name_str = name.to_string_lossy();
+                e.file_type().map(|ft| ft.is_file()).unwrap_or(false)
+                    && (name_str.ends_with(".md")
+                        || name_str.ends_with(".txt")
+                        || name_str.ends_with(".mdc"))
+            })
+            .collect();
+        rule_files.sort_by_key(|e| e.file_name());
+
+        for entry in rule_files {
+            let path = entry.path();
+            let Ok(canonical) = path.canonicalize() else {
+                continue;
+            };
+
+            if self.injected.contains(&canonical) {
+                continue;
+            }
+
+            let Ok(content) = std::fs::read_to_string(&canonical) else {
+                continue;
+            };
+            if content.trim().is_empty() {
+                continue;
+            }
+
+            let content = if content.len() > MAX_INSTRUCTION_SIZE {
+                content[..MAX_INSTRUCTION_SIZE].to_string()
+            } else {
+                content
+            };
+
+            // Parse frontmatter for conditional path_globs
+            let (frontmatter, remaining) = parse_frontmatter(&content);
+            let path_globs: Option<Vec<String>> = frontmatter.and_then(|fm| fm.paths);
+
+            let cleaned = strip_html_comments(&remaining);
+
+            let relative = canonical
+                .strip_prefix(canonical_root)
+                .unwrap_or(&canonical)
+                .display()
+                .to_string();
+
+            debug!(path = %relative, "Injecting subdirectory rule file");
+
+            self.injected.insert(canonical.clone());
+            results.push(SubdirInstruction {
+                path: canonical,
+                relative_path: relative,
+                content: cleaned,
+                path_globs,
+            });
+        }
     }
 
     /// After compaction removes middle messages, allow subdirectory instructions

--- a/crates/opendev-context/src/subdir_instructions_tests.rs
+++ b/crates/opendev-context/src/subdir_instructions_tests.rs
@@ -264,3 +264,77 @@ fn test_copilot_instructions_discovered() {
     assert_eq!(results.len(), 1);
     assert!(results[0].content.contains("conventional commits"));
 }
+
+#[test]
+fn test_opendev_rules_directory_discovered() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path().canonicalize().unwrap();
+
+    let rules_dir = root.join(".opendev").join("rules");
+    std::fs::create_dir_all(&rules_dir).unwrap();
+    std::fs::write(rules_dir.join("style.md"), "Use 4 spaces").unwrap();
+
+    let file = root.join("main.rs");
+    std::fs::write(&file, "").unwrap();
+
+    let mut tracker = SubdirInstructionTracker::new(root.clone(), &[]);
+
+    let results = tracker.check_file_read(&file);
+    assert!(
+        results.iter().any(|r| r.content.contains("4 spaces")),
+        "Should discover .opendev/rules/style.md"
+    );
+}
+
+#[test]
+fn test_opendev_rules_with_frontmatter_paths() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path().canonicalize().unwrap();
+
+    let rules_dir = root.join(".opendev").join("rules");
+    std::fs::create_dir_all(&rules_dir).unwrap();
+    std::fs::write(
+        rules_dir.join("rust.md"),
+        "---\npaths:\n  - \"**/*.rs\"\n---\nUse snake_case",
+    )
+    .unwrap();
+
+    let file = root.join("main.rs");
+    std::fs::write(&file, "").unwrap();
+
+    let mut tracker = SubdirInstructionTracker::new(root.clone(), &[]);
+
+    let results = tracker.check_file_read(&file);
+    let rust_rule = results.iter().find(|r| r.content.contains("snake_case"));
+    assert!(rust_rule.is_some());
+    assert!(rust_rule.unwrap().path_globs.is_some());
+    assert_eq!(
+        rust_rule.unwrap().path_globs.as_ref().unwrap()[0],
+        "**/*.rs"
+    );
+}
+
+#[test]
+fn test_html_comments_stripped_in_subdir() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path().canonicalize().unwrap();
+
+    let subdir = root.join("src");
+    std::fs::create_dir_all(&subdir).unwrap();
+    std::fs::write(
+        subdir.join("AGENTS.md"),
+        "Visible\n<!-- hidden -->\nAlso visible",
+    )
+    .unwrap();
+
+    let file = subdir.join("main.rs");
+    std::fs::write(&file, "").unwrap();
+
+    let mut tracker = SubdirInstructionTracker::new(root.clone(), &[]);
+
+    let results = tracker.check_file_read(&file);
+    assert_eq!(results.len(), 1);
+    assert!(results[0].content.contains("Visible"));
+    assert!(results[0].content.contains("Also visible"));
+    assert!(!results[0].content.contains("hidden"));
+}

--- a/crates/opendev-models/src/config/mod.rs
+++ b/crates/opendev-models/src/config/mod.rs
@@ -170,6 +170,10 @@ pub struct AppConfig {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub instructions: Vec<String>,
 
+    // Glob patterns for instruction files to exclude from discovery
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub instruction_excludes: Vec<String>,
+
     // Additional skill directories -- file paths or `~/` paths
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub skill_paths: Vec<String>,
@@ -280,6 +284,7 @@ impl Default for AppConfig {
             plan_mode_plan_agent_count: 1,
             plan_mode_explore_variant: "enabled".to_string(),
             instructions: Vec::new(),
+            instruction_excludes: Vec::new(),
             skill_paths: Vec::new(),
             skill_urls: Vec::new(),
             default_agent: None,


### PR DESCRIPTION
## Summary
- Add **@include directives** (`@path`, `@./relative`, `@~/home`, `@/absolute`) with 5-level depth limit, circular reference prevention, and text-file-only allowlist
- Add **`.opendev/rules/` directory** support with YAML frontmatter `paths` field for conditional rule application by file glob (great for monorepos)
- Add **local overrides** via `AGENTS.local.md` / `CLAUDE.local.md` (gitignored, highest priority within scope)
- Add **HTML comment stripping** (`<!-- -->` removed outside fenced code blocks, preserved inside)
- Add **instruction exclusion** via `instruction_excludes` config setting with glob patterns (managed `/etc/opendev/` instructions are immune)
- Add **managed/enterprise instructions** from `/etc/opendev/AGENTS.md`
- Add **additional directories** parameter to `discover_instruction_files()`
- Extend `InstructionFile` struct with `source`, `path_globs`, `included_from` fields
- Add `format_prompt_block_with_context()` that filters conditional rules by active files
- Update `SubdirInstructionTracker` to support `.opendev/rules/` and frontmatter
- 4 new modules: `include_parser`, `frontmatter`, `exclusions`, `conditional`
- 51+ new tests across 6 test files

## Test plan
- [x] `cargo test -p opendev-context --lib --tests` — 231 passed, 0 failed
- [x] `cargo test --workspace --lib --tests` — all pass (7 pre-existing grep tool failures unrelated)
- [x] `cargo clippy -p opendev-context -- -D warnings` — zero warnings
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings
- [x] `cargo check --workspace` — compiles clean
- [ ] Manual: create `.opendev/rules/rust.md` with `paths: ["**/*.rs"]` frontmatter, verify conditional loading
- [ ] Manual: create `AGENTS.local.md` with local overrides, verify it loads with scope "local"
- [ ] Manual: create `AGENTS.md` with `@./CONTRIBUTING.md` include, verify both load

🤖 Generated with [Claude Code](https://claude.com/claude-code)