### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TOCTOU vulnerability in state snapshot persistence

### DIFF
--- a/crates/opendev-runtime/src/state_snapshot.rs
+++ b/crates/opendev-runtime/src/state_snapshot.rs
@@ -121,13 +121,39 @@ impl SnapshotPersistence {
             .map_err(|e| format!("Failed to create snapshot dir: {e}"))?;
 
         let path = self.snapshot_path(&snapshot.session_id);
-        let tmp_path = path.with_extension("json.tmp");
+        let tmp_path = path.with_extension(format!("json.tmp.{}", uuid::Uuid::new_v4()));
 
         let json = serde_json::to_string_pretty(snapshot)
             .map_err(|e| format!("Failed to serialize snapshot: {e}"))?;
 
-        std::fs::write(&tmp_path, &json)
-            .map_err(|e| format!("Failed to write snapshot tmp: {e}"))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            let mut opts = std::fs::OpenOptions::new();
+            opts.write(true).create_new(true).mode(0o600);
+
+            let mut file = opts
+                .open(&tmp_path)
+                .map_err(|e| format!("Failed to open snapshot tmp: {e}"))?;
+
+            use std::io::Write;
+            file.write_all(json.as_bytes())
+                .map_err(|e| format!("Failed to write snapshot tmp: {e}"))?;
+        }
+
+        #[cfg(not(unix))]
+        {
+            let mut opts = std::fs::OpenOptions::new();
+            opts.write(true).create_new(true);
+
+            let mut file = opts
+                .open(&tmp_path)
+                .map_err(|e| format!("Failed to open snapshot tmp: {e}"))?;
+
+            use std::io::Write;
+            file.write_all(json.as_bytes())
+                .map_err(|e| format!("Failed to write snapshot tmp: {e}"))?;
+        }
 
         std::fs::rename(&tmp_path, &path).map_err(|e| format!("Failed to rename snapshot: {e}"))?;
 


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix TOCTOU vulnerability in state snapshot persistence

🚨 Severity: CRITICAL
💡 Vulnerability: State snapshots in `crates/opendev-runtime/src/state_snapshot.rs` were being written to disk using `std::fs::write` with default permissions. Since state snapshots can contain sensitive information (like API keys if they're embedded in tool outputs or session IDs), creating a file this way leaves a Time-of-Check to Time-of-Use (TOCTOU) race condition window where local attackers could read or symlink the temporary file before permissions could be restricted.
🎯 Impact: Local privilege escalation / information disclosure. Other users on the same system could potentially read sensitive session state.
🔧 Fix: Replaced `std::fs::write` with a secure atomic file creation pattern using `std::fs::OpenOptions`. Generated a randomized temporary filename using `uuid::Uuid::new_v4()` to prevent symlink attacks. Crucially, on Unix systems, the fix uses `std::os::unix::fs::OpenOptionsExt::mode(0o600)` and `.create_new(true)` to guarantee the file is created atomically with restricted (owner-only) read/write permissions from the moment it hits the disk.
✅ Verification: Ran `cargo test --workspace` to ensure no regressions in snapshot persistence logic. Reviewed the source code changes to confirm `OpenOptions` is correctly blocking on existence (`create_new`) and enforcing `0o600` on Unix platforms.

---
*PR created automatically by Jules for task [12112178562287533816](https://jules.google.com/task/12112178562287533816) started by @bdqnghi*