### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix predictable tmp filename and TOCTOU in auth store

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Configuration files containing sensitive data (like MCP OAuth client secrets or access tokens) were written using `std::fs::write` or non-atomic serialization. This creates a Time-of-Check to Time-of-Use (TOCTOU) race condition and defaults to standard user permissions, potentially allowing unauthorized read access on multi-user systems.
 **Learning:** Directly modifying permissions after writing a file still leaves a short window where a local attacker can read or modify the file.
 **Prevention:** Always write sensitive files using an atomic pattern: create a temporary file using `std::fs::OpenOptions` with `.create(true).write(true).truncate(true).mode(0o600)` (on Unix via `std::os::unix::fs::OpenOptionsExt`), write the contents, and then use `std::fs::rename` to atomically replace the destination file.
+
+## 2025-05-02 - Secure Atomic File Writing with create_new
+**Vulnerability:** When writing sensitive configuration files (like `auth.json`) atomically, using predictable temporary extensions (like `.tmp`) combined with `std::fs::OpenOptions` `.create(true).truncate(true)` makes the operation vulnerable to symlink attacks or TOCTOU exploitation by other users on a shared system.
+**Learning:** Even if `mode(0o600)` is specified, `.create(true)` allows an attacker to pre-create a symlink at the predictable `.tmp` location, causing the write to follow the symlink and overwrite an unintended file.
+**Prevention:** Always use random extensions (e.g. `uuid::Uuid::new_v4()`) for temporary files and strictly use `.create_new(true)` with `std::fs::OpenOptions` so that the atomic write safely fails if the temporary file already exists (preventing symlink attacks or accidental overwrites).

--- a/crates/opendev-http/src/auth.rs
+++ b/crates/opendev-http/src/auth.rs
@@ -187,7 +187,9 @@ impl CredentialStore {
         }
 
         // Write to temp file, then rename (atomic)
-        let tmp_path = self.path.with_extension(format!("tmp.{}", uuid::Uuid::new_v4()));
+        let tmp_path = self
+            .path
+            .with_extension(format!("tmp.{}", uuid::Uuid::new_v4()));
         let json = serde_json::to_string_pretty(data)?;
 
         #[cfg(unix)]

--- a/crates/opendev-http/src/auth.rs
+++ b/crates/opendev-http/src/auth.rs
@@ -187,20 +187,22 @@ impl CredentialStore {
         }
 
         // Write to temp file, then rename (atomic)
-        let tmp_path = self.path.with_extension("tmp");
+        let tmp_path = self.path.with_extension(format!("tmp.{}", uuid::Uuid::new_v4()));
         let json = serde_json::to_string_pretty(data)?;
 
         #[cfg(unix)]
         {
             use std::os::unix::fs::OpenOptionsExt;
             let mut opts = std::fs::OpenOptions::new();
-            opts.write(true).create(true).truncate(true).mode(0o600);
+            opts.write(true).create_new(true).mode(0o600);
             std::io::Write::write_all(&mut opts.open(&tmp_path)?, json.as_bytes())?;
         }
 
         #[cfg(not(unix))]
         {
-            std::fs::write(&tmp_path, &json)?;
+            let mut opts = std::fs::OpenOptions::new();
+            opts.write(true).create_new(true);
+            std::io::Write::write_all(&mut opts.open(&tmp_path)?, json.as_bytes())?;
         }
 
         std::fs::rename(&tmp_path, &self.path)?;

--- a/crates/opendev-http/src/user_store.rs
+++ b/crates/opendev-http/src/user_store.rs
@@ -129,12 +129,14 @@ impl UserStore {
             {
                 use std::os::unix::fs::OpenOptionsExt;
                 let mut opts = std::fs::OpenOptions::new();
-                opts.write(true).create(true).truncate(true).mode(0o600);
+                opts.write(true).create_new(true).mode(0o600);
                 std::io::Write::write_all(&mut opts.open(&tmp_path)?, b"{}")?;
             }
             #[cfg(not(unix))]
             {
-                std::fs::write(&tmp_path, "{}")?;
+                let mut opts = std::fs::OpenOptions::new();
+                opts.write(true).create_new(true);
+                std::io::Write::write_all(&mut opts.open(&tmp_path)?, b"{}")?;
             }
 
             std::fs::rename(&tmp_path, &self.users_file)?;
@@ -181,12 +183,14 @@ impl UserStore {
         {
             use std::os::unix::fs::OpenOptionsExt;
             let mut opts = std::fs::OpenOptions::new();
-            opts.write(true).create(true).truncate(true).mode(0o600);
+            opts.write(true).create_new(true).mode(0o600);
             std::io::Write::write_all(&mut opts.open(&tmp_path)?, json.as_bytes())?;
         }
         #[cfg(not(unix))]
         {
-            std::fs::write(&tmp_path, json)?;
+            let mut opts = std::fs::OpenOptions::new();
+            opts.write(true).create_new(true);
+            std::io::Write::write_all(&mut opts.open(&tmp_path)?, json.as_bytes())?;
         }
 
         std::fs::rename(&tmp_path, &self.users_file)?;


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: When atomically writing sensitive configuration files (`auth.json` and `users.json`), the application used predictable temporary extensions (`.tmp` or static configurations on `not(unix)`) combined with `std::fs::OpenOptions` `.create(true).truncate(true)`. This makes the operation vulnerable to symlink attacks or Time-of-Check to Time-of-Use (TOCTOU) exploitation on shared systems.
🎯 Impact: An attacker could pre-create a symlink at the predictable temporary file location, causing the atomic write process to follow the symlink and overwrite unintended files, bypassing intended write restrictions or escalating privileges.
🔧 Fix: Updated temporary file generation to use random extensions (`uuid::Uuid::new_v4()`) to prevent predictable symlinks. Modified the file creation options in both UNIX and non-UNIX architectures to strictly use `.create_new(true)`, ensuring that the atomic write safely fails if the temporary file already exists, completely eliminating the race condition.
✅ Verification: Ran `cargo test --workspace --lib --tests` and `cargo clippy --workspace -- -D warnings`. Code logic and security constraints manually verified via AST trace and CLI tools.

---
*PR created automatically by Jules for task [10418585089806952959](https://jules.google.com/task/10418585089806952959) started by @bdqnghi*