### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability in mcp.json config persistence

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,9 @@
-## 2025-02-26 - [TOCTOU in Sensitive File Creation]
-**Vulnerability:** Time-of-Check to Time-of-Use (TOCTOU) vulnerability where sensitive files (like `auth.json`) were created with default permissions using `std::fs::write` and then restricted using `std::fs::set_permissions(..., 0o600)`. This leaves a brief window where the file is readable by others.
-**Learning:** Post-creation permission modification leaves a race condition window that can be exploited, especially for files storing API keys and credentials.
-**Prevention:** Always use `std::fs::OpenOptions` with `std::os::unix::fs::OpenOptionsExt::mode(0o600)` to securely and atomically create the file with restricted permissions before writing any data to it.
+## 2025-04-09 - TOCTOU vulnerabilities in config persistence
+**Vulnerability:** `mcp.json` (which contains MCP server OAuth config and secrets) was being saved using `std::fs::write`, which could allow malicious local processes to read or overwrite the config briefly before or during writes.
+**Learning:** Security-sensitive files must be written securely using temporary files with restrictive permissions (0o600 on UNIX) via `std::os::unix::fs::OpenOptionsExt`, then atomically renamed. `uuid` should be used for unique tmp files.
+**Prevention:** Always check new occurrences of `std::fs::write` on configuration files or user files containing sensitive configuration. Use the atomic rename pattern with `OpenOptions`.
+
+## 2025-04-09 - TOCTOU vulnerabilities in config persistence
+**Vulnerability:** `mcp.json` (which contains MCP server OAuth config and secrets) was being saved using `std::fs::write`, which could allow malicious local processes to read or overwrite the config briefly before or during writes.
+**Learning:** Security-sensitive files must be written securely using temporary files with restrictive permissions (0o600 on UNIX) via `std::os::unix::fs::OpenOptionsExt`, then atomically renamed.
+**Prevention:** Always check new occurrences of `std::fs::write` on configuration files or user files containing sensitive configuration. Use the atomic rename pattern with `OpenOptions` or `tempfile`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4175,6 +4175,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/opendev-mcp/Cargo.toml
+++ b/crates/opendev-mcp/Cargo.toml
@@ -17,6 +17,7 @@ regex = { workspace = true }
 opendev-models = { workspace = true }
 opendev-config = { workspace = true }
 futures = { workspace = true }
+uuid = { version = "1", features = ["v4", "serde"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/opendev-mcp/src/config.rs
+++ b/crates/opendev-mcp/src/config.rs
@@ -174,17 +174,29 @@ pub fn save_config(config: &McpConfig, config_path: &Path) -> McpResult<()> {
         let mut opts = std::fs::OpenOptions::new();
         opts.write(true).create_new(true).mode(0o600);
         let mut file = opts.open(&tmp_path).map_err(|e| {
-            McpError::Config(format!("Failed to open temp config {}: {}", tmp_path.display(), e))
+            McpError::Config(format!(
+                "Failed to open temp config {}: {}",
+                tmp_path.display(),
+                e
+            ))
         })?;
         std::io::Write::write_all(&mut file, content.as_bytes()).map_err(|e| {
-            McpError::Config(format!("Failed to write temp config {}: {}", tmp_path.display(), e))
+            McpError::Config(format!(
+                "Failed to write temp config {}: {}",
+                tmp_path.display(),
+                e
+            ))
         })?;
     }
 
     #[cfg(not(unix))]
     {
         std::fs::write(&tmp_path, content).map_err(|e| {
-            McpError::Config(format!("Failed to write temp config {}: {}", tmp_path.display(), e))
+            McpError::Config(format!(
+                "Failed to write temp config {}: {}",
+                tmp_path.display(),
+                e
+            ))
         })?;
     }
 

--- a/crates/opendev-mcp/src/config.rs
+++ b/crates/opendev-mcp/src/config.rs
@@ -165,9 +165,32 @@ pub fn save_config(config: &McpConfig, config_path: &Path) -> McpResult<()> {
     }
 
     let content = serde_json::to_string_pretty(config)?;
-    std::fs::write(config_path, content).map_err(|e| {
+
+    let tmp_path = config_path.with_extension(format!("tmp.{}", uuid::Uuid::new_v4()));
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut opts = std::fs::OpenOptions::new();
+        opts.write(true).create_new(true).mode(0o600);
+        let mut file = opts.open(&tmp_path).map_err(|e| {
+            McpError::Config(format!("Failed to open temp config {}: {}", tmp_path.display(), e))
+        })?;
+        std::io::Write::write_all(&mut file, content.as_bytes()).map_err(|e| {
+            McpError::Config(format!("Failed to write temp config {}: {}", tmp_path.display(), e))
+        })?;
+    }
+
+    #[cfg(not(unix))]
+    {
+        std::fs::write(&tmp_path, content).map_err(|e| {
+            McpError::Config(format!("Failed to write temp config {}: {}", tmp_path.display(), e))
+        })?;
+    }
+
+    std::fs::rename(&tmp_path, config_path).map_err(|e| {
         McpError::Config(format!(
-            "Failed to write MCP config to {}: {}",
+            "Failed to rename temp config to {}: {}",
             config_path.display(),
             e
         ))

--- a/crates/opendev-web/Cargo.toml
+++ b/crates/opendev-web/Cargo.toml
@@ -18,7 +18,7 @@ tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }
-uuid = { workspace = true }
+uuid = { version = "1", features = ["v4", "serde"] }
 tracing = { workspace = true }
 thiserror = { workspace = true }
 strum = { workspace = true }

--- a/crates/opendev-web/src/routes/mcp/io.rs
+++ b/crates/opendev-web/src/routes/mcp/io.rs
@@ -80,7 +80,8 @@ pub(super) fn save_server_to_config(
         use std::os::unix::fs::OpenOptionsExt;
         let mut opts = std::fs::OpenOptions::new();
         opts.write(true).create_new(true).mode(0o600);
-        let mut file = opts.open(&tmp_path)
+        let mut file = opts
+            .open(&tmp_path)
             .map_err(|e| WebError::Internal(format!("Failed to open temp config: {}", e)))?;
         std::io::Write::write_all(&mut file, content.as_bytes())
             .map_err(|e| WebError::Internal(format!("Failed to write temp config: {}", e)))?;
@@ -123,7 +124,8 @@ pub(super) fn remove_server_from_config(name: &str, config_path: &Path) -> Resul
             use std::os::unix::fs::OpenOptionsExt;
             let mut opts = std::fs::OpenOptions::new();
             opts.write(true).create_new(true).mode(0o600);
-            let mut file = opts.open(&tmp_path)
+            let mut file = opts
+                .open(&tmp_path)
                 .map_err(|e| WebError::Internal(format!("Failed to open temp config: {}", e)))?;
             std::io::Write::write_all(&mut file, content.as_bytes())
                 .map_err(|e| WebError::Internal(format!("Failed to write temp config: {}", e)))?;

--- a/crates/opendev-web/src/routes/mcp/io.rs
+++ b/crates/opendev-web/src/routes/mcp/io.rs
@@ -73,8 +73,27 @@ pub(super) fn save_server_to_config(
     let content = serde_json::to_string_pretty(&mcp_config)
         .map_err(|e| WebError::Internal(format!("Failed to serialize config: {}", e)))?;
 
-    std::fs::write(config_path, content)
-        .map_err(|e| WebError::Internal(format!("Failed to write config: {}", e)))?;
+    let tmp_path = config_path.with_extension(format!("tmp.{}", uuid::Uuid::new_v4()));
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut opts = std::fs::OpenOptions::new();
+        opts.write(true).create_new(true).mode(0o600);
+        let mut file = opts.open(&tmp_path)
+            .map_err(|e| WebError::Internal(format!("Failed to open temp config: {}", e)))?;
+        std::io::Write::write_all(&mut file, content.as_bytes())
+            .map_err(|e| WebError::Internal(format!("Failed to write temp config: {}", e)))?;
+    }
+
+    #[cfg(not(unix))]
+    {
+        std::fs::write(&tmp_path, content)
+            .map_err(|e| WebError::Internal(format!("Failed to write temp config: {}", e)))?;
+    }
+
+    std::fs::rename(&tmp_path, config_path)
+        .map_err(|e| WebError::Internal(format!("Failed to rename temp config: {}", e)))?;
 
     Ok(())
 }
@@ -96,8 +115,28 @@ pub(super) fn remove_server_from_config(name: &str, config_path: &Path) -> Resul
     if removed {
         let content = serde_json::to_string_pretty(&mcp_config)
             .map_err(|e| WebError::Internal(format!("Failed to serialize config: {}", e)))?;
-        std::fs::write(config_path, content)
-            .map_err(|e| WebError::Internal(format!("Failed to write config: {}", e)))?;
+
+        let tmp_path = config_path.with_extension(format!("tmp.{}", uuid::Uuid::new_v4()));
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            let mut opts = std::fs::OpenOptions::new();
+            opts.write(true).create_new(true).mode(0o600);
+            let mut file = opts.open(&tmp_path)
+                .map_err(|e| WebError::Internal(format!("Failed to open temp config: {}", e)))?;
+            std::io::Write::write_all(&mut file, content.as_bytes())
+                .map_err(|e| WebError::Internal(format!("Failed to write temp config: {}", e)))?;
+        }
+
+        #[cfg(not(unix))]
+        {
+            std::fs::write(&tmp_path, content)
+                .map_err(|e| WebError::Internal(format!("Failed to write temp config: {}", e)))?;
+        }
+
+        std::fs::rename(&tmp_path, config_path)
+            .map_err(|e| WebError::Internal(format!("Failed to rename temp config: {}", e)))?;
     }
 
     Ok(removed)


### PR DESCRIPTION
🛡️ Sentinel: Fix TOCTOU vulnerability in mcp.json config persistence

🚨 **Severity:** HIGH
💡 **Vulnerability:** `mcp.json`, which contains sensitive MCP server OAuth secrets, was being saved using `std::fs::write`. This allowed malicious local processes to read or overwrite the config briefly before or during writes.
🎯 **Impact:** Local privilege escalation or secret exposure if an attacker monitors or modifies `mcp.json` during the write window.
🔧 **Fix:** Used atomic writes with temporary files and restricted 0o600 permissions via `OpenOptionsExt`. Added `uuid` dependency to `opendev-mcp` and `opendev-web` to generate unguessable temporary file names.
✅ **Verification:** Ran `cargo test --workspace` and `cargo clippy --workspace` and verified atomic write logic in tests.

---
*PR created automatically by Jules for task [9362990276204362814](https://jules.google.com/task/9362990276204362814) started by @bdqnghi*