### PR TITLE
🛡️ Sentinel: [MEDIUM] Secure MCP config file permissions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Time-of-Check to Time-of-Use (TOCTOU) vulnerability where sensitive files (like `auth.json`) were created with default permissions using `std::fs::write` and then restricted using `std::fs::set_permissions(..., 0o600)`. This leaves a brief window where the file is readable by others.
 **Learning:** Post-creation permission modification leaves a race condition window that can be exploited, especially for files storing API keys and credentials.
 **Prevention:** Always use `std::fs::OpenOptions` with `std::os::unix::fs::OpenOptionsExt::mode(0o600)` to securely and atomically create the file with restricted permissions before writing any data to it.
+
+## 2024-05-30 - [Secure Config File Permissions]
+**Vulnerability:** Configuration files (`mcp.json`) which contain sensitive settings like API keys and system environment variables, were being written using `std::fs::write` directly. This creates a file with default permissions, which allows other users to read sensitive credentials.
+**Learning:** Directly writing to file paths for security configurations results in insecure default permissions. To prevent TOCTOU vulnerabilities and securely save credentials, we need to apply atomic writes alongside tightly restricted file permissions (`0o600`).
+**Prevention:** In Rust environments, instead of utilizing standard `std::fs::write`, write configuration data securely to a temporary file via `.create_new(true)` with `.mode(0o600)` permissions via `std::os::unix::fs::OpenOptionsExt` (on Unix systems) and then apply `std::fs::rename` to move the temporary file exactly into place without a TOCTOU vulnerable window.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4176,6 +4176,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/opendev-mcp/Cargo.toml
+++ b/crates/opendev-mcp/Cargo.toml
@@ -15,6 +15,7 @@ async-trait = { workspace = true }
 reqwest = { workspace = true }
 regex = { workspace = true }
 opendev-models = { workspace = true }
+uuid = { workspace = true }
 opendev-config = { workspace = true }
 futures = { workspace = true }
 

--- a/crates/opendev-mcp/src/config.rs
+++ b/crates/opendev-mcp/src/config.rs
@@ -165,7 +165,50 @@ pub fn save_config(config: &McpConfig, config_path: &Path) -> McpResult<()> {
     }
 
     let content = serde_json::to_string_pretty(config)?;
-    std::fs::write(config_path, content).map_err(|e| {
+
+    // Atomic write: write to .tmp then rename, enforcing strict permissions
+    let tmp_path = config_path.with_extension(format!("{}.json.tmp", uuid::Uuid::new_v4()));
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut opts = std::fs::OpenOptions::new();
+        opts.write(true).create_new(true).mode(0o600);
+
+        let mut file = opts.open(&tmp_path).map_err(|e| {
+            McpError::Config(format!(
+                "Failed to write MCP config to {}: {}",
+                tmp_path.display(),
+                e
+            ))
+        })?;
+        std::io::Write::write_all(&mut file, content.as_bytes()).map_err(|e| {
+            McpError::Config(format!(
+                "Failed to write MCP config to {}: {}",
+                tmp_path.display(),
+                e
+            ))
+        })?;
+        file.sync_all().map_err(|e| {
+            McpError::Config(format!(
+                "Failed to sync MCP config to {}: {}",
+                tmp_path.display(),
+                e
+            ))
+        })?;
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::write(&tmp_path, &content).map_err(|e| {
+            McpError::Config(format!(
+                "Failed to write MCP config to {}: {}",
+                tmp_path.display(),
+                e
+            ))
+        })?;
+    }
+
+    std::fs::rename(&tmp_path, config_path).map_err(|e| {
         McpError::Config(format!(
             "Failed to write MCP config to {}: {}",
             config_path.display(),

--- a/crates/opendev-web/src/routes/mcp/io.rs
+++ b/crates/opendev-web/src/routes/mcp/io.rs
@@ -73,7 +73,29 @@ pub(super) fn save_server_to_config(
     let content = serde_json::to_string_pretty(&mcp_config)
         .map_err(|e| WebError::Internal(format!("Failed to serialize config: {}", e)))?;
 
-    std::fs::write(config_path, content)
+    let tmp_path = config_path.with_extension(format!("{}.json.tmp", uuid::Uuid::new_v4()));
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut opts = std::fs::OpenOptions::new();
+        opts.write(true).create_new(true).mode(0o600);
+
+        let mut file = opts
+            .open(&tmp_path)
+            .map_err(|e| WebError::Internal(format!("Failed to write config: {}", e)))?;
+        std::io::Write::write_all(&mut file, content.as_bytes())
+            .map_err(|e| WebError::Internal(format!("Failed to write config: {}", e)))?;
+        file.sync_all()
+            .map_err(|e| WebError::Internal(format!("Failed to sync config: {}", e)))?;
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::write(&tmp_path, &content)
+            .map_err(|e| WebError::Internal(format!("Failed to write config: {}", e)))?;
+    }
+
+    std::fs::rename(&tmp_path, config_path)
         .map_err(|e| WebError::Internal(format!("Failed to write config: {}", e)))?;
 
     Ok(())
@@ -96,7 +118,30 @@ pub(super) fn remove_server_from_config(name: &str, config_path: &Path) -> Resul
     if removed {
         let content = serde_json::to_string_pretty(&mcp_config)
             .map_err(|e| WebError::Internal(format!("Failed to serialize config: {}", e)))?;
-        std::fs::write(config_path, content)
+
+        let tmp_path = config_path.with_extension(format!("{}.json.tmp", uuid::Uuid::new_v4()));
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            let mut opts = std::fs::OpenOptions::new();
+            opts.write(true).create_new(true).mode(0o600);
+
+            let mut file = opts
+                .open(&tmp_path)
+                .map_err(|e| WebError::Internal(format!("Failed to write config: {}", e)))?;
+            std::io::Write::write_all(&mut file, content.as_bytes())
+                .map_err(|e| WebError::Internal(format!("Failed to write config: {}", e)))?;
+            file.sync_all()
+                .map_err(|e| WebError::Internal(format!("Failed to sync config: {}", e)))?;
+        }
+        #[cfg(not(unix))]
+        {
+            std::fs::write(&tmp_path, &content)
+                .map_err(|e| WebError::Internal(format!("Failed to write config: {}", e)))?;
+        }
+
+        std::fs::rename(&tmp_path, config_path)
             .map_err(|e| WebError::Internal(format!("Failed to write config: {}", e)))?;
     }
 


### PR DESCRIPTION
Superseded. MCP config secure atomic write already on main via earlier merges.