### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability in state snapshots

### DIFF
--- a/crates/opendev-runtime/src/state_snapshot.rs
+++ b/crates/opendev-runtime/src/state_snapshot.rs
@@ -121,13 +121,37 @@ impl SnapshotPersistence {
             .map_err(|e| format!("Failed to create snapshot dir: {e}"))?;
 
         let path = self.snapshot_path(&snapshot.session_id);
-        let tmp_path = path.with_extension("json.tmp");
+        let tmp_filename = format!("{}_{}.json.tmp", snapshot.session_id, uuid::Uuid::new_v4());
+        let tmp_path = self.snapshot_dir.join(tmp_filename);
 
         let json = serde_json::to_string_pretty(snapshot)
             .map_err(|e| format!("Failed to serialize snapshot: {e}"))?;
 
-        std::fs::write(&tmp_path, &json)
-            .map_err(|e| format!("Failed to write snapshot tmp: {e}"))?;
+        #[cfg(unix)]
+        {
+            use std::io::Write;
+            use std::os::unix::fs::OpenOptionsExt;
+            let mut file = std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .mode(0o600)
+                .open(&tmp_path)
+                .map_err(|e| format!("Failed to create snapshot tmp file: {e}"))?;
+            file.write_all(json.as_bytes())
+                .map_err(|e| format!("Failed to write snapshot tmp: {e}"))?;
+        }
+
+        #[cfg(not(unix))]
+        {
+            use std::io::Write;
+            let mut file = std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&tmp_path)
+                .map_err(|e| format!("Failed to create snapshot tmp file: {e}"))?;
+            file.write_all(json.as_bytes())
+                .map_err(|e| format!("Failed to write snapshot tmp: {e}"))?;
+        }
 
         std::fs::rename(&tmp_path, &path).map_err(|e| format!("Failed to rename snapshot: {e}"))?;
 


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: Insecure temporary file creation and incorrect default permissions in `state_snapshot.rs`. Writing state snapshots using `std::fs::write` or without restricted creation permissions leaves a brief TOCTOU window and exposes sensitive session data to other users on the system via the default `umask`. Predictable filenames like `.json.tmp` also invite symlink attacks.
🎯 **Impact**: A malicious local user could exploit the symlink attack to overwrite arbitrary files, or simply read the sensitive snapshot data due to the missing permission constraints.
🔧 **Fix**: Implemented atomic secure file creation using `std::fs::OpenOptions` with `.create_new(true)` and `.mode(0o600)` (on Unix) to enforce strict ownership and prevent TOCTOU race conditions. Filenames are also now randomized using `uuid::Uuid::new_v4()`.
✅ **Verification**: Run `cargo test --workspace` to ensure snapshots continue to function, and verify logic correctly leverages `uuid` for randomization and atomic rename.

---
*PR created automatically by Jules for task [13766765161458642849](https://jules.google.com/task/13766765161458642849) started by @bdqnghi*