### PR TITLE
⚡ Bolt: [performance improvement] Extract static ReactMarkdown components to prevent re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2024-04-19 - Isolating High-Frequency Animations
 **Learning:** `setInterval` states (like animation timers running at 100ms intervals) residing in high-level components (like `LandingPage` and `WelcomeScreen`) cause their entire component subtrees to re-render ten times a second. This leads to massive layout thrashing and poor responsiveness, especially when inputs are present.
 **Action:** Always extract high-frequency local state updates (like spinners or timers) into their own isolated, leaf-level components using `React.memo()`. Keep state strictly co-located with the UI that depends on it.
+
+## 2024-04-26 - React Component Referential Stability for Performance
+**Learning:** Defining complex static configuration objects, such as `components` mapping for `ReactMarkdown`, directly inside functional components causes React to generate a new object on every render. This forces deep re-renders of the component and all its children, leading to severe layout thrashing and performance degradation, especially in frequently-rendered UI components (like documentation or messages).
+**Action:** Always extract static configuration objects out of the component function to maintain referential stability and prevent unnecessary re-renders.

--- a/crates/opendev-runtime/src/approval/manager.rs
+++ b/crates/opendev-runtime/src/approval/manager.rs
@@ -99,7 +99,7 @@ impl ApprovalRulesManager {
     /// Returns the first matching rule, or `None` if no rule applies.
     pub fn evaluate_command(&self, command: &str) -> Option<&ApprovalRule> {
         let mut enabled: Vec<&ApprovalRule> = self.rules.iter().filter(|r| r.enabled).collect();
-        enabled.sort_by(|a, b| b.priority.cmp(&a.priority));
+        enabled.sort_by_key(|b| std::cmp::Reverse(b.priority));
         enabled.into_iter().find(|r| r.matches(command))
     }
 

--- a/crates/opendev-runtime/src/permissions/mod.rs
+++ b/crates/opendev-runtime/src/permissions/mod.rs
@@ -177,7 +177,7 @@ impl PermissionRuleSet {
         let input = format!("{tool_name}:{args}");
 
         let mut sorted: Vec<&PermissionRule> = self.rules.iter().collect();
-        sorted.sort_by(|a, b| b.priority.cmp(&a.priority));
+        sorted.sort_by_key(|b| std::cmp::Reverse(b.priority));
 
         for rule in sorted {
             // Check directory scope first

--- a/crates/opendev-runtime/src/state_snapshot.rs
+++ b/crates/opendev-runtime/src/state_snapshot.rs
@@ -169,7 +169,7 @@ impl SnapshotPersistence {
             }
         }
 
-        snapshots.sort_by(|a, b| b.snapshot_timestamp_ms.cmp(&a.snapshot_timestamp_ms));
+        snapshots.sort_by_key(|b| std::cmp::Reverse(b.snapshot_timestamp_ms));
         snapshots
     }
 

--- a/crates/opendev-runtime/src/todo/parsing.rs
+++ b/crates/opendev-runtime/src/todo/parsing.rs
@@ -102,15 +102,9 @@ fn extract_numbered_step(line: &str) -> Option<String> {
     let rest = rest.trim_start_matches(|c: char| c.is_ascii_digit());
 
     // Check for separator (. or ) or -)
-    let rest = if let Some(s) = rest.strip_prefix(". ") {
-        s
-    } else if let Some(s) = rest.strip_prefix(") ") {
-        s
-    } else if let Some(s) = rest.strip_prefix(" - ") {
-        s
-    } else {
-        return None;
-    };
+    let rest = rest.strip_prefix(". ")
+        .or_else(|| rest.strip_prefix(") "))
+        .or_else(|| rest.strip_prefix(" - "))?;
 
     let text = rest.trim();
     if text.is_empty() {

--- a/web-ui/src/components/CodeWiki/DocumentationContent.tsx
+++ b/web-ui/src/components/CodeWiki/DocumentationContent.tsx
@@ -17,6 +17,80 @@ interface DocumentationContentProps {
   wikiPage: WikiPage;
 }
 
+const MARKDOWN_COMPONENTS: any = {
+
+            h1: ({ children, ...props }: any) => (
+              <h1 className="text-3xl font-bold text-gray-900 mt-10 mb-6 leading-tight" {...props}>
+                {children}
+              </h1>
+            ),
+            h2: ({ children, ...props }: any) => (
+              <h2 className="text-2xl font-bold text-gray-900 mt-8 mb-4 leading-tight" {...props}>
+                {children}
+              </h2>
+            ),
+            h3: ({ children, ...props }: any) => (
+              <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3 leading-tight" {...props}>
+                {children}
+              </h3>
+            ),
+            p: ({ children, ...props }: any) => (
+              <p className="text-base text-gray-700 mb-4 leading-relaxed" {...props}>
+                {children}
+              </p>
+            ),
+            ul: ({ children, ...props }: any) => (
+              <ul className="list-disc pl-6 mb-4 space-y-2" {...props}>
+                {children}
+              </ul>
+            ),
+            ol: ({ children, ...props }: any) => (
+              <ol className="list-decimal pl-6 mb-4 space-y-2" {...props}>
+                {children}
+              </ol>
+            ),
+            li: ({ children, ...props }: any) => (
+              <li className="text-gray-700 leading-relaxed" {...props}>
+                {children}
+              </li>
+            ),
+            code: ({ children, className, ...props }: any) => {
+              const isInline = !className;
+              return isInline ? (
+                <code
+                  className="bg-purple-50 text-purple-900 px-1.5 py-0.5 rounded text-sm font-mono"
+                  {...props}
+                >
+                  {children}
+                </code>
+              ) : (
+                <code
+                  className="block bg-gray-900 text-gray-100 p-4 rounded-lg overflow-x-auto text-sm font-mono leading-relaxed"
+                  {...props}
+                >
+                  {children}
+                </code>
+              );
+            },
+            blockquote: ({ children, ...props }: any) => (
+              <blockquote
+                className="border-l-4 border-purple-500 pl-4 py-2 my-4 bg-purple-50 text-gray-700 italic"
+                {...props}
+              >
+                {children}
+              </blockquote>
+            ),
+            a: ({ children, ...props }: any) => (
+              <a
+                className="text-purple-600 hover:text-purple-800 underline"
+                {...props}
+              >
+                {children}
+              </a>
+            ),
+
+};
+
 export function DocumentationContent({ wikiPage }: DocumentationContentProps) {
   return (
     <div className="max-w-4xl mx-auto px-8 py-8">
@@ -62,77 +136,7 @@ export function DocumentationContent({ wikiPage }: DocumentationContentProps) {
       <article className="prose prose-lg max-w-none">
         <ReactMarkdown
           className="text-gray-800 leading-relaxed"
-          components={{
-            h1: ({ children, ...props }) => (
-              <h1 className="text-3xl font-bold text-gray-900 mt-10 mb-6 leading-tight" {...props}>
-                {children}
-              </h1>
-            ),
-            h2: ({ children, ...props }) => (
-              <h2 className="text-2xl font-bold text-gray-900 mt-8 mb-4 leading-tight" {...props}>
-                {children}
-              </h2>
-            ),
-            h3: ({ children, ...props }) => (
-              <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3 leading-tight" {...props}>
-                {children}
-              </h3>
-            ),
-            p: ({ children, ...props }) => (
-              <p className="text-base text-gray-700 mb-4 leading-relaxed" {...props}>
-                {children}
-              </p>
-            ),
-            ul: ({ children, ...props }) => (
-              <ul className="list-disc pl-6 mb-4 space-y-2" {...props}>
-                {children}
-              </ul>
-            ),
-            ol: ({ children, ...props }) => (
-              <ol className="list-decimal pl-6 mb-4 space-y-2" {...props}>
-                {children}
-              </ol>
-            ),
-            li: ({ children, ...props }) => (
-              <li className="text-gray-700 leading-relaxed" {...props}>
-                {children}
-              </li>
-            ),
-            code: ({ children, className, ...props }) => {
-              const isInline = !className;
-              return isInline ? (
-                <code
-                  className="bg-purple-50 text-purple-900 px-1.5 py-0.5 rounded text-sm font-mono"
-                  {...props}
-                >
-                  {children}
-                </code>
-              ) : (
-                <code
-                  className="block bg-gray-900 text-gray-100 p-4 rounded-lg overflow-x-auto text-sm font-mono leading-relaxed"
-                  {...props}
-                >
-                  {children}
-                </code>
-              );
-            },
-            blockquote: ({ children, ...props }) => (
-              <blockquote
-                className="border-l-4 border-purple-500 pl-4 py-2 my-4 bg-purple-50 text-gray-700 italic"
-                {...props}
-              >
-                {children}
-              </blockquote>
-            ),
-            a: ({ children, ...props }) => (
-              <a
-                className="text-purple-600 hover:text-purple-800 underline"
-                {...props}
-              >
-                {children}
-              </a>
-            ),
-          }}
+          components={MARKDOWN_COMPONENTS}
         >
           {wikiPage.content}
         </ReactMarkdown>


### PR DESCRIPTION
Closing as superseded. All changes in this PR (MARKDOWN_COMPONENTS extraction, sort_by_key refactors, todo/parsing.rs refactor) are already on main via earlier merges (#78, #120, #141, etc.). The duplicate MARKDOWN_COMPONENTS definition introduced by a prior merge conflict was fixed directly on main in d64245f.