### PR TITLE
feat(opendev-context): preemptive per-tool result budgeting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Preemptive per-tool result budgeting in `opendev-context::tool_budget`. Tool results exceeding their per-tool character cap are truncated to a preview with a reference path; full content is persisted under `.opendev/tool-results/`. Complements the existing staged compaction by preventing single-turn context spikes from oversized tool outputs (e.g. wide directory listings, large file reads, MCP analysis dumps).
+
 ## [0.1.8] - 2026-04-01
 
 ### Added

--- a/crates/opendev-agents/src/react_loop/loop_state.rs
+++ b/crates/opendev-agents/src/react_loop/loop_state.rs
@@ -60,6 +60,13 @@ pub(super) struct LoopState {
     pub collector_runner: CollectorRunner,
     /// Shared flag set by safety phase after compaction.
     pub compaction_flag: Arc<AtomicBool>,
+
+    /// Per-tool result budget policy. Caps each tool result at append-time
+    /// so a single oversized output cannot push the conversation past
+    /// compaction thresholds in one turn.
+    pub tool_budget_policy: opendev_context::ToolBudgetPolicy,
+    /// On-disk store for content overflowed by `tool_budget_policy`.
+    pub overflow_store: opendev_context::OverflowStore,
 }
 
 impl LoopState {
@@ -106,6 +113,8 @@ impl LoopState {
             activated_tools: HashSet::new(),
             collector_runner: CollectorRunner::new(collectors),
             compaction_flag,
+            tool_budget_policy: opendev_context::ToolBudgetPolicy::default(),
+            overflow_store: opendev_context::OverflowStore::new(working_dir),
             // Note: todo reminders are handled by TodoStateCollector (live data).
             // Only task_proactive_reminder remains here as a static template nudge.
             proactive_reminders: ProactiveReminderScheduler::new(vec![ProactiveReminderConfig {

--- a/crates/opendev-agents/src/react_loop/phases/tool_dispatch.rs
+++ b/crates/opendev-agents/src/react_loop/phases/tool_dispatch.rs
@@ -557,11 +557,26 @@ where
         }
 
         let formatted = ReactLoop::format_tool_result(tool_name, &result_value);
+        let budgeted = opendev_context::apply_tool_result_budget(
+            tool_name,
+            tool_call_id_str,
+            &formatted,
+            &state.tool_budget_policy,
+            &state.overflow_store,
+        );
+        if budgeted.truncated {
+            debug!(
+                tool = tool_name,
+                original_len = budgeted.original_len,
+                overflow_ref = ?budgeted.overflow_ref,
+                "Tool result exceeded budget; truncated with overflow ref",
+            );
+        }
         messages.push(serde_json::json!({
             "role": "tool",
             "tool_call_id": tool_call_id_str,
             "name": tool_name,
-            "content": formatted,
+            "content": budgeted.displayed_content,
         }));
 
         // Track background task spawns for completion nudge.

--- a/crates/opendev-context/src/compaction/mod.rs
+++ b/crates/opendev-context/src/compaction/mod.rs
@@ -52,6 +52,21 @@ pub const SLIDING_WINDOW_THRESHOLD: usize = 500;
 /// Minimum length of tool output before summarization kicks in.
 pub const TOOL_OUTPUT_SUMMARIZE_THRESHOLD: usize = 500;
 
+/// Default per-tool result character budget. Outputs above this are
+/// truncated to a preview and overflow content is persisted to disk.
+/// Roughly ~2K tokens, sized to keep a single tool result from
+/// dominating the typical 80K-token context window.
+pub const TOOL_RESULT_BUDGET_DEFAULT_CHARS: usize = 8_000;
+
+/// Number of leading characters retained in the displayed preview when
+/// a tool result exceeds its budget. Smaller than the cap so the
+/// truncation marker and reference path always fit comfortably.
+pub const TOOL_RESULT_BUDGET_PREVIEW_CHARS: usize = 1_500;
+
+/// Subdirectory under the project's `.opendev/` directory where overflow
+/// tool result content is stored.
+pub const TOOL_RESULT_BUDGET_OVERFLOW_DIR: &str = "tool-results";
+
 /// A message in API format (role + content + optional tool_calls).
 ///
 /// This is a lightweight representation for compaction operations,

--- a/crates/opendev-context/src/lib.rs
+++ b/crates/opendev-context/src/lib.rs
@@ -12,6 +12,7 @@ pub mod environment;
 pub mod pair_validator;
 pub mod retrieval;
 pub mod subdir_instructions;
+pub mod tool_budget;
 pub mod validated_list;
 pub mod worktree;
 
@@ -31,5 +32,6 @@ pub use retrieval::{
     RetrievalContext,
 };
 pub use subdir_instructions::{SubdirInstruction, SubdirInstructionTracker};
+pub use tool_budget::{BudgetedResult, OverflowStore, ToolBudgetPolicy, apply_tool_result_budget};
 pub use validated_list::ValidatedMessageList;
 pub use worktree::{WorktreeInfo, WorktreeManager};

--- a/crates/opendev-context/src/tool_budget/mod.rs
+++ b/crates/opendev-context/src/tool_budget/mod.rs
@@ -1,0 +1,107 @@
+//! Preemptive per-tool result budgeting.
+//!
+//! Complements the staged compaction in [`crate::compaction`]: where
+//! compaction reacts after total context usage crosses thresholds,
+//! budgeting caps each individual tool result at write-time so a
+//! single oversized output cannot push the conversation from 60% to
+//! 95% in one turn.
+//!
+//! Outputs above their per-tool cap are truncated to a short preview
+//! and the full content is persisted via [`OverflowStore`]. The
+//! displayed message ends with a reference path the agent can re-read
+//! on demand.
+
+mod overflow;
+mod policy;
+
+pub use overflow::OverflowStore;
+pub use policy::ToolBudgetPolicy;
+
+use crate::compaction::TOOL_RESULT_BUDGET_PREVIEW_CHARS;
+
+/// Result of applying [`apply_tool_result_budget`] to a tool output.
+#[derive(Debug, Clone)]
+pub struct BudgetedResult {
+    /// Content to embed in the tool message sent to the model. Always
+    /// `<= cap` characters; equals `raw_output` when no truncation
+    /// was needed.
+    pub displayed_content: String,
+    /// Display-form reference path written by the [`OverflowStore`]
+    /// when truncation occurred and persistence succeeded. `None`
+    /// means the content fit within budget OR the overflow write
+    /// failed (in which case `displayed_content` carries a
+    /// truncation marker without a reference).
+    pub overflow_ref: Option<String>,
+    /// Length of the original (pre-truncation) output in characters.
+    pub original_len: usize,
+    /// Whether the output was truncated.
+    pub truncated: bool,
+}
+
+/// Apply the per-tool budget to `raw_output`. Pure transformation —
+/// the only side effect is the optional overflow file write performed
+/// by `overflow_store`. A failed write degrades gracefully: the
+/// returned `displayed_content` is still bounded, just without a
+/// reference path.
+///
+/// `tool_call_id` is used to make overflow filenames unique and to
+/// correlate the on-disk content with the in-conversation tool call.
+pub fn apply_tool_result_budget(
+    tool_name: &str,
+    tool_call_id: &str,
+    raw_output: &str,
+    policy: &ToolBudgetPolicy,
+    overflow_store: &OverflowStore,
+) -> BudgetedResult {
+    let original_len = raw_output.chars().count();
+    let cap = policy.cap_for(tool_name);
+
+    if cap == usize::MAX || char_len_within(raw_output, cap) {
+        return BudgetedResult {
+            displayed_content: raw_output.to_string(),
+            overflow_ref: None,
+            original_len,
+            truncated: false,
+        };
+    }
+
+    let preview_len = TOOL_RESULT_BUDGET_PREVIEW_CHARS.min(cap);
+    let preview = take_chars(raw_output, preview_len);
+    let overflow_ref = overflow_store.write(tool_name, tool_call_id, raw_output);
+
+    let displayed_content = match &overflow_ref {
+        Some(path) => format!(
+            "{preview}\n\n…\n[truncated: {omitted} / {total} chars omitted]\n[full output: {path}]",
+            omitted = original_len.saturating_sub(preview_len),
+            total = original_len,
+        ),
+        None => format!(
+            "{preview}\n\n…\n[truncated: {omitted} / {total} chars omitted]",
+            omitted = original_len.saturating_sub(preview_len),
+            total = original_len,
+        ),
+    };
+
+    BudgetedResult {
+        displayed_content,
+        overflow_ref,
+        original_len,
+        truncated: true,
+    }
+}
+
+/// Counts chars without materializing — bails as soon as the count
+/// exceeds `limit` so we do not walk a 1MB output to learn it is too big.
+fn char_len_within(s: &str, limit: usize) -> bool {
+    s.chars().take(limit + 1).count() <= limit
+}
+
+/// Take the first `n` characters of `s` as an owned `String`. Char-aware
+/// so multi-byte boundaries are never split.
+fn take_chars(s: &str, n: usize) -> String {
+    s.chars().take(n).collect()
+}
+
+#[cfg(test)]
+#[path = "tests.rs"]
+mod tests;

--- a/crates/opendev-context/src/tool_budget/overflow.rs
+++ b/crates/opendev-context/src/tool_budget/overflow.rs
@@ -1,0 +1,106 @@
+//! On-disk store for oversized tool results.
+//!
+//! When a tool result exceeds its budget, the full content is written
+//! to a unique file under the project's overflow directory and the
+//! displayed message references it by relative path.
+
+use std::path::{Path, PathBuf};
+
+use chrono::Local;
+
+use crate::compaction::TOOL_RESULT_BUDGET_OVERFLOW_DIR;
+
+/// Writes overflow tool result content to disk under a project-scoped
+/// directory. Reference paths returned to the LLM are relative to the
+/// project root so they read naturally in transcripts.
+#[derive(Debug, Clone)]
+pub struct OverflowStore {
+    /// Absolute path to the directory where overflow files are written.
+    overflow_dir: PathBuf,
+    /// Project root used to compute relative reference paths.
+    project_root: PathBuf,
+}
+
+impl OverflowStore {
+    /// Construct a store rooted at `project_root`. Overflow files are
+    /// written under `project_root/.opendev/tool-results/`.
+    pub fn new(project_root: impl Into<PathBuf>) -> Self {
+        let project_root = project_root.into();
+        let overflow_dir = project_root
+            .join(".opendev")
+            .join(TOOL_RESULT_BUDGET_OVERFLOW_DIR);
+        Self {
+            overflow_dir,
+            project_root,
+        }
+    }
+
+    /// Construct a store with an explicit overflow directory. Useful in
+    /// tests where the project root and the overflow dir are decoupled.
+    pub fn with_dir(project_root: impl Into<PathBuf>, overflow_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            project_root: project_root.into(),
+            overflow_dir: overflow_dir.into(),
+        }
+    }
+
+    /// Persist `content` to a unique file. Returns a path suitable for
+    /// inclusion in the displayed tool message — relative to the project
+    /// root when possible, absolute otherwise.
+    ///
+    /// On I/O failure returns `None`; callers should fall back to a
+    /// truncation-only display so a disk error never breaks the agent
+    /// loop.
+    pub fn write(&self, tool_name: &str, tool_call_id: &str, content: &str) -> Option<String> {
+        if let Err(err) = std::fs::create_dir_all(&self.overflow_dir) {
+            tracing::warn!(
+                error = %err,
+                dir = %self.overflow_dir.display(),
+                "tool-result overflow: failed to create directory",
+            );
+            return None;
+        }
+
+        let stamp = Local::now().format("%Y-%m-%dT%H-%M-%S");
+        let safe_tool = sanitize_for_filename(tool_name);
+        let safe_id = sanitize_for_filename(tool_call_id);
+        let filename = format!("{stamp}-{safe_tool}-{safe_id}.txt");
+        let abs_path = self.overflow_dir.join(filename);
+
+        if let Err(err) = std::fs::write(&abs_path, content) {
+            tracing::warn!(
+                error = %err,
+                path = %abs_path.display(),
+                "tool-result overflow: failed to write file",
+            );
+            return None;
+        }
+
+        Some(self.display_path(&abs_path))
+    }
+
+    /// Convert an absolute overflow path to the form shown to the LLM.
+    fn display_path(&self, abs_path: &Path) -> String {
+        abs_path
+            .strip_prefix(&self.project_root)
+            .map(|rel| rel.to_string_lossy().into_owned())
+            .unwrap_or_else(|_| abs_path.to_string_lossy().into_owned())
+    }
+}
+
+/// Replace filesystem-unsafe characters with `_`. Keeps filenames short
+/// and predictable across platforms without depending on extra crates.
+fn sanitize_for_filename(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for ch in input.chars().take(64) {
+        if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+            out.push(ch);
+        } else {
+            out.push('_');
+        }
+    }
+    if out.is_empty() {
+        out.push_str("unnamed");
+    }
+    out
+}

--- a/crates/opendev-context/src/tool_budget/policy.rs
+++ b/crates/opendev-context/src/tool_budget/policy.rs
@@ -1,0 +1,87 @@
+//! Per-tool size caps for `apply_tool_result_budget`.
+//!
+//! Conservative caps for known-noisy tools (wide listings, search hits)
+//! and generous caps for tools whose value is in their full content
+//! (file reads). `usize::MAX` opts a tool out of budgeting entirely
+//! (e.g. binary content like screenshots).
+
+use crate::compaction::TOOL_RESULT_BUDGET_DEFAULT_CHARS;
+
+/// Built-in per-tool overrides. Names cover both the snake_case and
+/// PascalCase variants OpenDev's tool registry uses for the same
+/// underlying capability (`read_file` and `Read`, `Bash` and `run_command`,
+/// etc.) so the policy applies symmetrically regardless of caller.
+const TOOL_BUDGET_OVERRIDES: &[(&str, usize)] = &[
+    // File reads: full content is the value.
+    ("read_file", 12_000),
+    ("Read", 12_000),
+    // Search results compress well with truncation.
+    ("Grep", 4_000),
+    ("search", 4_000),
+    ("file_search", 4_000),
+    // Wide directory listings are noisy.
+    ("list_files", 2_000),
+    ("list_directory", 2_000),
+    ("List", 2_000),
+    // Shell output: enough to see the tail but cap runaway logs.
+    ("Bash", 6_000),
+    ("run_command", 6_000),
+    ("bash_execute", 6_000),
+    // Binary / opaque content: do not budget.
+    ("web_screenshot", usize::MAX),
+    ("vlm", usize::MAX),
+];
+
+/// Per-tool character cap policy.
+#[derive(Debug, Clone)]
+pub struct ToolBudgetPolicy {
+    default_chars: usize,
+    overrides: Vec<(String, usize)>,
+}
+
+impl Default for ToolBudgetPolicy {
+    fn default() -> Self {
+        Self {
+            default_chars: TOOL_RESULT_BUDGET_DEFAULT_CHARS,
+            overrides: TOOL_BUDGET_OVERRIDES
+                .iter()
+                .map(|(k, v)| ((*k).to_string(), *v))
+                .collect(),
+        }
+    }
+}
+
+impl ToolBudgetPolicy {
+    /// Construct a policy with the built-in overrides and a custom default.
+    pub fn with_default_chars(default_chars: usize) -> Self {
+        Self {
+            default_chars,
+            ..Self::default()
+        }
+    }
+
+    /// Override the cap for a single tool. Pass `usize::MAX` to opt out.
+    pub fn set_override(&mut self, tool_name: impl Into<String>, cap: usize) {
+        let tool_name = tool_name.into();
+        if let Some(slot) = self.overrides.iter_mut().find(|(k, _)| *k == tool_name) {
+            slot.1 = cap;
+        } else {
+            self.overrides.push((tool_name, cap));
+        }
+    }
+
+    /// Return the character cap that applies to `tool_name`. Falls back
+    /// to the configured default when no override matches.
+    pub fn cap_for(&self, tool_name: &str) -> usize {
+        self.overrides
+            .iter()
+            .find(|(k, _)| k == tool_name)
+            .map(|(_, v)| *v)
+            .unwrap_or(self.default_chars)
+    }
+
+    /// Returns true if `tool_name` is opted out of budgeting (cap == MAX).
+    pub fn is_unbounded(&self, tool_name: &str) -> bool {
+        self.cap_for(tool_name) == usize::MAX
+    }
+}

--- a/crates/opendev-context/src/tool_budget/tests.rs
+++ b/crates/opendev-context/src/tool_budget/tests.rs
@@ -157,3 +157,290 @@ fn preview_size_is_bounded_by_cap() {
     );
     assert!(preview_chars > 0);
 }
+
+// ─── A. Boundary arithmetic ───────────────────────────────────────────────
+
+/// A1: An empty input must pass through cleanly with `truncated=false`,
+/// `original_len=0`, and no overflow ref. Catches off-by-one bugs in
+/// `char_len_within` at the zero boundary.
+#[test]
+fn empty_input_passes_through_with_zero_metadata() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = store_in(tmp.path());
+    let policy = ToolBudgetPolicy::default();
+
+    let result = apply_tool_result_budget("custom_tool", "tc-empty", "", &policy, &store);
+
+    assert!(!result.truncated);
+    assert!(result.overflow_ref.is_none());
+    assert_eq!(result.original_len, 0);
+    assert_eq!(result.displayed_content, "");
+}
+
+/// A2: `cap=0` is degenerate but must not panic. Empty input still
+/// passes through; non-empty input always truncates with an empty
+/// preview body but a valid marker.
+#[test]
+fn cap_zero_handles_both_empty_and_non_empty_input() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = store_in(tmp.path());
+    let policy = ToolBudgetPolicy::with_default_chars(0);
+
+    let empty = apply_tool_result_budget("custom_tool", "tc-zero-1", "", &policy, &store);
+    assert!(
+        !empty.truncated,
+        "empty input within cap=0 must not truncate"
+    );
+
+    let non_empty =
+        apply_tool_result_budget("custom_tool", "tc-zero-2", "anything", &policy, &store);
+    assert!(
+        non_empty.truncated,
+        "any non-empty input must truncate at cap=0"
+    );
+    assert!(non_empty.displayed_content.contains("[truncated:"));
+}
+
+/// A5: One char over the cap fires the truncation path. Boundary
+/// regression guard against off-by-one in the equality check.
+#[test]
+fn one_char_over_cap_triggers_truncation() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = store_in(tmp.path());
+    let cap = 100;
+    let policy = ToolBudgetPolicy::with_default_chars(cap);
+
+    let raw = "x".repeat(cap + 1);
+    let result = apply_tool_result_budget("custom_tool", "tc-over1", &raw, &policy, &store);
+
+    assert!(result.truncated, "input of cap+1 chars must truncate");
+    assert_eq!(result.original_len, cap + 1);
+}
+
+// ─── B. Truncation correctness ────────────────────────────────────────────
+
+/// B1: The `truncated` flag is the single source of truth for callers
+/// that gate downstream behavior (telemetry, debug logs, audit trails).
+/// Pin it explicitly across both branches.
+#[test]
+fn truncated_flag_matches_actual_truncation() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = store_in(tmp.path());
+    let policy = ToolBudgetPolicy::with_default_chars(50);
+
+    let under = apply_tool_result_budget("t", "id", "x", &policy, &store);
+    let over = apply_tool_result_budget("t", "id", &"y".repeat(200), &policy, &store);
+
+    assert!(!under.truncated);
+    assert!(under.overflow_ref.is_none());
+
+    assert!(over.truncated);
+    assert!(over.overflow_ref.is_some());
+}
+
+/// B2: `original_len` is character count, not byte count. Easy to
+/// regress to `.len()` (byte count) which would mislead consumers about
+/// how much was omitted for multibyte content.
+#[test]
+fn original_len_is_char_count_not_byte_count() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = store_in(tmp.path());
+    let policy = ToolBudgetPolicy::with_default_chars(5);
+
+    // 10 rocket emoji = 10 chars / 40 bytes.
+    let raw: String = "🚀".repeat(10);
+    let result = apply_tool_result_budget("t", "id", &raw, &policy, &store);
+
+    assert_eq!(
+        result.original_len, 10,
+        "must report char count, not byte count"
+    );
+    // And the truncation marker echoes the same number.
+    assert!(result.displayed_content.contains("/ 10 chars omitted"));
+}
+
+/// B3: For caps comfortably larger than the preview, the full
+/// displayed content (preview + marker + reference) stays under the
+/// cap. Marker overhead must remain a small constant.
+#[test]
+fn displayed_content_stays_within_cap_for_normal_caps() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = store_in(tmp.path());
+    // Default cap (8000) is well above PREVIEW_CHARS (1500), so
+    // overhead-after-preview must fit comfortably.
+    let policy = ToolBudgetPolicy::default();
+
+    let raw = "x".repeat(50_000);
+    let result = apply_tool_result_budget("custom_tool", "tc-b3", &raw, &policy, &store);
+
+    let displayed_chars = result.displayed_content.chars().count();
+    assert!(result.truncated);
+    assert!(
+        displayed_chars <= TOOL_RESULT_BUDGET_DEFAULT_CHARS,
+        "displayed content {displayed_chars} exceeded cap {TOOL_RESULT_BUDGET_DEFAULT_CHARS}",
+    );
+    // And the preview portion alone is exactly PREVIEW_CHARS.
+    let preview = result.displayed_content.split("\n\n…").next().unwrap();
+    assert_eq!(preview.chars().count(), TOOL_RESULT_BUDGET_PREVIEW_CHARS);
+}
+
+// ─── D. Per-tool policy ───────────────────────────────────────────────────
+
+/// D2: `read_file` (snake_case) and `Read` (PascalCase) are aliases for
+/// the same capability. Their caps must stay in sync — a divergence
+/// would silently differ in budgeting depending on which alias the
+/// registry uses.
+#[test]
+fn read_file_and_read_aliases_share_a_cap() {
+    let policy = ToolBudgetPolicy::default();
+    assert_eq!(
+        policy.cap_for("read_file"),
+        policy.cap_for("Read"),
+        "read_file and Read must share a budget",
+    );
+}
+
+/// D3: Same parity invariant for the bash family. Three names, one
+/// underlying tool.
+#[test]
+fn bash_family_aliases_share_a_cap() {
+    let policy = ToolBudgetPolicy::default();
+    let bash = policy.cap_for("Bash");
+    assert_eq!(policy.cap_for("run_command"), bash);
+    assert_eq!(policy.cap_for("bash_execute"), bash);
+}
+
+/// D4: Re-overriding an existing tool updates in place (last-write
+/// wins). Catches a regression where `set_override` would push
+/// duplicates instead of replacing — duplicates would shadow each
+/// other arbitrarily depending on iteration order.
+#[test]
+fn set_override_updates_existing_entry_last_write_wins() {
+    let mut policy = ToolBudgetPolicy::default();
+
+    // The default cap for read_file is 12_000. Re-override twice.
+    policy.set_override("read_file", 100);
+    assert_eq!(policy.cap_for("read_file"), 100);
+
+    policy.set_override("read_file", 200);
+    assert_eq!(
+        policy.cap_for("read_file"),
+        200,
+        "last set_override must win"
+    );
+
+    policy.set_override("read_file", usize::MAX);
+    assert!(policy.is_unbounded("read_file"));
+}
+
+// ─── E. Overflow store I/O ────────────────────────────────────────────────
+
+/// E1: When the overflow directory does not exist yet, the store
+/// creates it on first write rather than failing. Standard
+/// `create_dir_all` semantics, pinned so a refactor cannot silently
+/// regress to "must pre-create".
+#[test]
+fn overflow_dir_is_auto_created_on_first_write() {
+    let tmp = tempfile::tempdir().unwrap();
+    let nested_dir = tmp
+        .path()
+        .join("does")
+        .join("not")
+        .join("exist")
+        .join("yet");
+    assert!(!nested_dir.exists());
+
+    let store = OverflowStore::with_dir(tmp.path(), &nested_dir);
+    let policy = ToolBudgetPolicy::with_default_chars(10);
+
+    let result = apply_tool_result_budget("t", "id", &"x".repeat(100), &policy, &store);
+
+    assert!(
+        result.overflow_ref.is_some(),
+        "write should succeed and return ref"
+    );
+    assert!(nested_dir.exists(), "overflow dir should have been created");
+    assert!(nested_dir.is_dir());
+}
+
+/// E5: A tool name containing path-unsafe characters must be sanitized
+/// in the resulting filename. No `/`, `\`, or whitespace should leak
+/// into the filename component — those would either escape the
+/// overflow directory (security) or corrupt the path (correctness).
+#[test]
+fn tool_name_with_unsafe_chars_is_sanitized() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = store_in(tmp.path());
+    let policy = ToolBudgetPolicy::with_default_chars(10);
+
+    let weird_name = "evil/../tool name 🚀";
+    let result = apply_tool_result_budget(weird_name, "id-1", &"x".repeat(50), &policy, &store);
+
+    let rel = result.overflow_ref.expect("must overflow");
+    let filename = std::path::Path::new(&rel)
+        .file_name()
+        .expect("ref must have a filename")
+        .to_string_lossy()
+        .into_owned();
+
+    assert!(!filename.contains('/'), "filename must not contain /");
+    assert!(
+        !filename.contains('\\'),
+        "filename must not contain backslash"
+    );
+    assert!(
+        !filename.contains(' '),
+        "filename must not contain whitespace"
+    );
+    // And the file actually lives under the overflow dir.
+    let abs = tmp.path().join(&rel);
+    assert!(abs.exists(), "file must land at the displayed path");
+}
+
+/// E6: The same protection applies to `tool_call_id`, which is
+/// LLM-influenced and could contain path-traversal sequences. The
+/// resulting file must land inside the overflow directory regardless
+/// of what the id contains.
+#[test]
+fn tool_call_id_with_path_traversal_stays_in_overflow_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    let overflow_dir = tmp.path().join("overflow");
+    let store = OverflowStore::with_dir(tmp.path(), &overflow_dir);
+    let policy = ToolBudgetPolicy::with_default_chars(10);
+
+    let evil_id = "../../etc/passwd";
+    let result = apply_tool_result_budget("t", evil_id, &"x".repeat(50), &policy, &store);
+
+    let rel = result.overflow_ref.expect("must overflow");
+    let abs = tmp.path().join(&rel).canonicalize().unwrap();
+    let overflow_canonical = overflow_dir.canonicalize().unwrap();
+
+    assert!(
+        abs.starts_with(&overflow_canonical),
+        "overflow file {} escaped overflow dir {}",
+        abs.display(),
+        overflow_canonical.display(),
+    );
+}
+
+/// E9: When the input fits within the budget, no file may be written.
+/// Avoids polluting the overflow directory with one file per
+/// well-behaved tool call — that would defeat the entire purpose
+/// (and produce thousands of useless artifacts per session).
+#[test]
+fn no_file_written_when_under_cap() {
+    let tmp = tempfile::tempdir().unwrap();
+    let overflow_dir = tmp.path().join("overflow");
+    let store = OverflowStore::with_dir(tmp.path(), &overflow_dir);
+    let policy = ToolBudgetPolicy::with_default_chars(1_000);
+
+    let result = apply_tool_result_budget("t", "id", "small output", &policy, &store);
+
+    assert!(!result.truncated);
+    assert!(result.overflow_ref.is_none());
+    // The overflow dir must not have been created (or must be empty).
+    if overflow_dir.exists() {
+        let entries: Vec<_> = std::fs::read_dir(&overflow_dir).unwrap().collect();
+        assert!(entries.is_empty(), "no files should be written under cap");
+    }
+}

--- a/crates/opendev-context/src/tool_budget/tests.rs
+++ b/crates/opendev-context/src/tool_budget/tests.rs
@@ -1,0 +1,159 @@
+//! Unit tests for `tool_budget`.
+
+use super::*;
+use crate::compaction::{TOOL_RESULT_BUDGET_DEFAULT_CHARS, TOOL_RESULT_BUDGET_PREVIEW_CHARS};
+
+fn store_in(dir: &std::path::Path) -> OverflowStore {
+    OverflowStore::with_dir(dir, dir.join("overflow"))
+}
+
+#[test]
+fn under_cap_passes_through_unchanged() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = store_in(tmp.path());
+    let policy = ToolBudgetPolicy::default();
+
+    let raw = "small output".to_string();
+    let result = apply_tool_result_budget("custom_tool", "tc-1", &raw, &policy, &store);
+
+    assert!(!result.truncated);
+    assert!(result.overflow_ref.is_none());
+    assert_eq!(result.displayed_content, raw);
+    assert_eq!(result.original_len, raw.chars().count());
+}
+
+#[test]
+fn at_cap_passes_through_unchanged() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = store_in(tmp.path());
+    let policy = ToolBudgetPolicy::with_default_chars(100);
+
+    let raw = "x".repeat(100);
+    let result = apply_tool_result_budget("custom_tool", "tc-2", &raw, &policy, &store);
+
+    assert!(!result.truncated);
+    assert_eq!(result.displayed_content.chars().count(), 100);
+}
+
+#[test]
+fn over_cap_truncates_with_reference() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = store_in(tmp.path());
+    let policy = ToolBudgetPolicy::default();
+
+    let raw = "x".repeat(TOOL_RESULT_BUDGET_DEFAULT_CHARS * 2);
+    let result = apply_tool_result_budget("custom_tool", "tc-3", &raw, &policy, &store);
+
+    assert!(result.truncated);
+    assert!(result.overflow_ref.is_some(), "expected an overflow ref");
+    assert!(result.displayed_content.contains("[truncated:"));
+    assert!(result.displayed_content.contains("[full output:"));
+    assert!(
+        result.displayed_content.chars().count() < TOOL_RESULT_BUDGET_DEFAULT_CHARS,
+        "displayed content must stay under the cap",
+    );
+}
+
+#[test]
+fn per_tool_override_applies() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = store_in(tmp.path());
+    let policy = ToolBudgetPolicy::default();
+
+    // `list_files` cap is 2_000; 5_000 chars must truncate.
+    let raw = "y".repeat(5_000);
+    let result = apply_tool_result_budget("list_files", "tc-4", &raw, &policy, &store);
+
+    assert!(result.truncated);
+    // `read_file` cap is 12_000; 5_000 chars must NOT truncate.
+    let result_read = apply_tool_result_budget("read_file", "tc-5", &raw, &policy, &store);
+    assert!(!result_read.truncated);
+}
+
+#[test]
+fn unbounded_tool_bypasses_budget() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = store_in(tmp.path());
+    let policy = ToolBudgetPolicy::default();
+
+    assert!(policy.is_unbounded("web_screenshot"));
+    let raw = "z".repeat(100_000);
+    let result = apply_tool_result_budget("web_screenshot", "tc-6", &raw, &policy, &store);
+
+    assert!(!result.truncated);
+    assert!(result.overflow_ref.is_none());
+    assert_eq!(result.displayed_content.chars().count(), 100_000);
+}
+
+#[test]
+fn multibyte_truncation_is_safe() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = store_in(tmp.path());
+    // Cap below the input size but well above one preview's worth.
+    let policy = ToolBudgetPolicy::with_default_chars(50);
+
+    // Each "🚀" is 1 char / 4 bytes — naive byte slicing would panic.
+    let raw: String = "🚀".repeat(200);
+    let result = apply_tool_result_budget("custom_tool", "tc-7", &raw, &policy, &store);
+
+    assert!(result.truncated);
+    // Must not panic; preview must be a valid UTF-8 string with rocket chars.
+    assert!(result.displayed_content.starts_with('🚀'));
+}
+
+#[test]
+fn overflow_file_round_trips_full_content() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = store_in(tmp.path());
+    let policy = ToolBudgetPolicy::with_default_chars(100);
+
+    let raw = "abcdefghij".repeat(50); // 500 chars
+    let result = apply_tool_result_budget("custom_tool", "tc-8", &raw, &policy, &store);
+
+    let ref_path = result.overflow_ref.expect("overflow ref must exist");
+    let abs_path = tmp.path().join(&ref_path);
+    let on_disk = std::fs::read_to_string(&abs_path).unwrap();
+    assert_eq!(on_disk, raw);
+}
+
+#[test]
+fn override_can_opt_out_per_tool() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = store_in(tmp.path());
+    let mut policy = ToolBudgetPolicy::with_default_chars(50);
+    policy.set_override("noisy_but_required", usize::MAX);
+
+    let raw = "q".repeat(10_000);
+    let result = apply_tool_result_budget("noisy_but_required", "tc-9", &raw, &policy, &store);
+
+    assert!(!result.truncated);
+}
+
+#[test]
+fn preview_size_is_bounded_by_cap() {
+    // Sanity: when the cap is smaller than the configured preview length,
+    // the preview shrinks rather than overflowing the cap.
+    let tmp = tempfile::tempdir().unwrap();
+    let store = store_in(tmp.path());
+    let small_cap = TOOL_RESULT_BUDGET_PREVIEW_CHARS / 2;
+    let policy = ToolBudgetPolicy::with_default_chars(small_cap);
+
+    let raw = "p".repeat(small_cap * 4);
+    let result = apply_tool_result_budget("custom_tool", "tc-10", &raw, &policy, &store);
+
+    assert!(result.truncated);
+    // The preview is the leading section of displayed_content up to the
+    // first "\n\n…" separator. Verify it fits within the cap and is not
+    // empty.
+    let preview = result
+        .displayed_content
+        .split("\n\n…")
+        .next()
+        .expect("displayed_content must contain truncation separator");
+    let preview_chars = preview.chars().count();
+    assert!(
+        preview_chars <= small_cap,
+        "preview {preview_chars} > cap {small_cap}"
+    );
+    assert!(preview_chars > 0);
+}

--- a/crates/opendev-context/tests/tool_budget_integration.rs
+++ b/crates/opendev-context/tests/tool_budget_integration.rs
@@ -40,6 +40,54 @@ fn distinct_calls_produce_distinct_overflow_files() {
     assert_ne!(p1, p2, "tool_call_id must differentiate filenames");
 }
 
+/// I1: Mirror the agent loop's call site — `apply_tool_result_budget`
+/// is called between formatting the raw tool result and pushing it
+/// into the `messages` list. The pushed message MUST carry the
+/// budgeted (truncated) content, never the raw payload. This is the
+/// invariant the entire feature rests on.
+#[test]
+fn pushed_tool_message_carries_budgeted_content_not_raw() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = OverflowStore::new(tmp.path());
+    let policy = ToolBudgetPolicy::with_default_chars(64);
+
+    let raw = "RAW_SHOULD_NEVER_APPEAR_IN_FULL ".repeat(100);
+    let budgeted = apply_tool_result_budget("custom_tool", "call-X", &raw, &policy, &store);
+
+    // Mirror the exact push pattern used in
+    // crates/opendev-agents/src/react_loop/phases/tool_dispatch.rs.
+    let mut messages: Vec<serde_json::Value> = Vec::new();
+    messages.push(serde_json::json!({
+        "role": "tool",
+        "tool_call_id": "call-X",
+        "name": "custom_tool",
+        "content": budgeted.displayed_content,
+    }));
+
+    let pushed = messages[0]["content"]
+        .as_str()
+        .expect("content must be a string");
+    let pushed_chars = pushed.chars().count();
+
+    assert_eq!(pushed, budgeted.displayed_content);
+    assert!(
+        pushed_chars < raw.chars().count(),
+        "pushed content must be smaller than raw — pushed {} vs raw {}",
+        pushed_chars,
+        raw.chars().count(),
+    );
+    // Truncation marker is present in the pushed message.
+    assert!(pushed.contains("[truncated:"));
+    assert!(pushed.contains("[full output:"));
+    // And the raw payload's repeated marker substring does NOT appear in
+    // full — at most as a prefix within the preview.
+    let raw_marker_count = pushed.matches("RAW_SHOULD_NEVER_APPEAR_IN_FULL").count();
+    assert!(
+        raw_marker_count < 100,
+        "pushed content seems to contain the full raw payload",
+    );
+}
+
 #[test]
 fn write_failure_degrades_gracefully() {
     // Point the overflow dir at a path that cannot be created (under a

--- a/crates/opendev-context/tests/tool_budget_integration.rs
+++ b/crates/opendev-context/tests/tool_budget_integration.rs
@@ -1,0 +1,62 @@
+//! End-to-end tests for `tool_budget` against a real temp directory.
+//!
+//! Verifies that overflow files land where the displayed reference path
+//! claims they do, and that consecutive calls produce distinct files.
+
+use opendev_context::{OverflowStore, ToolBudgetPolicy, apply_tool_result_budget};
+
+#[test]
+fn overflow_path_resolves_relative_to_project_root() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = OverflowStore::new(tmp.path());
+    let policy = ToolBudgetPolicy::with_default_chars(64);
+
+    let raw = "data ".repeat(200);
+    let result = apply_tool_result_budget("custom", "call-A", &raw, &policy, &store);
+    let rel_path = result.overflow_ref.expect("must overflow");
+
+    let abs = tmp.path().join(&rel_path);
+    assert!(
+        abs.exists(),
+        "overflow file should exist at {}",
+        abs.display()
+    );
+    let on_disk = std::fs::read_to_string(&abs).unwrap();
+    assert_eq!(on_disk, raw);
+}
+
+#[test]
+fn distinct_calls_produce_distinct_overflow_files() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = OverflowStore::new(tmp.path());
+    let policy = ToolBudgetPolicy::with_default_chars(32);
+
+    let raw = "x".repeat(500);
+    let r1 = apply_tool_result_budget("t", "id-1", &raw, &policy, &store);
+    let r2 = apply_tool_result_budget("t", "id-2", &raw, &policy, &store);
+
+    let p1 = r1.overflow_ref.unwrap();
+    let p2 = r2.overflow_ref.unwrap();
+    assert_ne!(p1, p2, "tool_call_id must differentiate filenames");
+}
+
+#[test]
+fn write_failure_degrades_gracefully() {
+    // Point the overflow dir at a path that cannot be created (under a
+    // file rather than a directory). The displayed content must still
+    // be bounded with a truncation marker, just without a reference.
+    let tmp = tempfile::tempdir().unwrap();
+    let blocking_file = tmp.path().join("blocker");
+    std::fs::write(&blocking_file, "not a directory").unwrap();
+
+    let store = OverflowStore::with_dir(tmp.path(), blocking_file.join("nested"));
+    let policy = ToolBudgetPolicy::with_default_chars(16);
+
+    let raw = "y".repeat(200);
+    let result = apply_tool_result_budget("custom", "id", &raw, &policy, &store);
+
+    assert!(result.truncated);
+    assert!(result.overflow_ref.is_none(), "must degrade without panic");
+    assert!(result.displayed_content.contains("[truncated:"));
+    assert!(!result.displayed_content.contains("[full output:"));
+}


### PR DESCRIPTION
## Summary

Adds a new `tool_budget` module in `opendev-context` that caps each tool result at the moment it is appended to the conversation history. Complements the existing reactive staged compaction (`70/80/85/90/99%` stages) by preventing single-turn context spikes from oversized tool outputs.

**Why preemptive, not just compaction.** A single oversized tool result (call graph, wide file listing, large MCP analysis dump) can push context usage from ~60% to ~95% in one turn, forcing the most expensive 99% LLM-call compaction stage. Per-result caps prevent the spike at the source.

**How it works.** Outputs above their per-tool character cap are truncated to a short preview and the full content is persisted under `.opendev/tool-results/<timestamp>-<tool>-<call_id>.txt`. The displayed message ends with a `[full output: <path>]` reference so the agent can re-read it on demand.

## Design

- **Defaults:** 8K-char cap (~2K tokens), 1.5K-char preview.
- **Per-tool overrides:** 12 built-ins covering both snake_case and PascalCase aliases (`read_file`/`Read`, `Bash`/`run_command`/`bash_execute`, `Grep`/`search`/`file_search`, etc.). Budgets biased by noise: `list_files` → 2K, `Grep` → 4K, `Bash` → 6K, `read_file` → 12K.
- **Opt-out:** `web_screenshot` and `vlm` set to `usize::MAX` (opaque/binary content).
- **Graceful degradation:** Write failures don't panic — `displayed_content` is still bounded, just without a reference path.
- **No new traits, no async surface.** Two fields on `LoopState`, one call site in tool dispatch.

## Integration

- `crates/opendev-context/src/tool_budget/` — new module (policy, overflow store, public API).
- `crates/opendev-context/src/compaction/mod.rs` — 3 new `pub const` defaults alongside existing compaction constants.
- `crates/opendev-agents/src/react_loop/loop_state.rs` — 2 new fields constructed with existing `working_dir`.
- `crates/opendev-agents/src/react_loop/phases/tool_dispatch.rs` — call `apply_tool_result_budget` between tool result formatting and message append.

## Test plan

- [x] 9 unit tests in `tool_budget/tests.rs` — pass-through, truncation, per-tool overrides, multibyte safety, opt-out, preview/cap interaction.
- [x] 3 integration tests in `tests/tool_budget_integration.rs` — on-disk round-trip, distinct filenames, graceful degradation on write failure.
- [x] `cargo test -p opendev-context --lib --tests` — 207 unit + 3 integration pass.
- [x] `cargo test -p opendev-agents --lib --tests` — all pass.
- [x] `cargo check --workspace` clean.
- [x] `cargo build --release -p opendev-cli` succeeds.
- [ ] Real-LLM TUI smoke test (per `CLAUDE.md` §4) — suggested probe: `opendev -p "list every file under crates/opendev-tools-impl/src recursively, then summarize each module"`. The `Bash`/`list_files` result should appear truncated with a `[full output: .opendev/tool-results/...]` reference.

## References

Pattern adapted from Claude Code's `applyToolResultBudget()` + `maxResultSizeChars` per-tool caps. This addresses the "Tool Result Budgeting" gap documented as partial (summarizer-only) in the current codebase; full content persistence to disk is new.