### PR TITLE
fix(opendev-agents): back off on retryable LLM failures to break runaway loop

### DIFF
--- a/crates/opendev-agents/src/react_loop/phases/llm_call.rs
+++ b/crates/opendev-agents/src/react_loop/phases/llm_call.rs
@@ -6,6 +6,7 @@
 //! generation for lower per-iteration latency.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use serde_json::Value;
 use tracing::{Instrument, debug, info, info_span, warn};
@@ -175,6 +176,15 @@ where
             logger.log_llm_error(state.iteration, err_msg);
         }
         if http_result.retryable {
+            // Back off before the next iteration. The lower HTTP layer can
+            // open a circuit breaker and reject for several seconds; without
+            // a sleep here the agent loop spins at sub-millisecond rates,
+            // generating runaway log volume and burning CPU until the
+            // breaker closes. Prefer a parsed hint from the error message
+            // (e.g. "Will retry in 27s"); fall back to a small fixed delay
+            // for any other retryable failure.
+            let backoff = retry_backoff_for(err_msg);
+            tokio::time::sleep(backoff).await;
             return Err(LoopAction::Continue);
         }
         return Err(LoopAction::Return(Err(AgentError::LlmError(
@@ -236,3 +246,40 @@ where
         streaming_executor,
     })
 }
+
+/// Minimum backoff applied to any retryable LLM HTTP failure.
+/// 500ms is enough to prevent CPU/log runaway while staying responsive
+/// to transient hiccups.
+const RETRY_FALLBACK_BACKOFF: Duration = Duration::from_millis(500);
+
+/// Upper bound applied to a parsed retry hint, in case the source layer
+/// reports an unreasonably large value.
+const RETRY_MAX_BACKOFF: Duration = Duration::from_secs(60);
+
+/// Compute the backoff to apply before retrying a failed LLM call.
+///
+/// Parses a "Will retry in Ns" hint from the error message (emitted by
+/// the HTTP layer's circuit breaker) and uses that, capped at
+/// [`RETRY_MAX_BACKOFF`]. Falls back to [`RETRY_FALLBACK_BACKOFF`] when
+/// no hint is present.
+fn retry_backoff_for(err_msg: &str) -> Duration {
+    parse_retry_hint(err_msg)
+        .map(|d| d.min(RETRY_MAX_BACKOFF))
+        .unwrap_or(RETRY_FALLBACK_BACKOFF)
+}
+
+/// Parse a retry-after hint from a circuit breaker error string.
+///
+/// Recognises the literal phrase `"Will retry in Ns"` produced by
+/// `opendev_http::circuit_breaker`. Returns `None` for any other
+/// shape so unrelated retryable errors fall through to the default
+/// backoff.
+fn parse_retry_hint(err_msg: &str) -> Option<Duration> {
+    let after = err_msg.split("Will retry in ").nth(1)?;
+    let secs_str = after.split('s').next()?.trim();
+    secs_str.parse::<u64>().ok().map(Duration::from_secs)
+}
+
+#[cfg(test)]
+#[path = "llm_call_tests.rs"]
+mod tests;

--- a/crates/opendev-agents/src/react_loop/phases/llm_call.rs
+++ b/crates/opendev-agents/src/react_loop/phases/llm_call.rs
@@ -259,12 +259,18 @@ const RETRY_MAX_BACKOFF: Duration = Duration::from_secs(60);
 /// Compute the backoff to apply before retrying a failed LLM call.
 ///
 /// Parses a "Will retry in Ns" hint from the error message (emitted by
-/// the HTTP layer's circuit breaker) and uses that, capped at
-/// [`RETRY_MAX_BACKOFF`]. Falls back to [`RETRY_FALLBACK_BACKOFF`] when
-/// no hint is present.
+/// the HTTP layer's circuit breaker) and uses that, clamped to
+/// `[RETRY_FALLBACK_BACKOFF, RETRY_MAX_BACKOFF]`. When no hint is
+/// present, falls back to [`RETRY_FALLBACK_BACKOFF`].
+///
+/// The lower bound matters at the circuit-breaker half-open boundary:
+/// when the cooldown has just expired the breaker reports
+/// `Will retry in 0s.` and a naive parse would produce a zero-second
+/// sleep, allowing a tight retry burst until the breaker fully opens
+/// again. Clamping to the fallback prevents that.
 fn retry_backoff_for(err_msg: &str) -> Duration {
     parse_retry_hint(err_msg)
-        .map(|d| d.min(RETRY_MAX_BACKOFF))
+        .map(|d| d.clamp(RETRY_FALLBACK_BACKOFF, RETRY_MAX_BACKOFF))
         .unwrap_or(RETRY_FALLBACK_BACKOFF)
 }
 

--- a/crates/opendev-agents/src/react_loop/phases/llm_call_tests.rs
+++ b/crates/opendev-agents/src/react_loop/phases/llm_call_tests.rs
@@ -1,0 +1,59 @@
+//! Unit tests for `llm_call` retry-backoff logic.
+
+use std::time::Duration;
+
+use super::{RETRY_FALLBACK_BACKOFF, RETRY_MAX_BACKOFF, parse_retry_hint, retry_backoff_for};
+
+#[test]
+fn parses_canonical_circuit_breaker_message() {
+    let msg = "Circuit breaker open for provider 'anthropic'. \
+               Too many consecutive failures (9). \
+               Will retry in 27s.";
+    assert_eq!(parse_retry_hint(msg), Some(Duration::from_secs(27)));
+}
+
+#[test]
+fn parses_with_extra_surrounding_context() {
+    let msg = "[request_id=abc] Circuit open. Will retry in 5s. (jittered)";
+    assert_eq!(parse_retry_hint(msg), Some(Duration::from_secs(5)));
+}
+
+#[test]
+fn returns_none_when_phrase_absent() {
+    assert_eq!(parse_retry_hint("HTTP 500 internal server error"), None);
+    assert_eq!(parse_retry_hint(""), None);
+}
+
+#[test]
+fn returns_none_when_seconds_unparseable() {
+    assert_eq!(parse_retry_hint("Will retry in soons."), None);
+    assert_eq!(parse_retry_hint("Will retry in -1s."), None);
+}
+
+#[test]
+fn backoff_uses_parsed_hint_when_present() {
+    let msg = "Circuit open. Will retry in 3s.";
+    assert_eq!(retry_backoff_for(msg), Duration::from_secs(3));
+}
+
+#[test]
+fn backoff_caps_unreasonably_large_hints() {
+    let msg = "Will retry in 999999s.";
+    assert_eq!(retry_backoff_for(msg), RETRY_MAX_BACKOFF);
+}
+
+#[test]
+fn backoff_falls_back_when_no_hint() {
+    assert_eq!(retry_backoff_for("HTTP 500"), RETRY_FALLBACK_BACKOFF);
+    assert_eq!(retry_backoff_for(""), RETRY_FALLBACK_BACKOFF);
+}
+
+#[test]
+fn fallback_is_at_least_one_log_line_apart() {
+    // Sanity: fallback must be large enough to prevent the runaway-loop
+    // scenario this fix addresses (sub-millisecond retries flooding logs).
+    assert!(
+        RETRY_FALLBACK_BACKOFF >= Duration::from_millis(100),
+        "fallback backoff too small to prevent log/CPU runaway",
+    );
+}

--- a/crates/opendev-agents/src/react_loop/phases/llm_call_tests.rs
+++ b/crates/opendev-agents/src/react_loop/phases/llm_call_tests.rs
@@ -49,6 +49,26 @@ fn backoff_falls_back_when_no_hint() {
 }
 
 #[test]
+fn parsed_zero_seconds_clamps_up_to_fallback() {
+    // Reproduces the half-open boundary case observed in the field:
+    // the circuit breaker reports `remaining_secs=0` the moment its
+    // cooldown expires. A naive parse would yield a zero-second sleep,
+    // letting the loop burst-retry until the breaker fully opens
+    // again. The clamp must lift parsed=0 up to the fallback.
+    let msg = "Circuit breaker open … Will retry in 0s.";
+    assert_eq!(parse_retry_hint(msg), Some(Duration::ZERO));
+    assert_eq!(retry_backoff_for(msg), RETRY_FALLBACK_BACKOFF);
+}
+
+#[test]
+fn parsed_below_fallback_clamps_up() {
+    // Any hint smaller than the fallback floor must be lifted, not
+    // honored verbatim.
+    let msg = "Will retry in 0s.";
+    assert!(retry_backoff_for(msg) >= RETRY_FALLBACK_BACKOFF);
+}
+
+#[test]
 fn fallback_is_at_least_one_log_line_apart() {
     // Sanity: fallback must be large enough to prevent the runaway-loop
     // scenario this fix addresses (sub-millisecond retries flooding logs).

--- a/crates/opendev-config/src/models_dev/models.rs
+++ b/crates/opendev-config/src/models_dev/models.rs
@@ -94,7 +94,7 @@ impl ProviderInfo {
         if let Some(cap) = capability {
             models.retain(|m| m.capabilities.contains(&cap.to_string()));
         }
-        models.sort_by(|a, b| b.context_length.cmp(&a.context_length));
+        models.sort_by_key(|b| std::cmp::Reverse(b.context_length));
         models
     }
 

--- a/crates/opendev-config/src/models_dev/registry.rs
+++ b/crates/opendev-config/src/models_dev/registry.rs
@@ -238,7 +238,7 @@ impl ModelRegistry {
     /// List all available providers, sorted by priority then alphabetically.
     pub fn list_providers(&self) -> Vec<&ProviderInfo> {
         let mut providers: Vec<&ProviderInfo> = self.providers.values().collect();
-        providers.sort_by(|a, b| provider_sort_key(&a.id).cmp(&provider_sort_key(&b.id)));
+        providers.sort_by_key(|a| provider_sort_key(&a.id));
         providers
     }
 


### PR DESCRIPTION
## Summary

When the HTTP layer's circuit breaker rejects a request, the agent loop's retryable-failure path returned `LoopAction::Continue` with **no sleep**, causing the loop to spin at sub-millisecond rates against an open breaker.

## Reproduction

Observed in the wild during a real-LLM smoke test against Anthropic with a model that triggered a per-request 400 (\`thinking.adaptive.budget_tokens: Extra inputs are not permitted\`):

- ~11,500 loop iterations in **under one minute**
- ~10GB of session debug log output before the disk filled
- Each iteration: one circuit-open rejection, one warn line, one soft-fail return — repeated immediately with zero backoff

The relevant log pattern (every line representing one loop iteration):

\`\`\`
WARN llm_call{iteration=11580 model=\"…\"}: Circuit open, rejecting request provider=anthropic remaining_secs=1
WARN llm_call{iteration=11580 model=\"…\"}: Streaming request failed after retries, soft-failing error=Circuit breaker open … Will retry in 1s.
WARN LLM HTTP call failed error=\"Circuit breaker open … Will retry in 1s.\"
\`\`\`

The HTTP layer (\`opendev_http::circuit_breaker\`) correctly emits a \`\"Will retry in Ns.\"\` hint, but the agent loop ignored it.

## Fix

Minimal: in \`crates/opendev-agents/src/react_loop/phases/llm_call.rs\`, before the existing \`return Err(LoopAction::Continue)\` on retryable failure, sleep for either:

1. the parsed \`Will retry in Ns.\` hint (capped at 60s), or
2. a fixed 500ms fallback for any other retryable error.

No changes to the circuit breaker, the HTTP layer, or \`LoopState\`. Two new helpers (\`parse_retry_hint\`, \`retry_backoff_for\`) plus one \`tokio::time::sleep\`.

## Why these specific numbers

| Constant | Value | Reason |
|---|---|---|
| \`RETRY_FALLBACK_BACKOFF\` | 500ms | Two orders of magnitude slower than observed runaway (sub-ms). Big enough to prevent log/CPU runaway while staying responsive to transient hiccups. |
| \`RETRY_MAX_BACKOFF\` | 60s | Defensive cap in case the HTTP layer ever reports an unreasonable cooldown. |

## Test plan

- [x] 8 new unit tests in \`react_loop/phases/llm_call_tests.rs\` covering: canonical-format parsing, surrounding-context tolerance, missing hint → fallback, unparseable seconds → fallback, hint cap enforcement, and a guard test that documents the minimum fallback constraint.
- [x] \`cargo test -p opendev-agents --lib\` — all pass (33 in scope, 8 new).
- [x] \`cargo check --workspace\` clean.
- [x] \`cargo build --release -p opendev-cli\` succeeds.
- [x] Real-LLM rerun: trigger a repeated provider failure (e.g., known-bad model name) and confirm the loop logs are seconds apart instead of microseconds, with no disk pressure.

## Independent of #88

This is a separate concern from \`feat(opendev-context): preemptive per-tool result budgeting\` (PR #88). Both are needed; neither depends on the other.

## Related (out of scope, not blocking)

The original 400 from Anthropic was \`thinking.adaptive.budget_tokens: Extra inputs are not permitted\` for a model that opendev's \`supports_adaptive_thinking()\` classified as adaptive-thinking-capable. That classifier may need updating but is a separate investigation — this PR only fixes the retry-loop amplifier.