### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TOCTOU vulnerability when saving sensitive MCP configuration files

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Time-of-Check to Time-of-Use (TOCTOU) vulnerability where sensitive files (like `auth.json`) were created with default permissions using `std::fs::write` and then restricted using `std::fs::set_permissions(..., 0o600)`. This leaves a brief window where the file is readable by others.
 **Learning:** Post-creation permission modification leaves a race condition window that can be exploited, especially for files storing API keys and credentials.
 **Prevention:** Always use `std::fs::OpenOptions` with `std::os::unix::fs::OpenOptionsExt::mode(0o600)` to securely and atomically create the file with restricted permissions before writing any data to it.
+
+## 2025-02-18 - Enforce Secure File Permissions via Atomic Writes for Configuration Files
+**Vulnerability:** Configuration files containing sensitive data (like MCP OAuth client secrets or access tokens) were written using `std::fs::write` or non-atomic serialization. This creates a Time-of-Check to Time-of-Use (TOCTOU) race condition and defaults to standard user permissions, potentially allowing unauthorized read access on multi-user systems.
+**Learning:** Directly modifying permissions after writing a file still leaves a short window where a local attacker can read or modify the file.
+**Prevention:** Always write sensitive files using an atomic pattern: create a temporary file using `std::fs::OpenOptions` with `.create(true).write(true).truncate(true).mode(0o600)` (on Unix via `std::os::unix::fs::OpenOptionsExt`), write the contents, and then use `std::fs::rename` to atomically replace the destination file.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4177,6 +4177,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/opendev-mcp/Cargo.toml
+++ b/crates/opendev-mcp/Cargo.toml
@@ -17,6 +17,7 @@ regex = { workspace = true }
 opendev-models = { workspace = true }
 opendev-config = { workspace = true }
 futures = { workspace = true }
+uuid = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/opendev-mcp/src/config.rs
+++ b/crates/opendev-mcp/src/config.rs
@@ -165,9 +165,47 @@ pub fn save_config(config: &McpConfig, config_path: &Path) -> McpResult<()> {
     }
 
     let content = serde_json::to_string_pretty(config)?;
-    std::fs::write(config_path, content).map_err(|e| {
+
+    // Use atomic write pattern to prevent TOCTOU and secure the file.
+    let tmp_path = config_path.with_extension(format!("tmp.{}", uuid::Uuid::new_v4()));
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut opts = std::fs::OpenOptions::new();
+        opts.write(true).create(true).truncate(true).mode(0o600);
+        std::io::Write::write_all(
+            &mut opts.open(&tmp_path).map_err(|e| {
+                McpError::Config(format!(
+                    "Failed to open temp config file {}: {}",
+                    tmp_path.display(),
+                    e
+                ))
+            })?,
+            content.as_bytes(),
+        )
+        .map_err(|e| {
+            McpError::Config(format!(
+                "Failed to write to temp config file {}: {}",
+                tmp_path.display(),
+                e
+            ))
+        })?;
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::write(&tmp_path, content).map_err(|e| {
+            McpError::Config(format!(
+                "Failed to write temp config to {}: {}",
+                tmp_path.display(),
+                e
+            ))
+        })?;
+    }
+
+    std::fs::rename(&tmp_path, config_path).map_err(|e| {
         McpError::Config(format!(
-            "Failed to write MCP config to {}: {}",
+            "Failed to rename temp config to {}: {}",
             config_path.display(),
             e
         ))

--- a/crates/opendev-web/src/routes/mcp/io.rs
+++ b/crates/opendev-web/src/routes/mcp/io.rs
@@ -73,8 +73,56 @@ pub(super) fn save_server_to_config(
     let content = serde_json::to_string_pretty(&mcp_config)
         .map_err(|e| WebError::Internal(format!("Failed to serialize config: {}", e)))?;
 
-    std::fs::write(config_path, content)
-        .map_err(|e| WebError::Internal(format!("Failed to write config: {}", e)))?;
+    atomic_write_config(config_path, &content)?;
+
+    Ok(())
+}
+
+/// Helper function to atomically write a config file with secure permissions.
+fn atomic_write_config(config_path: &Path, content: &str) -> Result<(), WebError> {
+    let tmp_path = config_path.with_extension(format!("tmp.{}", uuid::Uuid::new_v4()));
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut opts = std::fs::OpenOptions::new();
+        opts.write(true).create(true).truncate(true).mode(0o600);
+        std::io::Write::write_all(
+            &mut opts.open(&tmp_path).map_err(|e| {
+                WebError::Internal(format!(
+                    "Failed to open temp config file {}: {}",
+                    tmp_path.display(),
+                    e
+                ))
+            })?,
+            content.as_bytes(),
+        )
+        .map_err(|e| {
+            WebError::Internal(format!(
+                "Failed to write to temp config file {}: {}",
+                tmp_path.display(),
+                e
+            ))
+        })?;
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::write(&tmp_path, content).map_err(|e| {
+            WebError::Internal(format!(
+                "Failed to write temp config to {}: {}",
+                tmp_path.display(),
+                e
+            ))
+        })?;
+    }
+
+    std::fs::rename(&tmp_path, config_path).map_err(|e| {
+        WebError::Internal(format!(
+            "Failed to rename temp config to {}: {}",
+            config_path.display(),
+            e
+        ))
+    })?;
 
     Ok(())
 }
@@ -96,8 +144,7 @@ pub(super) fn remove_server_from_config(name: &str, config_path: &Path) -> Resul
     if removed {
         let content = serde_json::to_string_pretty(&mcp_config)
             .map_err(|e| WebError::Internal(format!("Failed to serialize config: {}", e)))?;
-        std::fs::write(config_path, content)
-            .map_err(|e| WebError::Internal(format!("Failed to write config: {}", e)))?;
+        atomic_write_config(config_path, &content)?;
     }
 
     Ok(removed)


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Sensitive MCP configuration files (`mcp.json`), which can contain OAuth `client_secret` tokens, were written to disk using `std::fs::write` with standard permissions.
🎯 Impact: Local attackers or unauthorized users on the same machine could read the configuration files and extract sensitive credentials, leading to potential unauthorized access to connected MCP servers. Furthermore, modifying the file in place opens up a TOCTOU window where an attacker could replace the file before permissions could be manually tightened.
🔧 Fix: Implemented an atomic write pattern in both `crates/opendev-mcp/src/config.rs` and `crates/opendev-web/src/routes/mcp/io.rs`. The code now creates a temporary file using `uuid::Uuid::new_v4()` with strict `0o600` permissions via `OpenOptionsExt::mode`, writes the configuration, and atomically renames the temporary file to the final destination.
✅ Verification: Ran `cargo check`, `cargo fmt`, `cargo clippy`, and `cargo test --workspace --lib --tests`. All tests pass successfully. Also verified the file writing logic uses the correct `std::os::unix::fs::OpenOptionsExt` configuration on Unix platforms.

---
*PR created automatically by Jules for task [6813626368864927946](https://jules.google.com/task/6813626368864927946) started by @bdqnghi*