### PR TITLE
fix(opendev-http): carry tool-call args emitted in the same chunk as id/name

### DIFF
--- a/crates/opendev-agents/src/react_loop/streaming_executor.rs
+++ b/crates/opendev-agents/src/react_loop/streaming_executor.rs
@@ -248,6 +248,7 @@ impl StreamCallback for StreamingToolExecutor {
                 index,
                 call_id,
                 name,
+                ..
             } => {
                 // Store metadata keyed by stream index for later lookup.
                 if let Ok(mut map) = self.call_metadata.lock() {

--- a/crates/opendev-agents/src/react_loop/streaming_executor_tests.rs
+++ b/crates/opendev-agents/src/react_loop/streaming_executor_tests.rs
@@ -18,6 +18,7 @@ fn test_function_call_start_stored() {
         index: 0,
         call_id: "call_123".to_string(),
         name: "Read".to_string(),
+        initial_args: None,
     });
 
     // Verify it was stored by index
@@ -42,6 +43,7 @@ fn test_write_tool_preparsed() {
         index: 0,
         call_id: "call_456".to_string(),
         name: "Edit".to_string(),
+        initial_args: None,
     });
 
     // Complete it
@@ -112,6 +114,7 @@ async fn test_read_only_tool_spawns_task() {
         index: 0,
         call_id: "call_789".to_string(),
         name: "Read".to_string(),
+        initial_args: None,
     });
 
     // Complete it - this should spawn a task

--- a/crates/opendev-config/src/models_dev/models.rs
+++ b/crates/opendev-config/src/models_dev/models.rs
@@ -94,7 +94,7 @@ impl ProviderInfo {
         if let Some(cap) = capability {
             models.retain(|m| m.capabilities.contains(&cap.to_string()));
         }
-        models.sort_by(|a, b| b.context_length.cmp(&a.context_length));
+        models.sort_by_key(|b| std::cmp::Reverse(b.context_length));
         models
     }
 

--- a/crates/opendev-config/src/models_dev/registry.rs
+++ b/crates/opendev-config/src/models_dev/registry.rs
@@ -238,7 +238,7 @@ impl ModelRegistry {
     /// List all available providers, sorted by priority then alphabetically.
     pub fn list_providers(&self) -> Vec<&ProviderInfo> {
         let mut providers: Vec<&ProviderInfo> = self.providers.values().collect();
-        providers.sort_by(|a, b| provider_sort_key(&a.id).cmp(&provider_sort_key(&b.id)));
+        providers.sort_by_key(|a| provider_sort_key(&a.id));
         providers
     }
 

--- a/crates/opendev-history/src/listing.rs
+++ b/crates/opendev-history/src/listing.rs
@@ -50,7 +50,7 @@ impl SessionListing {
             sessions.retain(|s| s.owner_id.as_deref() == Some(owner));
         }
 
-        sessions.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+        sessions.sort_by_key(|b| std::cmp::Reverse(b.updated_at));
         sessions
     }
 
@@ -109,7 +109,7 @@ impl SessionListing {
             let listing = SessionListing::new(projects_dir.join(&workspace));
             all.extend(listing.list_sessions(None, false));
         }
-        all.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+        all.sort_by_key(|b| std::cmp::Reverse(b.updated_at));
         all
     }
 

--- a/crates/opendev-http/src/adapted_client.rs
+++ b/crates/opendev-http/src/adapted_client.rs
@@ -461,18 +461,20 @@ impl AdaptedClient {
                                     index,
                                     call_id,
                                     name,
+                                    initial_args,
                                 } => {
                                     let tc_idx = tool_calls.len();
+                                    let seeded = initial_args.clone().unwrap_or_default();
                                     tool_calls.push(serde_json::json!({
                                         "id": call_id,
                                         "type": "function",
                                         "function": {
                                             "name": name,
-                                            "arguments": "",
+                                            "arguments": seeded.clone(),
                                         }
                                     }));
                                     tool_call_index.insert(*index, tc_idx);
-                                    current_tool_args.insert(tc_idx, String::new());
+                                    current_tool_args.insert(tc_idx, seeded);
                                 }
                                 StreamEvent::FunctionCallDelta { index, delta } => {
                                     if let Some(&tc_idx) = tool_call_index.get(index) {

--- a/crates/opendev-http/src/adapters/anthropic/response.rs
+++ b/crates/opendev-http/src/adapters/anthropic/response.rs
@@ -196,6 +196,7 @@ impl AnthropicAdapter {
                             index,
                             call_id,
                             name,
+                            initial_args: None,
                         })
                     }
                     _ => None,

--- a/crates/opendev-http/src/adapters/chat_completions.rs
+++ b/crates/opendev-http/src/adapters/chat_completions.rs
@@ -43,7 +43,24 @@ impl ChatCompletionsAdapter {
                 for tc_delta in tc_deltas {
                     let idx = tc_delta.get("index").and_then(|i| i.as_u64()).unwrap_or(0) as usize;
 
+                    // OpenAI spec says `arguments` is a JSON-encoded string, but some
+                    // providers (observed: z.ai GLM-5.1 in OpenAI-compat mode) emit a raw
+                    // JSON value instead. Normalize to a string here. Empty/null values
+                    // are skipped so the accumulator isn't polluted with no-op entries.
+                    let args_str = tc_delta
+                        .get("function")
+                        .and_then(|f| f.get("arguments"))
+                        .and_then(|v| match v {
+                            Value::String(s) if !s.is_empty() => Some(s.clone()),
+                            Value::String(_) | Value::Null => None,
+                            other => Some(other.to_string()),
+                        });
+
                     if let Some(id) = tc_delta.get("id").and_then(|i| i.as_str()) {
+                        // First (or only) chunk for this tool call. Providers like z.ai
+                        // GLM-5.1 stuff the full arguments JSON into this same chunk —
+                        // carry it through `initial_args` so the accumulator seeds the
+                        // tool-call's args buffer rather than ending up empty.
                         let name = tc_delta
                             .get("function")
                             .and_then(|f| f.get("name"))
@@ -54,18 +71,12 @@ impl ChatCompletionsAdapter {
                             index: idx,
                             call_id: id.to_string(),
                             name,
+                            initial_args: args_str,
                         });
                     }
 
-                    if let Some(args) = tc_delta
-                        .get("function")
-                        .and_then(|f| f.get("arguments"))
-                        .and_then(|a| a.as_str())
-                    {
-                        return Some(StreamEvent::FunctionCallDelta {
-                            index: idx,
-                            delta: args.to_string(),
-                        });
+                    if let Some(delta) = args_str {
+                        return Some(StreamEvent::FunctionCallDelta { index: idx, delta });
                     }
                 }
             }
@@ -125,3 +136,7 @@ impl super::base::ProviderAdapter for ChatCompletionsAdapter {
         Self::parse_chat_completions_sse(data)
     }
 }
+
+#[cfg(test)]
+#[path = "chat_completions_tests.rs"]
+mod tests;

--- a/crates/opendev-http/src/adapters/chat_completions_tests.rs
+++ b/crates/opendev-http/src/adapters/chat_completions_tests.rs
@@ -1,0 +1,200 @@
+use super::*;
+use crate::streaming::StreamEvent;
+use serde_json::json;
+
+/// Baseline: a standard OpenAI-compat chunk with string-encoded args
+/// must parse into a `FunctionCallDelta` carrying that string verbatim.
+#[test]
+fn test_parse_tool_call_args_as_string_delta() {
+    let chunk = json!({
+        "choices": [{
+            "delta": {
+                "tool_calls": [{
+                    "index": 0,
+                    "function": { "arguments": "{\"file_path\":\"a.txt\"}" }
+                }]
+            }
+        }]
+    });
+    let event = ChatCompletionsAdapter::parse_chat_completions_sse(&chunk);
+    match event {
+        Some(StreamEvent::FunctionCallDelta { index, delta }) => {
+            assert_eq!(index, 0);
+            assert_eq!(delta, "{\"file_path\":\"a.txt\"}");
+        }
+        other => panic!("expected FunctionCallDelta, got {other:?}"),
+    }
+}
+
+/// Regression (z.ai GLM-5.1, observed 2026-04-19): GLM-5.1 in OpenAI-compat
+/// mode emits `function.arguments` as a JSON *object* instead of the
+/// spec-mandated JSON-encoded string. The previous adapter silently dropped
+/// the delta, so the downstream tool-call was dispatched with empty args and
+/// failed param validation on every iteration.
+///
+/// Expected: the adapter serializes the object and emits it as a
+/// `FunctionCallDelta` carrying the JSON string form.
+#[test]
+fn test_parse_tool_call_args_as_object_is_serialized() {
+    let chunk = json!({
+        "choices": [{
+            "delta": {
+                "tool_calls": [{
+                    "index": 0,
+                    "function": {
+                        "arguments": { "file_path": "hello.txt", "content": "world" }
+                    }
+                }]
+            }
+        }]
+    });
+    let event = ChatCompletionsAdapter::parse_chat_completions_sse(&chunk);
+    let (index, delta) = match event {
+        Some(StreamEvent::FunctionCallDelta { index, delta }) => (index, delta),
+        other => panic!("expected FunctionCallDelta, got {other:?}"),
+    };
+    assert_eq!(index, 0);
+    let parsed: serde_json::Value =
+        serde_json::from_str(&delta).expect("emitted delta must be valid JSON");
+    assert_eq!(parsed["file_path"], "hello.txt");
+    assert_eq!(parsed["content"], "world");
+}
+
+/// Defensive: a chunk where `arguments` is present but empty (string "")
+/// should NOT generate an event — empty deltas would pollute the
+/// accumulator with no-op entries.
+#[test]
+fn test_parse_tool_call_empty_string_args_no_event() {
+    let chunk = json!({
+        "choices": [{
+            "delta": {
+                "tool_calls": [{
+                    "index": 0,
+                    "function": { "arguments": "" }
+                }]
+            }
+        }]
+    });
+    let event = ChatCompletionsAdapter::parse_chat_completions_sse(&chunk);
+    assert!(
+        !matches!(event, Some(StreamEvent::FunctionCallDelta { .. })),
+        "empty string args must not emit a FunctionCallDelta, got {event:?}"
+    );
+}
+
+/// First-chunk style (id + name present) still emits `FunctionCallStart`,
+/// regardless of whether args are string or object in that same chunk.
+#[test]
+fn test_parse_tool_call_start_with_object_args() {
+    let chunk = json!({
+        "choices": [{
+            "delta": {
+                "tool_calls": [{
+                    "index": 0,
+                    "id": "call_abc",
+                    "function": {
+                        "name": "Write",
+                        "arguments": { "file_path": "a.txt" }
+                    }
+                }]
+            }
+        }]
+    });
+    let event = ChatCompletionsAdapter::parse_chat_completions_sse(&chunk);
+    match event {
+        Some(StreamEvent::FunctionCallStart {
+            index,
+            call_id,
+            name,
+            ..
+        }) => {
+            assert_eq!(index, 0);
+            assert_eq!(call_id, "call_abc");
+            assert_eq!(name, "Write");
+        }
+        other => panic!("expected FunctionCallStart, got {other:?}"),
+    }
+}
+
+/// Regression (z.ai GLM-5.1, observed 2026-04-19): GLM emits the *entire*
+/// tool call — id, name, AND the full arguments string — in one SSE chunk.
+/// The parser must surface those args (via `initial_args`) so the accumulator
+/// downstream doesn't end up with an empty-args tool call and drop the call.
+///
+/// Real payload captured from z.ai GLM-5.1 chat.completions streaming:
+/// ```json
+/// {"choices":[{"index":0,"delta":{"tool_calls":[{
+///   "id":"call_c3ebf1e3ec8d4a4981472f38","index":0,"type":"function",
+///   "function":{"name":"Write",
+///     "arguments":"{\"file_path\":\"hello.txt\",\"content\":\"world\"}"}
+/// }]}}]}
+/// ```
+#[test]
+fn test_parse_tool_call_id_name_and_full_args_in_one_chunk() {
+    let chunk = json!({
+        "choices": [{
+            "index": 0,
+            "delta": {
+                "tool_calls": [{
+                    "id": "call_c3ebf1e3ec8d4a4981472f38",
+                    "index": 0,
+                    "type": "function",
+                    "function": {
+                        "name": "Write",
+                        "arguments": "{\"file_path\":\"hello.txt\",\"content\":\"world\"}"
+                    }
+                }]
+            }
+        }]
+    });
+    let event = ChatCompletionsAdapter::parse_chat_completions_sse(&chunk);
+    let (call_id, name, initial_args) = match event {
+        Some(StreamEvent::FunctionCallStart {
+            call_id,
+            name,
+            initial_args,
+            ..
+        }) => (call_id, name, initial_args),
+        other => panic!("expected FunctionCallStart carrying initial_args, got {other:?}"),
+    };
+    assert_eq!(call_id, "call_c3ebf1e3ec8d4a4981472f38");
+    assert_eq!(name, "Write");
+    let args_str = initial_args.expect("initial_args must be populated when args present");
+    let parsed: serde_json::Value =
+        serde_json::from_str(&args_str).expect("initial_args must be valid JSON");
+    assert_eq!(parsed["file_path"], "hello.txt");
+    assert_eq!(parsed["content"], "world");
+}
+
+/// id + name chunk without args in the same chunk must still work (the
+/// legacy OpenAI-Chat-Completions pattern — start event carries no args,
+/// args arrive as subsequent `FunctionCallDelta` chunks).
+#[test]
+fn test_parse_tool_call_start_without_args_leaves_initial_args_none() {
+    let chunk = json!({
+        "choices": [{
+            "delta": {
+                "tool_calls": [{
+                    "index": 0,
+                    "id": "call_xyz",
+                    "function": { "name": "Read" }
+                }]
+            }
+        }]
+    });
+    let event = ChatCompletionsAdapter::parse_chat_completions_sse(&chunk);
+    match event {
+        Some(StreamEvent::FunctionCallStart {
+            call_id,
+            initial_args,
+            ..
+        }) => {
+            assert_eq!(call_id, "call_xyz");
+            assert!(
+                initial_args.is_none(),
+                "no args in chunk → initial_args must be None, got {initial_args:?}"
+            );
+        }
+        other => panic!("expected FunctionCallStart, got {other:?}"),
+    }
+}

--- a/crates/opendev-http/src/adapters/openai/mod.rs
+++ b/crates/opendev-http/src/adapters/openai/mod.rs
@@ -173,6 +173,7 @@ impl super::base::ProviderAdapter for OpenAiAdapter {
                     index,
                     call_id,
                     name,
+                    initial_args: None,
                 })
             }
             "response.function_call_arguments.delta" => {

--- a/crates/opendev-http/src/adapters/schema_adapter.rs
+++ b/crates/opendev-http/src/adapters/schema_adapter.rs
@@ -24,28 +24,14 @@ pub fn adapt_for_provider(schemas: &[Value], provider: &str) -> Vec<Value> {
     let mut modified = false;
 
     match provider.as_str() {
-        "gemini" | "google" => {
-            if adapt_gemini(&mut adapted) {
-                modified = true;
-            }
-        }
-        "xai" | "grok" => {
-            if adapt_xai(&mut adapted) {
-                modified = true;
-            }
-        }
-        "mistral" => {
-            if adapt_mistral(&mut adapted) {
-                modified = true;
-            }
-        }
+        "gemini" | "google" => modified |= adapt_gemini(&mut adapted),
+        "xai" | "grok" => modified |= adapt_xai(&mut adapted),
+        "mistral" => modified |= adapt_mistral(&mut adapted),
         _ => {}
     }
 
     // General cleanup for all non-standard providers
-    if general_cleanup(&mut adapted) {
-        modified = true;
-    }
+    modified |= general_cleanup(&mut adapted);
 
     if modified {
         debug!(
@@ -202,16 +188,10 @@ fn flatten_union_types(obj: &mut Value) -> bool {
     for key in keys {
         if let Some(value) = map.get_mut(&key) {
             match value {
-                Value::Object(_) => {
-                    if flatten_union_types(value) {
-                        changed = true;
-                    }
-                }
+                Value::Object(_) => changed |= flatten_union_types(value),
                 Value::Array(arr) => {
                     for item in arr.iter_mut() {
-                        if flatten_union_types(item) {
-                            changed = true;
-                        }
+                        changed |= flatten_union_types(item);
                     }
                 }
                 _ => {}

--- a/crates/opendev-http/src/streaming.rs
+++ b/crates/opendev-http/src/streaming.rs
@@ -16,11 +16,17 @@ pub enum StreamEvent {
     /// between multiple interleaved thinking blocks in a single response).
     ReasoningBlockStart,
     /// A new function/tool call is starting.
-    /// Fields: `(index, call_id, function_name)`
+    ///
+    /// Some providers (e.g., z.ai GLM-5.1 in OpenAI-compat mode) emit the
+    /// *complete* arguments JSON string in the same SSE chunk as `id`/`name`
+    /// rather than as subsequent `FunctionCallDelta` chunks. When that
+    /// happens the adapter sets `initial_args` and the accumulator seeds
+    /// the tool call's args buffer with it before consuming any deltas.
     FunctionCallStart {
         index: usize,
         call_id: String,
         name: String,
+        initial_args: Option<String>,
     },
     /// A chunk of function call arguments.
     FunctionCallDelta { index: usize, delta: String },


### PR DESCRIPTION
## Symptom

Running `opendev -p "Create a file named hello.txt containing 'world'"` against the z.ai coding plan (GLM-5.1) crashed into an infinite tool-retry loop:

```
WARN tool_execution{tool=Write}: Parameter validation failed
  error=The Write tool was called with invalid arguments:
  - file_path: Missing required parameter: 'file_path'
  - content: Missing required parameter: 'content'
```

Three fresh `call_id`s per invocation — the model *was* emitting distinct tool calls, but opendev persisted each one with `arguments: ""`.

## Root cause

Captured raw SSE from z.ai GLM-5.1 — the model emits the entire tool call (`id`, `name`, AND the full `arguments` JSON string) in **one** SSE chunk:

```json
{"choices":[{"index":0,"delta":{"tool_calls":[{
  "id":"call_c3ebf1e3ec8d4a4981472f38", "index":0, "type":"function",
  "function":{"name":"Write",
    "arguments":"{\"file_path\":\"hello.txt\",\"content\":\"world\"}"}
}]}}]}
```

The OpenAI Chat Completions spec permits this — `arguments` can ride along in the same chunk as `id`/`name`. But `ChatCompletionsAdapter::parse_chat_completions_sse` short-circuited on `id` first, returning `FunctionCallStart` with no args and dropping the `arguments` field on the same chunk on the floor. The downstream accumulator only registered the call, never received a `FunctionCallDelta`, so the synthetic `FunctionCallDone` fired at stream end carried an empty string. The agent then called `Write` with no args, validation failed, and the loop retried (hitting the same shape each iteration).

This is exactly the class of persistent-failure loop #89 defends against — and exactly the root cause it explicitly scoped out.

## Fix

Thread in-chunk `arguments` through `FunctionCallStart` via a new `initial_args: Option<String>` field. The accumulator seeds `current_tool_args` with it at registration time, so the synthetic `FunctionCallDone` fired at stream end contains the real args even when the provider never emitted a separate delta chunk.

Secondary robustness: `arguments` is now accepted as either the spec-mandated JSON-encoded string OR a raw JSON value (some providers emit the object directly, e.g. `{"file_path":"a.txt"}` instead of `"{\"file_path\":\"a.txt\"}"`). Empty/null values are skipped so the accumulator isn't polluted with no-op entries.

## Scope

- `StreamEvent::FunctionCallStart` gains `initial_args: Option<String>` (documented on the variant).
- `chat_completions.rs`: single-chunk tool calls now carry args through.
- `openai/mod.rs`, `anthropic/response.rs`: pass `initial_args: None` — those providers emit args as separate delta events, unchanged behavior.
- `adapted_client.rs`: accumulator seeds `current_tool_args` from `initial_args` at registration.
- `streaming_executor.rs`: destructure with `..` — tool execution still triggers from `FunctionCallDone`, so no behavior change in the executor itself.

## Tests

New file `chat_completions_tests.rs` — 6 unit tests covering:
- Baseline string-delta args (unchanged behavior).
- Args as JSON object (serialized to a valid JSON string).
- Empty-string args (no-op — no event emitted).
- id+name without args in same chunk (`initial_args: None`).
- **id+name+full args in one chunk (GLM-5.1 shape) — the regression.**
- id+name+object-args-in-same-chunk (belt-and-braces).

```
cargo test -p opendev-http --lib      # 235 pass, 0 fail
cargo check -p opendev-http           # clean
cargo build --release -p opendev-cli  # succeeds
```

## Real-LLM verification

Repro from first principles using the user's existing `~/.opendev/settings.json` (no env overrides needed):

```
cd /tmp/opendev-glm-fixed
opendev -p "Create a file named hello.txt containing the single word: world. Then read it back and tell me its contents."
```

- **Before:** three `Parameter validation failed` WARNs per run, `hello.txt` never created, hang until agent-loop backoff (from #89) eventually short-circuits.
- **After:** `hello.txt` created with content `world` in ~12 s; clean exit 0.

## Relation to #89 and #90

| PR | Layer | Concern |
|----|-------|---------|
| #89 | agent loop | Backoff / circuit-breaker honoring — prevents runaway when ANY provider fails persistently |
| #90 | Anthropic adapter | Drops `budget_tokens` from adaptive-thinking payload (removes one specific 400 trigger) |
| **this** | Chat Completions adapter | Removes the specific silent-drop of tool-call args that caused the observed GLM-5.1 loop |

All three are complementary; none depends on another. Each addresses a different failure mode observed in the same incident.

## Out of scope

- `post_json_streaming_curl` (the curl-transport path used only for DashScope Coding Plan's `coding-intl.dashscope.aliyuncs.com`) has the same `.as_str()` short-circuit on `arguments`. Leaving for a follow-up PR — no reproducer today, and a fix there would duplicate this PR's logic without a test harness.
- The 8 pre-existing `opendev-tools-impl` `file_search` / `formatter` test failures on `main` are environmental and unchanged by this PR.