### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability in state snapshots

### DIFF
--- a/crates/opendev-runtime/src/state_snapshot.rs
+++ b/crates/opendev-runtime/src/state_snapshot.rs
@@ -126,8 +126,24 @@ impl SnapshotPersistence {
         let json = serde_json::to_string_pretty(snapshot)
             .map_err(|e| format!("Failed to serialize snapshot: {e}"))?;
 
-        std::fs::write(&tmp_path, &json)
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            let mut opts = std::fs::OpenOptions::new();
+            opts.write(true).create(true).truncate(true).mode(0o600);
+            std::io::Write::write_all(
+                &mut opts
+                    .open(&tmp_path)
+                    .map_err(|e| format!("Failed to open snapshot tmp: {e}"))?,
+                json.as_bytes(),
+            )
             .map_err(|e| format!("Failed to write snapshot tmp: {e}"))?;
+        }
+        #[cfg(not(unix))]
+        {
+            std::fs::write(&tmp_path, &json)
+                .map_err(|e| format!("Failed to write snapshot tmp: {e}"))?;
+        }
 
         std::fs::rename(&tmp_path, &path).map_err(|e| format!("Failed to rename snapshot: {e}"))?;
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `AppStateSnapshot` data contains sensitive information like internal variables, states, and history which were being saved using standard file permissions which allows any user to read it before `chmod` restrictions.
🎯 Impact: Privilege escalation / Sensitive info read access by an attacker locally.
🔧 Fix: Utilized an atomic approach of defining permissions concurrently when creating a temporary file via `std::os::unix::fs::OpenOptionsExt::mode(0o600)`.
✅ Verification: Ensure the test suites run normally and verifying that the `session_snapshot.json` files have the correct permission (600) directly on write.

---
*PR created automatically by Jules for task [17036418452690226128](https://jules.google.com/task/17036418452690226128) started by @bdqnghi*