### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TOCTOU vulnerability in state snapshot save

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Configuration files containing sensitive data (like MCP OAuth client secrets or access tokens) were written using `std::fs::write` or non-atomic serialization. This creates a Time-of-Check to Time-of-Use (TOCTOU) race condition and defaults to standard user permissions, potentially allowing unauthorized read access on multi-user systems.
 **Learning:** Directly modifying permissions after writing a file still leaves a short window where a local attacker can read or modify the file.
 **Prevention:** Always write sensitive files using an atomic pattern: create a temporary file using `std::fs::OpenOptions` with `.create(true).write(true).truncate(true).mode(0o600)` (on Unix via `std::os::unix::fs::OpenOptionsExt`), write the contents, and then use `std::fs::rename` to atomically replace the destination file.
+
+## 2025-02-27 - Predictable Tempfiles and TOCTOU in Application State Snapshots
+**Vulnerability:** The application state snapshots in `SnapshotPersistence::save` contained sensitive session data (like tool outputs and costs) and were written using predictable temporary filenames (e.g., `.with_extension("json.tmp")`) with default permissions (`std::fs::write`). This allows potential TOCTOU attacks or unintended data exposure on multi-user systems.
+**Learning:** Even internal cache or snapshot files that are quickly renamed can be intercepted if they use predictable filenames and default permissions.
+**Prevention:** Use cryptographically secure random identifiers (e.g., `uuid::Uuid::new_v4()`) for temporary filenames and enforce strict creation permissions (`.mode(0o600)` with `.create_new(true)`) during atomic writes to prevent predictability and race condition windows.

--- a/crates/opendev-agents/src/attachments/collectors/memory.rs
+++ b/crates/opendev-agents/src/attachments/collectors/memory.rs
@@ -88,7 +88,7 @@ fn scan_memory_dir(working_dir: &Path) -> Vec<MemoryFileEntry> {
     }
 
     // Sort by modification time, newest first
-    entries.sort_by(|a, b| b.modified.cmp(&a.modified));
+    entries.sort_by_key(|b| std::cmp::Reverse(b.modified));
     entries
 }
 

--- a/crates/opendev-agents/src/memory_consolidation.rs
+++ b/crates/opendev-agents/src/memory_consolidation.rs
@@ -299,7 +299,7 @@ fn scan_all_memory_files(dir: &Path) -> Vec<MemoryFile> {
     }
 
     // Sort oldest first (process oldest sessions first)
-    files.sort_by(|a, b| a.modified.cmp(&b.modified));
+    files.sort_by_key(|a| a.modified);
     files
 }
 

--- a/crates/opendev-agents/src/subagents/custom_loader/parser.rs
+++ b/crates/opendev-agents/src/subagents/custom_loader/parser.rs
@@ -105,16 +105,13 @@ pub(super) fn parse_simple_yaml(yaml: &str) -> CustomAgentFrontmatter {
                         meta.top_p = value.parse().ok();
                     }
                     "color" => meta.color = Some(value.to_string()),
-                    "tools" => {
-                        if value.is_empty() {
-                            ctx = Context::Tools;
-                        }
+                    "tools" if value.is_empty() => {
+                        ctx = Context::Tools;
                     }
-                    "permission" => {
-                        if value.is_empty() {
-                            ctx = Context::Permission;
-                        }
+                    "permission" if value.is_empty() => {
+                        ctx = Context::Permission;
                     }
+                    "tools" | "permission" => {} // Do nothing if not empty
                     _ => {}
                 }
             }

--- a/crates/opendev-runtime/src/approval/manager.rs
+++ b/crates/opendev-runtime/src/approval/manager.rs
@@ -99,7 +99,7 @@ impl ApprovalRulesManager {
     /// Returns the first matching rule, or `None` if no rule applies.
     pub fn evaluate_command(&self, command: &str) -> Option<&ApprovalRule> {
         let mut enabled: Vec<&ApprovalRule> = self.rules.iter().filter(|r| r.enabled).collect();
-        enabled.sort_by(|a, b| b.priority.cmp(&a.priority));
+        enabled.sort_by_key(|b| std::cmp::Reverse(b.priority));
         enabled.into_iter().find(|r| r.matches(command))
     }
 

--- a/crates/opendev-runtime/src/permissions/mod.rs
+++ b/crates/opendev-runtime/src/permissions/mod.rs
@@ -177,7 +177,7 @@ impl PermissionRuleSet {
         let input = format!("{tool_name}:{args}");
 
         let mut sorted: Vec<&PermissionRule> = self.rules.iter().collect();
-        sorted.sort_by(|a, b| b.priority.cmp(&a.priority));
+        sorted.sort_by_key(|b| std::cmp::Reverse(b.priority));
 
         for rule in sorted {
             // Check directory scope first

--- a/crates/opendev-runtime/src/state_snapshot.rs
+++ b/crates/opendev-runtime/src/state_snapshot.rs
@@ -121,13 +121,27 @@ impl SnapshotPersistence {
             .map_err(|e| format!("Failed to create snapshot dir: {e}"))?;
 
         let path = self.snapshot_path(&snapshot.session_id);
-        let tmp_path = path.with_extension("json.tmp");
+        // Use a secure temporary filename to prevent predictable tempfile attacks
+        let tmp_path = path.with_extension(format!("json.tmp.{}", uuid::Uuid::new_v4()));
 
         let json = serde_json::to_string_pretty(snapshot)
             .map_err(|e| format!("Failed to serialize snapshot: {e}"))?;
 
-        std::fs::write(&tmp_path, &json)
-            .map_err(|e| format!("Failed to write snapshot tmp: {e}"))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            let mut opts = std::fs::OpenOptions::new();
+            opts.write(true).create_new(true).mode(0o600);
+
+            let mut file = opts.open(&tmp_path).map_err(|e| format!("Failed to open snapshot tmp securely: {e}"))?;
+            std::io::Write::write_all(&mut file, json.as_bytes())
+                .map_err(|e| format!("Failed to write snapshot tmp: {e}"))?;
+        }
+        #[cfg(not(unix))]
+        {
+            std::fs::write(&tmp_path, &json)
+                .map_err(|e| format!("Failed to write snapshot tmp: {e}"))?;
+        }
 
         std::fs::rename(&tmp_path, &path).map_err(|e| format!("Failed to rename snapshot: {e}"))?;
 

--- a/crates/opendev-runtime/src/state_snapshot.rs
+++ b/crates/opendev-runtime/src/state_snapshot.rs
@@ -185,7 +185,7 @@ impl SnapshotPersistence {
             }
         }
 
-        snapshots.sort_by(|a, b| b.snapshot_timestamp_ms.cmp(&a.snapshot_timestamp_ms));
+        snapshots.sort_by_key(|b| std::cmp::Reverse(b.snapshot_timestamp_ms));
         snapshots
     }
 

--- a/crates/opendev-runtime/src/state_snapshot.rs
+++ b/crates/opendev-runtime/src/state_snapshot.rs
@@ -133,7 +133,9 @@ impl SnapshotPersistence {
             let mut opts = std::fs::OpenOptions::new();
             opts.write(true).create_new(true).mode(0o600);
 
-            let mut file = opts.open(&tmp_path).map_err(|e| format!("Failed to open snapshot tmp securely: {e}"))?;
+            let mut file = opts
+                .open(&tmp_path)
+                .map_err(|e| format!("Failed to open snapshot tmp securely: {e}"))?;
             std::io::Write::write_all(&mut file, json.as_bytes())
                 .map_err(|e| format!("Failed to write snapshot tmp: {e}"))?;
         }

--- a/crates/opendev-runtime/src/todo/parsing.rs
+++ b/crates/opendev-runtime/src/todo/parsing.rs
@@ -102,7 +102,8 @@ fn extract_numbered_step(line: &str) -> Option<String> {
     let rest = rest.trim_start_matches(|c: char| c.is_ascii_digit());
 
     // Check for separator (. or ) or -)
-    let rest = rest.strip_prefix(". ")
+    let rest = rest
+        .strip_prefix(". ")
         .or_else(|| rest.strip_prefix(") "))
         .or_else(|| rest.strip_prefix(" - "))?;
 

--- a/crates/opendev-runtime/src/todo/parsing.rs
+++ b/crates/opendev-runtime/src/todo/parsing.rs
@@ -102,15 +102,9 @@ fn extract_numbered_step(line: &str) -> Option<String> {
     let rest = rest.trim_start_matches(|c: char| c.is_ascii_digit());
 
     // Check for separator (. or ) or -)
-    let rest = if let Some(s) = rest.strip_prefix(". ") {
-        s
-    } else if let Some(s) = rest.strip_prefix(") ") {
-        s
-    } else if let Some(s) = rest.strip_prefix(" - ") {
-        s
-    } else {
-        return None;
-    };
+    let rest = rest.strip_prefix(". ")
+        .or_else(|| rest.strip_prefix(") "))
+        .or_else(|| rest.strip_prefix(" - "))?;
 
     let text = rest.trim();
     if text.is_empty() {


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: The `opendev-runtime` crate saves application state snapshots containing sensitive session data (tool outputs, session configurations) by writing to a temporary file (`json.tmp`) using default `std::fs::write` permissions before renaming it. This creates a Time-of-Check to Time-of-Use (TOCTOU) race condition and exposes the file to other users on the system with default creation permissions.
🎯 **Impact**: A local attacker could predict the temporary filename (`json.tmp`) and read or overwrite sensitive application state data before it is renamed.
🔧 **Fix**: Updated `crates/opendev-runtime/src/state_snapshot.rs` to generate a secure random temporary filename using `uuid::Uuid::new_v4()`. On Unix systems, the fix uses `std::os::unix::fs::OpenOptionsExt` to enforce `mode(0o600)` and `create_new(true)` during the atomic write phase, ensuring the file is exclusively created and immediately restricted.
✅ **Verification**: Code review passed, tests pass (`cargo test --workspace`), and `cargo clippy` runs cleanly.

Logged in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [3677157153960715601](https://jules.google.com/task/3677157153960715601) started by @bdqnghi*