### PR TITLE
fix: non-interactive hangs on extended-thinking models

### DIFF
--- a/crates/opendev-agents/src/attachments/collectors/memory.rs
+++ b/crates/opendev-agents/src/attachments/collectors/memory.rs
@@ -88,7 +88,7 @@ fn scan_memory_dir(working_dir: &Path) -> Vec<MemoryFileEntry> {
     }
 
     // Sort by modification time, newest first
-    entries.sort_by(|a, b| b.modified.cmp(&a.modified));
+    entries.sort_by_key(|e| std::cmp::Reverse(e.modified));
     entries
 }
 

--- a/crates/opendev-agents/src/llm_calls/mod.rs
+++ b/crates/opendev-agents/src/llm_calls/mod.rs
@@ -71,7 +71,9 @@ impl LlmCaller {
         messages.retain(|msg| msg.get("_msg_class").and_then(|v| v.as_str()) != Some("internal"));
         for msg in &mut messages {
             if let Some(obj) = msg.as_object_mut() {
-                obj.retain(|k, _| !k.starts_with('_'));
+                // Preserve _thinking_blocks: needed by the Anthropic adapter to echo
+                // encrypted thinking signatures back on multi-turn requests.
+                obj.retain(|k, _| !k.starts_with('_') || k == "_thinking_blocks");
             }
         }
         messages

--- a/crates/opendev-agents/src/llm_calls/tests.rs
+++ b/crates/opendev-agents/src/llm_calls/tests.rs
@@ -298,17 +298,16 @@ fn test_internal_removal_exposes_merge() {
 fn test_clean_messages_preserves_thinking_blocks() {
     // _thinking_blocks carries Anthropic's encrypted thinking signatures for
     // multi-turn echo-back and must survive clean_messages.
-    let blocks = serde_json::json!([{"type": "thinking", "thinking": "...", "signature": "sig123"}]);
-    let messages = vec![
-        serde_json::json!({
-            "role": "assistant",
-            "content": null,
-            "tool_calls": [{"id": "tc-1", "function": {"name": "read_file", "arguments": "{}"}}],
-            "reasoning_content": "some reasoning",
-            "_thinking_blocks": blocks.clone(),
-            "_other_internal": "should be stripped",
-        }),
-    ];
+    let blocks =
+        serde_json::json!([{"type": "thinking", "thinking": "...", "signature": "sig123"}]);
+    let messages = vec![serde_json::json!({
+        "role": "assistant",
+        "content": null,
+        "tool_calls": [{"id": "tc-1", "function": {"name": "read_file", "arguments": "{}"}}],
+        "reasoning_content": "some reasoning",
+        "_thinking_blocks": blocks.clone(),
+        "_other_internal": "should be stripped",
+    })];
     let cleaned = LlmCaller::clean_messages(&messages);
     assert_eq!(cleaned.len(), 1);
     let msg = &cleaned[0];

--- a/crates/opendev-agents/src/llm_calls/tests.rs
+++ b/crates/opendev-agents/src/llm_calls/tests.rs
@@ -293,3 +293,27 @@ fn test_internal_removal_exposes_merge() {
     assert_eq!(cleaned.len(), 1);
     assert_eq!(cleaned[0]["content"], "part one\n\npart two");
 }
+
+#[test]
+fn test_clean_messages_preserves_thinking_blocks() {
+    // _thinking_blocks carries Anthropic's encrypted thinking signatures for
+    // multi-turn echo-back and must survive clean_messages.
+    let blocks = serde_json::json!([{"type": "thinking", "thinking": "...", "signature": "sig123"}]);
+    let messages = vec![
+        serde_json::json!({
+            "role": "assistant",
+            "content": null,
+            "tool_calls": [{"id": "tc-1", "function": {"name": "read_file", "arguments": "{}"}}],
+            "reasoning_content": "some reasoning",
+            "_thinking_blocks": blocks.clone(),
+            "_other_internal": "should be stripped",
+        }),
+    ];
+    let cleaned = LlmCaller::clean_messages(&messages);
+    assert_eq!(cleaned.len(), 1);
+    let msg = &cleaned[0];
+    assert_eq!(msg.get("_thinking_blocks").unwrap(), &blocks);
+    assert!(msg.get("_other_internal").is_none());
+    assert!(msg.get("tool_calls").is_some());
+    assert_eq!(msg.get("reasoning_content").unwrap(), "some reasoning");
+}

--- a/crates/opendev-agents/src/memory_consolidation.rs
+++ b/crates/opendev-agents/src/memory_consolidation.rs
@@ -299,7 +299,7 @@ fn scan_all_memory_files(dir: &Path) -> Vec<MemoryFile> {
     }
 
     // Sort oldest first (process oldest sessions first)
-    files.sort_by(|a, b| a.modified.cmp(&b.modified));
+    files.sort_by_key(|f| f.modified);
     files
 }
 

--- a/crates/opendev-agents/src/react_loop/config.rs
+++ b/crates/opendev-agents/src/react_loop/config.rs
@@ -25,7 +25,7 @@ pub struct ReactLoopConfig {
 impl Default for ReactLoopConfig {
     fn default() -> Self {
         Self {
-            max_iterations: None, // Unlimited by default (matches Python)
+            max_iterations: Some(50), // 50 iterations is generous for real tasks; prevents headless hangs
             max_nudge_attempts: 3,
             max_todo_nudges: 4,
             original_task: None,

--- a/crates/opendev-agents/src/react_loop/config_tests.rs
+++ b/crates/opendev-agents/src/react_loop/config_tests.rs
@@ -3,7 +3,7 @@ use super::*;
 #[test]
 fn test_default_config() {
     let config = ReactLoopConfig::default();
-    assert!(config.max_iterations.is_none());
+    assert_eq!(config.max_iterations, Some(50));
     assert_eq!(config.max_nudge_attempts, 3);
     assert_eq!(config.max_todo_nudges, 4);
     assert!(config.permission.is_empty());

--- a/crates/opendev-agents/src/react_loop/execution.rs
+++ b/crates/opendev-agents/src/react_loop/execution.rs
@@ -272,15 +272,20 @@ impl ReactLoop {
                     return Ok(AgentResult::interrupted(messages.clone()));
                 }
                 TurnResult::MaxIterations => {
-                    // This path is reached from process_iteration's secondary
-                    // limit check. The primary wind-down happens above, but
-                    // this acts as a safety net.
                     iter_metrics.total_duration_ms = iter_start.elapsed().as_millis() as u64;
                     self.push_metrics(iter_metrics);
-                    return Ok(AgentResult::fail(
-                        "Max iterations reached without completion",
+                    let max = self.config.max_iterations.unwrap_or(0);
+                    warn!(
+                        iteration = state.iteration,
+                        max_iterations = max,
+                        "React loop hit max_iterations ceiling — aborting"
+                    );
+                    let mut result = AgentResult::fail(
+                        format!("Reached max_iterations ({max}) without completion"),
                         messages.clone(),
-                    ));
+                    );
+                    result.completion_status = Some("max_iterations_reached".to_string());
+                    return Ok(result);
                 }
                 TurnResult::Complete { content, status } => {
                     iter_metrics.total_duration_ms = iter_start.elapsed().as_millis() as u64;

--- a/crates/opendev-agents/src/react_loop/helpers/mod.rs
+++ b/crates/opendev-agents/src/react_loop/helpers/mod.rs
@@ -129,10 +129,17 @@ impl ReactLoop {
 
         // Append assistant message to history
         if let Some(ref msg) = response.message {
-            let raw_content = msg.get("content").and_then(|c| c.as_str()).unwrap_or("");
+            // Prefer the full content value (string or array); fall back to "" for safety.
+            // An array content is returned by Anthropic when extended thinking is active —
+            // stripping it to "" loses thinking signatures, breaking multi-turn requests.
+            let content_value = msg
+                .get("content")
+                .filter(|v| !v.is_null())
+                .cloned()
+                .unwrap_or(serde_json::Value::String(String::new()));
             let mut assistant_msg = serde_json::json!({
                 "role": "assistant",
-                "content": raw_content,
+                "content": content_value,
             });
             if let Some(tool_calls) = msg.get("tool_calls")
                 && !tool_calls.is_null()
@@ -143,6 +150,12 @@ impl ReactLoop {
                 && !reasoning.is_null()
             {
                 assistant_msg["reasoning_content"] = reasoning.clone();
+            }
+            // Preserve raw thinking blocks (with Anthropic `signature` fields) for multi-turn echo-back.
+            if let Some(blocks) = msg.get("_thinking_blocks")
+                && !blocks.is_null()
+            {
+                assistant_msg["_thinking_blocks"] = blocks.clone();
             }
             messages.push(assistant_msg);
         }

--- a/crates/opendev-agents/src/react_loop/helpers/tests.rs
+++ b/crates/opendev-agents/src/react_loop/helpers/tests.rs
@@ -312,7 +312,7 @@ fn test_process_iteration_resets_no_tool_counter_on_tool_call() {
 #[test]
 fn test_default_config() {
     let config = ReactLoopConfig::default();
-    assert!(config.max_iterations.is_none());
+    assert_eq!(config.max_iterations, Some(50));
     assert_eq!(config.max_nudge_attempts, 3);
     assert_eq!(config.max_todo_nudges, 4);
 }

--- a/crates/opendev-agents/src/react_loop/phases/completion.rs
+++ b/crates/opendev-agents/src/react_loop/phases/completion.rs
@@ -111,6 +111,18 @@ where
                 append_nudge(messages, &nudge);
                 react_loop.push_metrics(iter_metrics);
                 return LoopAction::Continue;
+            } else {
+                warn!(
+                    spawned = state.bg_tasks_spawned,
+                    completed = bg_completed,
+                    pending,
+                    "Background tasks still pending after 10 nudges — aborting to prevent hang"
+                );
+                return LoopAction::Return(Err(
+                    crate::traits::AgentError::Other(
+                        format!("{pending} background task(s) did not complete after 10 wait nudges — aborting"),
+                    )
+                ));
             }
         }
     }

--- a/crates/opendev-agents/src/react_loop/phases/completion.rs
+++ b/crates/opendev-agents/src/react_loop/phases/completion.rs
@@ -118,11 +118,9 @@ where
                     pending,
                     "Background tasks still pending after 10 nudges — aborting to prevent hang"
                 );
-                return LoopAction::Return(Err(
-                    crate::traits::AgentError::Other(
-                        format!("{pending} background task(s) did not complete after 10 wait nudges — aborting"),
-                    )
-                ));
+                return LoopAction::Return(Err(crate::traits::AgentError::Other(format!(
+                    "{pending} background task(s) did not complete after 10 wait nudges — aborting"
+                ))));
             }
         }
     }

--- a/crates/opendev-agents/src/subagents/custom_loader/parser.rs
+++ b/crates/opendev-agents/src/subagents/custom_loader/parser.rs
@@ -105,15 +105,11 @@ pub(super) fn parse_simple_yaml(yaml: &str) -> CustomAgentFrontmatter {
                         meta.top_p = value.parse().ok();
                     }
                     "color" => meta.color = Some(value.to_string()),
-                    "tools" => {
-                        if value.is_empty() {
-                            ctx = Context::Tools;
-                        }
+                    "tools" if value.is_empty() => {
+                        ctx = Context::Tools;
                     }
-                    "permission" => {
-                        if value.is_empty() {
-                            ctx = Context::Permission;
-                        }
+                    "permission" if value.is_empty() => {
+                        ctx = Context::Permission;
                     }
                     _ => {}
                 }

--- a/crates/opendev-cli/src/runners.rs
+++ b/crates/opendev-cli/src/runners.rs
@@ -101,6 +101,9 @@ pub async fn run_non_interactive(
         }
     };
 
+    // No TUI to drain the approval channel — auto-execute every tool.
+    agent_runtime.disable_tool_approvals();
+
     // Connect MCP servers (best-effort, failures are logged)
     agent_runtime.start_mcp_connections();
 
@@ -278,8 +281,6 @@ pub async fn run_interactive(
         session_manager.create_session();
     }
 
-    let _ = dangerously_skip_permissions; // Will be wired to approval system
-
     // Create agent runtime (prompt composer is initialized inside)
     let mut agent_runtime =
         match runtime::AgentRuntime::new(config.clone(), working_dir, session_manager) {
@@ -289,6 +290,10 @@ pub async fn run_interactive(
                 std::process::exit(1);
             }
         };
+
+    if dangerously_skip_permissions {
+        agent_runtime.disable_tool_approvals();
+    }
 
     // Connect MCP servers (best-effort, failures are logged)
     agent_runtime.start_mcp_connections();

--- a/crates/opendev-cli/src/runtime/mod.rs
+++ b/crates/opendev-cli/src/runtime/mod.rs
@@ -718,6 +718,15 @@ impl AgentRuntime {
 }
 
 impl AgentRuntime {
+    /// Drop the tool-approval channel sender so Bash and MCP tools auto-execute
+    /// without prompting. The corresponding receiver is only consumed by the TUI;
+    /// callers that don't run a TUI (non-interactive `-p` mode, or interactive with
+    /// `--dangerously-skip-permissions`) must call this or the approval gate will
+    /// block forever on a response that never comes.
+    pub fn disable_tool_approvals(&mut self) {
+        self.tool_approval_tx = None;
+    }
+
     /// Compose the system prompt for the current turn.
     ///
     /// Uses the section cache: `Static` sections are resolved once per session,

--- a/crates/opendev-cli/src/setup/interactive_menu.rs
+++ b/crates/opendev-cli/src/setup/interactive_menu.rs
@@ -114,12 +114,10 @@ impl InteractiveMenu {
                             self.search_query.clear();
                             self.filter_items();
                         }
-                        KeyCode::Enter => {
-                            if !self.filtered_items.is_empty() {
-                                let id = self.filtered_items[self.selected_index].0.clone();
-                                self.clear_display(&mut stdout, num_lines)?;
-                                return Ok(Some(id));
-                            }
+                        KeyCode::Enter if !self.filtered_items.is_empty() => {
+                            let id = self.filtered_items[self.selected_index].0.clone();
+                            self.clear_display(&mut stdout, num_lines)?;
+                            return Ok(Some(id));
                         }
                         KeyCode::Backspace => {
                             self.search_query.pop();
@@ -133,42 +131,32 @@ impl InteractiveMenu {
                             self.search_query.push(c);
                             self.filter_items();
                         }
-                        KeyCode::Up => {
-                            if !self.filtered_items.is_empty() {
-                                self.selected_index =
-                                    (self.selected_index + self.filtered_items.len() - 1)
-                                        % self.filtered_items.len();
-                            }
+                        KeyCode::Up if !self.filtered_items.is_empty() => {
+                            self.selected_index = (self.selected_index + self.filtered_items.len()
+                                - 1)
+                                % self.filtered_items.len();
                         }
-                        KeyCode::Down => {
-                            if !self.filtered_items.is_empty() {
-                                self.selected_index =
-                                    (self.selected_index + 1) % self.filtered_items.len();
-                            }
+                        KeyCode::Down if !self.filtered_items.is_empty() => {
+                            self.selected_index =
+                                (self.selected_index + 1) % self.filtered_items.len();
                         }
                         _ => {}
                     }
                 } else {
                     match key.code {
-                        KeyCode::Up => {
-                            if !self.filtered_items.is_empty() {
-                                self.selected_index =
-                                    (self.selected_index + self.filtered_items.len() - 1)
-                                        % self.filtered_items.len();
-                            }
+                        KeyCode::Up if !self.filtered_items.is_empty() => {
+                            self.selected_index = (self.selected_index + self.filtered_items.len()
+                                - 1)
+                                % self.filtered_items.len();
                         }
-                        KeyCode::Down => {
-                            if !self.filtered_items.is_empty() {
-                                self.selected_index =
-                                    (self.selected_index + 1) % self.filtered_items.len();
-                            }
+                        KeyCode::Down if !self.filtered_items.is_empty() => {
+                            self.selected_index =
+                                (self.selected_index + 1) % self.filtered_items.len();
                         }
-                        KeyCode::Enter => {
-                            if !self.filtered_items.is_empty() {
-                                let id = self.filtered_items[self.selected_index].0.clone();
-                                self.clear_display(&mut stdout, num_lines)?;
-                                return Ok(Some(id));
-                            }
+                        KeyCode::Enter if !self.filtered_items.is_empty() => {
+                            let id = self.filtered_items[self.selected_index].0.clone();
+                            self.clear_display(&mut stdout, num_lines)?;
+                            return Ok(Some(id));
                         }
                         KeyCode::Char('/') => {
                             self.search_mode = true;

--- a/crates/opendev-cli/src/setup/rail_ui.rs
+++ b/crates/opendev-cli/src/setup/rail_ui.rs
@@ -242,11 +242,9 @@ fn read_password() -> io::Result<String> {
                     let _ = writeln!(stdout);
                     return Ok(password);
                 }
-                KeyCode::Backspace => {
-                    if password.pop().is_some() {
-                        let _ = write!(stdout, "\x08 \x08");
-                        stdout.flush()?;
-                    }
+                KeyCode::Backspace if password.pop().is_some() => {
+                    let _ = write!(stdout, "\x08 \x08");
+                    stdout.flush()?;
                 }
                 KeyCode::Char('c') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
                     terminal::disable_raw_mode()?;

--- a/crates/opendev-http/src/adapted_client.rs
+++ b/crates/opendev-http/src/adapted_client.rs
@@ -11,6 +11,16 @@ use crate::streaming::{StreamCallback, StreamEvent};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
 
+/// Per-block accumulator for Anthropic extended-thinking output during SSE streaming.
+///
+/// `index` matches the Anthropic SSE `index` field; `signature` is filled in by
+/// `signature_delta` (final delta of the block); `text` accumulates `thinking_delta`.
+struct ThinkingBlockBuf {
+    index: usize,
+    signature: Option<String>,
+    text: String,
+}
+
 /// HTTP client with provider-specific request/response adaptation.
 ///
 /// Wraps `HttpClient` and an optional `ProviderAdapter`. When an adapter
@@ -355,6 +365,8 @@ impl AdaptedClient {
         // Track which tool call indices have already received FunctionCallDone
         // (OpenAI Responses API emits them natively; Chat Completions does not).
         let mut done_indices: std::collections::HashSet<usize> = std::collections::HashSet::new();
+        // Anthropic extended thinking: track blocks with signatures for multi-turn echo-back.
+        let mut thinking_blocks: Vec<ThinkingBlockBuf> = Vec::new();
         let mut line_buf = String::new();
         let mut event_type: Option<String> = None;
 
@@ -449,6 +461,22 @@ impl AdaptedClient {
                                 StreamEvent::TextDelta(text) => {
                                     accumulated_text.push_str(text);
                                 }
+                                StreamEvent::ThinkingBlockStart { index, signature } => {
+                                    thinking_blocks.push(ThinkingBlockBuf {
+                                        index: *index,
+                                        signature: signature.clone(),
+                                        text: String::new(),
+                                    });
+                                    if !accumulated_reasoning.is_empty() {
+                                        accumulated_reasoning.push_str("\n\n");
+                                    }
+                                    // Also fan out a ReasoningBlockStart so UI/TUI handlers
+                                    // that predate ThinkingBlockStart still see the separator.
+                                    // The original ThinkingBlockStart is dispatched after the
+                                    // match — current subscribers ignore it, but new ones can
+                                    // opt in to read the signature.
+                                    callback.on_event(&StreamEvent::ReasoningBlockStart);
+                                }
                                 StreamEvent::ReasoningBlockStart => {
                                     if !accumulated_reasoning.is_empty() {
                                         accumulated_reasoning.push_str("\n\n");
@@ -456,6 +484,19 @@ impl AdaptedClient {
                                 }
                                 StreamEvent::ReasoningDelta(text) => {
                                     accumulated_reasoning.push_str(text);
+                                    if let Some(last) = thinking_blocks.last_mut() {
+                                        last.text.push_str(text);
+                                    }
+                                }
+                                StreamEvent::ThinkingSignature { index, signature } => {
+                                    // Anthropic sends the encrypted signature as the final
+                                    // `signature_delta` before `content_block_stop`; without
+                                    // echoing it back, multi-turn requests fail with 400.
+                                    if let Some(entry) =
+                                        thinking_blocks.iter_mut().find(|b| b.index == *index)
+                                    {
+                                        entry.signature = Some(signature.clone());
+                                    }
                                 }
                                 StreamEvent::FunctionCallStart {
                                     index,
@@ -624,6 +665,19 @@ impl AdaptedClient {
                 });
                 if !accumulated_reasoning.is_empty() {
                     message["reasoning_content"] = serde_json::Value::String(accumulated_reasoning);
+                }
+                // Include structured thinking blocks (with signatures) for Anthropic multi-turn.
+                if !thinking_blocks.is_empty() {
+                    let blocks: Vec<serde_json::Value> = thinking_blocks
+                        .iter()
+                        .map(|b| {
+                            crate::adapters::anthropic::response::build_thinking_block(
+                                &b.text,
+                                b.signature.as_deref(),
+                            )
+                        })
+                        .collect();
+                    message["_thinking_blocks"] = serde_json::Value::Array(blocks);
                 }
                 // Finalize tool call arguments
                 if !tool_calls.is_empty() {

--- a/crates/opendev-http/src/adapters/anthropic/mod.rs
+++ b/crates/opendev-http/src/adapters/anthropic/mod.rs
@@ -7,7 +7,7 @@
 //! - Image blocks using Anthropic's native `source` format
 
 mod request;
-mod response;
+pub(crate) mod response;
 
 use serde_json::{Value, json};
 

--- a/crates/opendev-http/src/adapters/anthropic/request.rs
+++ b/crates/opendev-http/src/adapters/anthropic/request.rs
@@ -175,10 +175,9 @@ impl AnthropicAdapter {
                                 msg.get("reasoning_content").and_then(|r| r.as_str())
                                 && !reasoning.is_empty()
                             {
-                                content_blocks.push(json!({
-                                    "type": "thinking",
-                                    "thinking": reasoning
-                                }));
+                                content_blocks.push(super::response::build_thinking_block(
+                                    reasoning, None,
+                                ));
                             }
 
                             // Add text content if present
@@ -238,10 +237,9 @@ impl AnthropicAdapter {
                                     msg.get("reasoning_content").and_then(|r| r.as_str())
                                     && !reasoning.is_empty()
                                 {
-                                    content_blocks.push(json!({
-                                        "type": "thinking",
-                                        "thinking": reasoning
-                                    }));
+                                    content_blocks.push(super::response::build_thinking_block(
+                                        reasoning, None,
+                                    ));
                                 }
 
                                 if !text.is_empty() {

--- a/crates/opendev-http/src/adapters/anthropic/request.rs
+++ b/crates/opendev-http/src/adapters/anthropic/request.rs
@@ -175,9 +175,8 @@ impl AnthropicAdapter {
                                 msg.get("reasoning_content").and_then(|r| r.as_str())
                                 && !reasoning.is_empty()
                             {
-                                content_blocks.push(super::response::build_thinking_block(
-                                    reasoning, None,
-                                ));
+                                content_blocks
+                                    .push(super::response::build_thinking_block(reasoning, None));
                             }
 
                             // Add text content if present

--- a/crates/opendev-http/src/adapters/anthropic/response.rs
+++ b/crates/opendev-http/src/adapters/anthropic/response.rs
@@ -199,8 +199,10 @@ impl AnthropicAdapter {
                     "thinking" => {
                         let index =
                             data.get("index").and_then(|i| i.as_u64()).unwrap_or(0) as usize;
-                        let signature =
-                            cb.get("signature").and_then(|s| s.as_str()).map(String::from);
+                        let signature = cb
+                            .get("signature")
+                            .and_then(|s| s.as_str())
+                            .map(String::from);
                         Some(StreamEvent::ThinkingBlockStart { index, signature })
                     }
                     "tool_use" => {

--- a/crates/opendev-http/src/adapters/anthropic/response.rs
+++ b/crates/opendev-http/src/adapters/anthropic/response.rs
@@ -8,6 +8,18 @@ use serde_json::{Value, json};
 
 use super::AnthropicAdapter;
 
+/// Build a single Anthropic `thinking` content block.
+///
+/// Used by both the streaming synthesizer (which has signatures from `signature_delta`)
+/// and the request path's fallback (which only has plain reasoning text).
+pub(crate) fn build_thinking_block(text: &str, signature: Option<&str>) -> Value {
+    let mut b = json!({"type": "thinking", "thinking": text});
+    if let Some(s) = signature {
+        b["signature"] = Value::String(s.to_string());
+    }
+    b
+}
+
 impl AnthropicAdapter {
     /// Convert Anthropic response to Chat Completions format.
     pub(super) fn response_to_chat_completions(response: Value) -> Value {
@@ -142,6 +154,12 @@ impl AnthropicAdapter {
                         let text = delta.get("thinking")?.as_str()?;
                         Some(StreamEvent::ReasoningDelta(text.to_string()))
                     }
+                    "signature_delta" => {
+                        let index =
+                            data.get("index").and_then(|i| i.as_u64()).unwrap_or(0) as usize;
+                        let signature = delta.get("signature")?.as_str()?.to_string();
+                        Some(StreamEvent::ThinkingSignature { index, signature })
+                    }
                     "input_json_delta" => {
                         let index =
                             data.get("index").and_then(|i| i.as_u64()).unwrap_or(0) as usize;
@@ -178,7 +196,13 @@ impl AnthropicAdapter {
                 let cb = data.get("content_block")?;
                 let block_type = cb.get("type").and_then(|t| t.as_str())?;
                 match block_type {
-                    "thinking" => Some(StreamEvent::ReasoningBlockStart),
+                    "thinking" => {
+                        let index =
+                            data.get("index").and_then(|i| i.as_u64()).unwrap_or(0) as usize;
+                        let signature =
+                            cb.get("signature").and_then(|s| s.as_str()).map(String::from);
+                        Some(StreamEvent::ThinkingBlockStart { index, signature })
+                    }
                     "tool_use" => {
                         let index =
                             data.get("index").and_then(|i| i.as_u64()).unwrap_or(0) as usize;

--- a/crates/opendev-http/src/adapters/anthropic/tests.rs
+++ b/crates/opendev-http/src/adapters/anthropic/tests.rs
@@ -428,3 +428,48 @@ fn test_thinking_blocks_signature_roundtrip() {
     assert_eq!(assistant_content[1]["type"], "text");
     assert_eq!(assistant_content[2]["type"], "tool_use");
 }
+
+#[test]
+fn test_parse_stream_event_signature_delta() {
+    let adapter = AnthropicAdapter::new();
+    // Verify signature_delta content_block_delta emits ThinkingSignature
+    let data = serde_json::json!({
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+            "type": "signature_delta",
+            "signature": "EucBtest_signature_abc123"
+        }
+    });
+    let event = adapter.parse_stream_event("content_block_delta", &data);
+    match event {
+        Some(crate::streaming::StreamEvent::ThinkingSignature { index, signature }) => {
+            assert_eq!(index, 0);
+            assert_eq!(signature, "EucBtest_signature_abc123");
+        }
+        other => panic!("Expected ThinkingSignature, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_parse_stream_event_thinking_block_start() {
+    let adapter = AnthropicAdapter::new();
+    let data = serde_json::json!({
+        "type": "content_block_start",
+        "index": 0,
+        "content_block": {
+            "type": "thinking",
+            "thinking": "",
+            "signature": ""
+        }
+    });
+    let event = adapter.parse_stream_event("content_block_start", &data);
+    match event {
+        Some(crate::streaming::StreamEvent::ThinkingBlockStart { index, signature }) => {
+            assert_eq!(index, 0);
+            // signature is Some("") from the empty placeholder in content_block_start
+            assert_eq!(signature, Some("".to_string()));
+        }
+        other => panic!("Expected ThinkingBlockStart, got {:?}", other),
+    }
+}

--- a/crates/opendev-http/src/streaming.rs
+++ b/crates/opendev-http/src/streaming.rs
@@ -15,6 +15,22 @@ pub enum StreamEvent {
     /// A new reasoning/thinking block is starting (used to insert separators
     /// between multiple interleaved thinking blocks in a single response).
     ReasoningBlockStart,
+    /// A new Anthropic-native thinking block is starting.
+    ///
+    /// Carries the block index and the `signature` field required for multi-turn
+    /// echo-back. The streaming client accumulates these into `_thinking_blocks`
+    /// for inclusion in the synthesized response. UI code should treat this as
+    /// `ReasoningBlockStart` for display purposes.
+    ThinkingBlockStart {
+        index: usize,
+        signature: Option<String>,
+    },
+    /// The signature for a completed thinking block (from Anthropic `signature_delta`).
+    ///
+    /// Anthropic sends the encrypted signature as the final delta for a thinking
+    /// block before `content_block_stop`. Must be preserved in `_thinking_blocks`
+    /// for valid multi-turn requests.
+    ThinkingSignature { index: usize, signature: String },
     /// A new function/tool call is starting.
     ///
     /// Some providers (e.g., z.ai GLM-5.1 in OpenAI-compat mode) emit the

--- a/crates/opendev-runtime/src/approval/manager.rs
+++ b/crates/opendev-runtime/src/approval/manager.rs
@@ -99,7 +99,7 @@ impl ApprovalRulesManager {
     /// Returns the first matching rule, or `None` if no rule applies.
     pub fn evaluate_command(&self, command: &str) -> Option<&ApprovalRule> {
         let mut enabled: Vec<&ApprovalRule> = self.rules.iter().filter(|r| r.enabled).collect();
-        enabled.sort_by(|a, b| b.priority.cmp(&a.priority));
+        enabled.sort_by_key(|r| std::cmp::Reverse(r.priority));
         enabled.into_iter().find(|r| r.matches(command))
     }
 

--- a/crates/opendev-runtime/src/permissions/mod.rs
+++ b/crates/opendev-runtime/src/permissions/mod.rs
@@ -177,7 +177,7 @@ impl PermissionRuleSet {
         let input = format!("{tool_name}:{args}");
 
         let mut sorted: Vec<&PermissionRule> = self.rules.iter().collect();
-        sorted.sort_by(|a, b| b.priority.cmp(&a.priority));
+        sorted.sort_by_key(|r| std::cmp::Reverse(r.priority));
 
         for rule in sorted {
             // Check directory scope first

--- a/crates/opendev-runtime/src/state_snapshot.rs
+++ b/crates/opendev-runtime/src/state_snapshot.rs
@@ -169,7 +169,7 @@ impl SnapshotPersistence {
             }
         }
 
-        snapshots.sort_by(|a, b| b.snapshot_timestamp_ms.cmp(&a.snapshot_timestamp_ms));
+        snapshots.sort_by_key(|s| std::cmp::Reverse(s.snapshot_timestamp_ms));
         snapshots
     }
 

--- a/crates/opendev-runtime/src/todo/parsing.rs
+++ b/crates/opendev-runtime/src/todo/parsing.rs
@@ -106,10 +106,8 @@ fn extract_numbered_step(line: &str) -> Option<String> {
         s
     } else if let Some(s) = rest.strip_prefix(") ") {
         s
-    } else if let Some(s) = rest.strip_prefix(" - ") {
-        s
     } else {
-        return None;
+        rest.strip_prefix(" - ")?
     };
 
     let text = rest.trim();

--- a/crates/opendev-tools-impl/src/agents/tool_search.rs
+++ b/crates/opendev-tools-impl/src/agents/tool_search.rs
@@ -127,7 +127,7 @@ impl BaseTool for ToolSearchTool {
                 })
                 .collect();
 
-            scored.sort_by(|a, b| b.0.cmp(&a.0));
+            scored.sort_by_key(|s| std::cmp::Reverse(s.0));
             scored
                 .into_iter()
                 .take(max_results)

--- a/crates/opendev-tools-impl/src/file_list.rs
+++ b/crates/opendev-tools-impl/src/file_list.rs
@@ -211,7 +211,7 @@ impl BaseTool for FileListTool {
         }
 
         // Sort by modification time (most recent first)
-        files.sort_by(|a, b| b.1.cmp(&a.1));
+        files.sort_by_key(|f| std::cmp::Reverse(f.1));
 
         let total = files.len();
         let truncated = total > Self::MAX_RESULTS;

--- a/crates/opendev-tools-impl/src/file_search/backends.rs
+++ b/crates/opendev-tools-impl/src/file_search/backends.rs
@@ -298,7 +298,7 @@ impl GrepTool {
                         unique_paths.push((key, mtime));
                     }
                 }
-                unique_paths.sort_by(|a, b| b.1.cmp(&a.1));
+                unique_paths.sort_by_key(|p| std::cmp::Reverse(p.1));
                 for (key, _) in &unique_paths {
                     output.push_str(key);
                     output.push('\n');

--- a/crates/opendev-tools-impl/src/session.rs
+++ b/crates/opendev-tools-impl/src/session.rs
@@ -174,7 +174,7 @@ fn action_list(
     }
 
     // Sort by most recent first
-    sessions.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+    sessions.sort_by_key(|s| std::cmp::Reverse(s.updated_at));
 
     if sessions.is_empty() {
         return ToolResult::ok("No past sessions found.".to_string());

--- a/crates/opendev-tools-impl/src/web_search/parser.rs
+++ b/crates/opendev-tools-impl/src/web_search/parser.rs
@@ -81,10 +81,8 @@ fn extract_domain(url: &str) -> Option<String> {
     // Simple domain extraction without pulling in the `url` crate.
     let after_scheme = if let Some(rest) = url.strip_prefix("https://") {
         rest
-    } else if let Some(rest) = url.strip_prefix("http://") {
-        rest
     } else {
-        return None;
+        url.strip_prefix("http://")?
     };
     let domain = after_scheme.split('/').next().unwrap_or("");
     let domain = domain.split(':').next().unwrap_or(domain); // strip port

--- a/crates/opendev-tui/src/app/key_handler.rs
+++ b/crates/opendev-tui/src/app/key_handler.rs
@@ -220,17 +220,13 @@ impl App {
             }
 
             // Focus navigation: left
-            (_, KeyCode::Char('h')) | (_, KeyCode::Left) => {
-                if self.state.task_watcher_focus > 0 {
-                    self.state.task_watcher_focus -= 1;
-                }
+            (_, KeyCode::Char('h')) | (_, KeyCode::Left) if self.state.task_watcher_focus > 0 => {
+                self.state.task_watcher_focus -= 1;
             }
             // Focus navigation: right
-            (_, KeyCode::Char('l')) | (_, KeyCode::Right) => {
-                if total_tasks > 0 {
-                    self.state.task_watcher_focus =
-                        (self.state.task_watcher_focus + 1).min(total_tasks - 1);
-                }
+            (_, KeyCode::Char('l')) | (_, KeyCode::Right) if total_tasks > 0 => {
+                self.state.task_watcher_focus =
+                    (self.state.task_watcher_focus + 1).min(total_tasks - 1);
             }
             // Focus navigation: up (move by cols)
             (_, KeyCode::Char('k')) | (_, KeyCode::Up) => {
@@ -692,55 +688,44 @@ impl App {
             // Shift+Enter — insert newline in input buffer
             // iTerm2 (and many terminals) map Shift+Enter to Ctrl+J (ASCII LF).
             // Alt+Enter sends Enter with ALT modifier. Both insert a newline.
-            (KeyModifiers::CONTROL, KeyCode::Char('j')) => {
-                if !self.state.agent_active {
-                    self.state
-                        .input_buffer
-                        .insert(self.state.input_cursor, '\n');
-                    self.state.input_cursor += '\n'.len_utf8();
-                }
+            (KeyModifiers::CONTROL, KeyCode::Char('j')) if !self.state.agent_active => {
+                self.state
+                    .input_buffer
+                    .insert(self.state.input_cursor, '\n');
+                self.state.input_cursor += '\n'.len_utf8();
             }
             (m, KeyCode::Enter)
-                if m.contains(KeyModifiers::SHIFT) || m.contains(KeyModifiers::ALT) =>
+                if (m.contains(KeyModifiers::SHIFT) || m.contains(KeyModifiers::ALT))
+                    && !self.state.agent_active =>
             {
-                if !self.state.agent_active {
-                    self.state
-                        .input_buffer
-                        .insert(self.state.input_cursor, '\n');
-                    self.state.input_cursor += '\n'.len_utf8();
-                }
+                self.state
+                    .input_buffer
+                    .insert(self.state.input_cursor, '\n');
+                self.state.input_cursor += '\n'.len_utf8();
             }
             // Enter — accept autocomplete, submit message, or execute slash command
             (_, KeyCode::Enter) => self.handle_key_enter(),
             // Backspace
-            (_, KeyCode::Backspace) => {
-                if self.state.input_cursor > 0 {
-                    self.state.input_cursor =
-                        Self::prev_char_boundary(&self.state.input_buffer, self.state.input_cursor);
-                    self.state.input_buffer.remove(self.state.input_cursor);
-                    self.update_autocomplete();
-                }
+            (_, KeyCode::Backspace) if self.state.input_cursor > 0 => {
+                self.state.input_cursor =
+                    Self::prev_char_boundary(&self.state.input_buffer, self.state.input_cursor);
+                self.state.input_buffer.remove(self.state.input_cursor);
+                self.update_autocomplete();
             }
             // Delete
-            (_, KeyCode::Delete) => {
-                if self.state.input_cursor < self.state.input_buffer.len() {
-                    self.state.input_buffer.remove(self.state.input_cursor);
-                    self.update_autocomplete();
-                }
+            (_, KeyCode::Delete) if self.state.input_cursor < self.state.input_buffer.len() => {
+                self.state.input_buffer.remove(self.state.input_cursor);
+                self.update_autocomplete();
             }
             // Left arrow
-            (_, KeyCode::Left) => {
-                if self.state.input_cursor > 0 {
-                    self.state.input_cursor =
-                        Self::prev_char_boundary(&self.state.input_buffer, self.state.input_cursor);
-                }
+            (_, KeyCode::Left) if self.state.input_cursor > 0 => {
+                self.state.input_cursor =
+                    Self::prev_char_boundary(&self.state.input_buffer, self.state.input_cursor);
             }
             // Right arrow
-            (_, KeyCode::Right) => {
-                if self.state.input_cursor < self.state.input_buffer.len() {
-                    self.state.input_cursor =
-                        Self::next_char_boundary(&self.state.input_buffer, self.state.input_cursor);
-                }
+            (_, KeyCode::Right) if self.state.input_cursor < self.state.input_buffer.len() => {
+                self.state.input_cursor =
+                    Self::next_char_boundary(&self.state.input_buffer, self.state.input_cursor);
             }
             // Home
             (_, KeyCode::Home) => {
@@ -873,11 +858,9 @@ impl App {
                 self.state.user_scrolled = false;
             }
             // Ctrl+T — toggle todo panel expanded/collapsed
-            (KeyModifiers::CONTROL, KeyCode::Char('t')) => {
-                if !self.state.todo_items.is_empty() {
-                    self.state.todo_expanded = !self.state.todo_expanded;
-                    self.state.dirty = true;
-                }
+            (KeyModifiers::CONTROL, KeyCode::Char('t')) if !self.state.todo_items.is_empty() => {
+                self.state.todo_expanded = !self.state.todo_expanded;
+                self.state.dirty = true;
             }
             // Alt+B — toggle task watcher subpanel
             (KeyModifiers::ALT, KeyCode::Char('b')) => {

--- a/crates/opendev-tui/src/history.rs
+++ b/crates/opendev-tui/src/history.rs
@@ -92,7 +92,7 @@ impl CommandHistory {
         }
 
         // Sort by last_used descending (most recent first)
-        self.entries.sort_by(|a, b| b.last_used.cmp(&a.last_used));
+        self.entries.sort_by_key(|e| std::cmp::Reverse(e.last_used));
 
         // Trim to max size
         if self.entries.len() > MAX_HISTORY_ENTRIES {

--- a/crates/opendev-tui/src/managers/background_agents.rs
+++ b/crates/opendev-tui/src/managers/background_agents.rs
@@ -207,7 +207,7 @@ impl BackgroundAgentManager {
     /// Get all tasks sorted by start time (newest first).
     pub fn all_tasks(&self) -> Vec<&BackgroundAgentTask> {
         let mut tasks: Vec<&BackgroundAgentTask> = self.tasks.values().collect();
-        tasks.sort_by(|a, b| b.started_at.cmp(&a.started_at));
+        tasks.sort_by_key(|t| std::cmp::Reverse(t.started_at));
         tasks
     }
 

--- a/crates/opendev-tui/src/managers/background_tasks.rs
+++ b/crates/opendev-tui/src/managers/background_tasks.rs
@@ -235,7 +235,7 @@ impl BackgroundTaskManager {
     /// Get all tasks sorted by start time (newest first).
     pub fn all_tasks(&self) -> Vec<&TaskStatus> {
         let mut tasks: Vec<&TaskStatus> = self.tasks.values().collect();
-        tasks.sort_by(|a, b| b.started_at.cmp(&a.started_at));
+        tasks.sort_by_key(|t| std::cmp::Reverse(t.started_at));
         tasks
     }
 


### PR DESCRIPTION
## Summary

Three independent root causes that conspired to make the agent hang indefinitely in non-interactive (`-p`) mode on Anthropic extended-thinking models (`claude-sonnet-4-6`).

- **Anthropic thinking signatures** are now captured during SSE streaming, carried through message history, and echoed back on multi-turn requests. Without this, the second API call fails with `400: messages.N.content.0.thinking.signature: Field required`, triggering a retry storm.
- **Tool-approval channel** is now disabled in non-interactive mode and when `--dangerously-skip-permissions` is passed. The receiver was only consumed by the TUI; in `-p` mode the first `Bash` call would block forever on a response that never arrived.
- **`max_iterations`** now defaults to `Some(50)` (was unlimited) and the background-task wait nudge bails out after 10 attempts, providing a hard ceiling on doom loops.

Each fix is in its own commit; together they let `01-bugfix-calculator` complete end-to-end on `claude-sonnet-4-6` in ~14s (was: 240s timeout into kill).

## Commits

| | |
|---|---|
| `e2b5fa8` | `fix(opendev-agents): cap max_iterations and bail out on stalled background tasks` |
| `e3f9814` | `fix: preserve Anthropic thinking signatures across multi-turn calls` |
| `c5f60ec` | `fix(opendev-cli): prevent non-interactive hang on Bash tool approval` |
| `c4478cd` | `style: cargo fmt --all` |
| `f96e607` | `chore: satisfy clippy 1.95 lints workspace-wide` |

The last commit fixes 21 pre-existing lint errors that landed on `main` after the rust toolchain bumped to 1.95 (`unnecessary_sort_by`, `collapsible_match`, `question_mark`). All fixes are mechanical `cargo clippy --fix` suggestions; required to unblock CI but easy to split out to a separate PR if preferred.

## Behavior change details

### `_thinking_blocks` carrier field

The Anthropic adapter writes raw thinking blocks (with `signature`) to a private `_thinking_blocks` field on assistant messages during response synthesis, then reads them back when building the next request body. `clean_messages` previously stripped every `_`-prefixed key as "internal metadata"; the fix whitelists `_thinking_blocks` while keeping `_msg_class` etc. stripped.

A small helper `build_thinking_block(text, signature)` in `adapters/anthropic/response.rs` is shared by the streaming synthesizer and both fallback branches in `request.rs` to avoid duplicating the JSON shape.

### Non-interactive approval bypass

`AgentRuntime::tool_approval_tx` is now `None` whenever no consumer would drain the corresponding receiver:
- `run_non_interactive` (the `-p` mode entrypoint) always disables it.
- `run_interactive` disables it when `--dangerously-skip-permissions` is set; the flag had been declared but never wired up (`let _ = ...`).

A new `AgentRuntime::disable_tool_approvals()` method centralises this so the two callsites share one doc-commented entry point.

### Safety cap

`ReactLoopConfig::default()` was `max_iterations: None` (unlimited) — a leftover from porting the Python implementation. `Some(50)` is generous for real tasks, hard-stops doom loops, and the `MaxIterations` arm now logs the ceiling and tags the result with `completion_status="max_iterations_reached"` so callers can distinguish budget exhaustion from real failure.

The `task_complete` background-task wait nudge previously had no upper bound; it now aborts with an error after 10 attempts.

## Test plan

- [x] `cargo test -p opendev-agents -p opendev-http -p opendev-cli` — 779 passed, 0 failed
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo build --release -p opendev-cli` — clean
- [x] All 9 CI checks green (Format, plan, Check ×3 OS, Clippy, Test ×3 OS)
- [x] End-to-end: `opendev -p "..." --dangerously-skip-permissions` against `claude-sonnet-4-6` on a 3-test pytest fixup — completes in ~14s with exit 0, all tests pass
- [x] New unit tests cover `signature_delta` parsing, `thinking` `content_block_start`, and `clean_messages` `_thinking_blocks` preservation