### PR TITLE
⚡ Bolt: [performance improvement] Optimize ReactMarkdown in DocumentationContent

### DIFF
--- a/crates/opendev-agents/src/attachments/collectors/memory.rs
+++ b/crates/opendev-agents/src/attachments/collectors/memory.rs
@@ -88,7 +88,7 @@ fn scan_memory_dir(working_dir: &Path) -> Vec<MemoryFileEntry> {
     }
 
     // Sort by modification time, newest first
-    entries.sort_by(|a, b| b.modified.cmp(&a.modified));
+    entries.sort_by_key(|b| std::cmp::Reverse(b.modified));
     entries
 }
 

--- a/crates/opendev-agents/src/memory_consolidation.rs
+++ b/crates/opendev-agents/src/memory_consolidation.rs
@@ -299,7 +299,7 @@ fn scan_all_memory_files(dir: &Path) -> Vec<MemoryFile> {
     }
 
     // Sort oldest first (process oldest sessions first)
-    files.sort_by(|a, b| a.modified.cmp(&b.modified));
+    files.sort_by_key(|a| a.modified);
     files
 }
 

--- a/crates/opendev-agents/src/subagents/custom_loader/parser.rs
+++ b/crates/opendev-agents/src/subagents/custom_loader/parser.rs
@@ -105,15 +105,11 @@ pub(super) fn parse_simple_yaml(yaml: &str) -> CustomAgentFrontmatter {
                         meta.top_p = value.parse().ok();
                     }
                     "color" => meta.color = Some(value.to_string()),
-                    "tools" => {
-                        if value.is_empty() {
-                            ctx = Context::Tools;
-                        }
+                    "tools" if value.is_empty() => {
+                        ctx = Context::Tools;
                     }
-                    "permission" => {
-                        if value.is_empty() {
-                            ctx = Context::Permission;
-                        }
+                    "permission" if value.is_empty() => {
+                        ctx = Context::Permission;
                     }
                     _ => {}
                 }

--- a/crates/opendev-runtime/src/approval/manager.rs
+++ b/crates/opendev-runtime/src/approval/manager.rs
@@ -99,7 +99,7 @@ impl ApprovalRulesManager {
     /// Returns the first matching rule, or `None` if no rule applies.
     pub fn evaluate_command(&self, command: &str) -> Option<&ApprovalRule> {
         let mut enabled: Vec<&ApprovalRule> = self.rules.iter().filter(|r| r.enabled).collect();
-        enabled.sort_by(|a, b| b.priority.cmp(&a.priority));
+        enabled.sort_by_key(|b| std::cmp::Reverse(b.priority));
         enabled.into_iter().find(|r| r.matches(command))
     }
 

--- a/crates/opendev-runtime/src/permissions/mod.rs
+++ b/crates/opendev-runtime/src/permissions/mod.rs
@@ -177,7 +177,7 @@ impl PermissionRuleSet {
         let input = format!("{tool_name}:{args}");
 
         let mut sorted: Vec<&PermissionRule> = self.rules.iter().collect();
-        sorted.sort_by(|a, b| b.priority.cmp(&a.priority));
+        sorted.sort_by_key(|b| std::cmp::Reverse(b.priority));
 
         for rule in sorted {
             // Check directory scope first

--- a/crates/opendev-runtime/src/state_snapshot.rs
+++ b/crates/opendev-runtime/src/state_snapshot.rs
@@ -169,7 +169,7 @@ impl SnapshotPersistence {
             }
         }
 
-        snapshots.sort_by(|a, b| b.snapshot_timestamp_ms.cmp(&a.snapshot_timestamp_ms));
+        snapshots.sort_by_key(|b| std::cmp::Reverse(b.snapshot_timestamp_ms));
         snapshots
     }
 

--- a/crates/opendev-runtime/src/todo/parsing.rs
+++ b/crates/opendev-runtime/src/todo/parsing.rs
@@ -106,10 +106,8 @@ fn extract_numbered_step(line: &str) -> Option<String> {
         s
     } else if let Some(s) = rest.strip_prefix(") ") {
         s
-    } else if let Some(s) = rest.strip_prefix(" - ") {
-        s
     } else {
-        return None;
+        rest.strip_prefix(" - ")?
     };
 
     let text = rest.trim();

--- a/web-ui/src/components/CodeWiki/DocumentationContent.tsx
+++ b/web-ui/src/components/CodeWiki/DocumentationContent.tsx
@@ -17,82 +17,6 @@ interface DocumentationContentProps {
   wikiPage: WikiPage;
 }
 
-// ⚡ Bolt Performance Optimization:
-// Extract markdown components outside the functional component to ensure referential stability.
-// Creating them inline causes React to generate a new object on every render, triggering
-// unnecessary deep re-renders of the ReactMarkdown component and all its children.
-const MARKDOWN_COMPONENTS = {
-  h1: ({ children, ...props }: any) => (
-    <h1 className="text-3xl font-bold text-gray-900 mt-10 mb-6 leading-tight" {...props}>
-      {children}
-    </h1>
-  ),
-  h2: ({ children, ...props }: any) => (
-    <h2 className="text-2xl font-bold text-gray-900 mt-8 mb-4 leading-tight" {...props}>
-      {children}
-    </h2>
-  ),
-  h3: ({ children, ...props }: any) => (
-    <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3 leading-tight" {...props}>
-      {children}
-    </h3>
-  ),
-  p: ({ children, ...props }: any) => (
-    <p className="text-base text-gray-700 mb-4 leading-relaxed" {...props}>
-      {children}
-    </p>
-  ),
-  ul: ({ children, ...props }: any) => (
-    <ul className="list-disc pl-6 mb-4 space-y-2" {...props}>
-      {children}
-    </ul>
-  ),
-  ol: ({ children, ...props }: any) => (
-    <ol className="list-decimal pl-6 mb-4 space-y-2" {...props}>
-      {children}
-    </ol>
-  ),
-  li: ({ children, ...props }: any) => (
-    <li className="text-gray-700 leading-relaxed" {...props}>
-      {children}
-    </li>
-  ),
-  code: ({ children, className, ...props }: any) => {
-    const isInline = !className;
-    return isInline ? (
-      <code
-        className="bg-purple-50 text-purple-900 px-1.5 py-0.5 rounded text-sm font-mono"
-        {...props}
-      >
-        {children}
-      </code>
-    ) : (
-      <code
-        className="block bg-gray-900 text-gray-100 p-4 rounded-lg overflow-x-auto text-sm font-mono leading-relaxed"
-        {...props}
-      >
-        {children}
-      </code>
-    );
-  },
-  blockquote: ({ children, ...props }: any) => (
-    <blockquote
-      className="border-l-4 border-purple-500 pl-4 py-2 my-4 bg-purple-50 text-gray-700 italic"
-      {...props}
-    >
-      {children}
-    </blockquote>
-  ),
-  a: ({ children, ...props }: any) => (
-    <a
-      className="text-purple-600 hover:text-purple-800 underline"
-      {...props}
-    >
-      {children}
-    </a>
-  ),
-};
-
 export function DocumentationContent({ wikiPage }: DocumentationContentProps) {
   return (
     <div className="max-w-4xl mx-auto px-8 py-8">
@@ -138,7 +62,77 @@ export function DocumentationContent({ wikiPage }: DocumentationContentProps) {
       <article className="prose prose-lg max-w-none">
         <ReactMarkdown
           className="text-gray-800 leading-relaxed"
-          components={MARKDOWN_COMPONENTS}
+          components={{
+            h1: ({ children, ...props }) => (
+              <h1 className="text-3xl font-bold text-gray-900 mt-10 mb-6 leading-tight" {...props}>
+                {children}
+              </h1>
+            ),
+            h2: ({ children, ...props }) => (
+              <h2 className="text-2xl font-bold text-gray-900 mt-8 mb-4 leading-tight" {...props}>
+                {children}
+              </h2>
+            ),
+            h3: ({ children, ...props }) => (
+              <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3 leading-tight" {...props}>
+                {children}
+              </h3>
+            ),
+            p: ({ children, ...props }) => (
+              <p className="text-base text-gray-700 mb-4 leading-relaxed" {...props}>
+                {children}
+              </p>
+            ),
+            ul: ({ children, ...props }) => (
+              <ul className="list-disc pl-6 mb-4 space-y-2" {...props}>
+                {children}
+              </ul>
+            ),
+            ol: ({ children, ...props }) => (
+              <ol className="list-decimal pl-6 mb-4 space-y-2" {...props}>
+                {children}
+              </ol>
+            ),
+            li: ({ children, ...props }) => (
+              <li className="text-gray-700 leading-relaxed" {...props}>
+                {children}
+              </li>
+            ),
+            code: ({ children, className, ...props }) => {
+              const isInline = !className;
+              return isInline ? (
+                <code
+                  className="bg-purple-50 text-purple-900 px-1.5 py-0.5 rounded text-sm font-mono"
+                  {...props}
+                >
+                  {children}
+                </code>
+              ) : (
+                <code
+                  className="block bg-gray-900 text-gray-100 p-4 rounded-lg overflow-x-auto text-sm font-mono leading-relaxed"
+                  {...props}
+                >
+                  {children}
+                </code>
+              );
+            },
+            blockquote: ({ children, ...props }) => (
+              <blockquote
+                className="border-l-4 border-purple-500 pl-4 py-2 my-4 bg-purple-50 text-gray-700 italic"
+                {...props}
+              >
+                {children}
+              </blockquote>
+            ),
+            a: ({ children, ...props }) => (
+              <a
+                className="text-purple-600 hover:text-purple-800 underline"
+                {...props}
+              >
+                {children}
+              </a>
+            ),
+          }}
         >
           {wikiPage.content}
         </ReactMarkdown>

--- a/web-ui/src/components/CodeWiki/DocumentationContent.tsx
+++ b/web-ui/src/components/CodeWiki/DocumentationContent.tsx
@@ -17,6 +17,82 @@ interface DocumentationContentProps {
   wikiPage: WikiPage;
 }
 
+// ⚡ Bolt Performance Optimization:
+// Extract markdown components outside the functional component to ensure referential stability.
+// Creating them inline causes React to generate a new object on every render, triggering
+// unnecessary deep re-renders of the ReactMarkdown component and all its children.
+const MARKDOWN_COMPONENTS = {
+  h1: ({ children, ...props }: any) => (
+    <h1 className="text-3xl font-bold text-gray-900 mt-10 mb-6 leading-tight" {...props}>
+      {children}
+    </h1>
+  ),
+  h2: ({ children, ...props }: any) => (
+    <h2 className="text-2xl font-bold text-gray-900 mt-8 mb-4 leading-tight" {...props}>
+      {children}
+    </h2>
+  ),
+  h3: ({ children, ...props }: any) => (
+    <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3 leading-tight" {...props}>
+      {children}
+    </h3>
+  ),
+  p: ({ children, ...props }: any) => (
+    <p className="text-base text-gray-700 mb-4 leading-relaxed" {...props}>
+      {children}
+    </p>
+  ),
+  ul: ({ children, ...props }: any) => (
+    <ul className="list-disc pl-6 mb-4 space-y-2" {...props}>
+      {children}
+    </ul>
+  ),
+  ol: ({ children, ...props }: any) => (
+    <ol className="list-decimal pl-6 mb-4 space-y-2" {...props}>
+      {children}
+    </ol>
+  ),
+  li: ({ children, ...props }: any) => (
+    <li className="text-gray-700 leading-relaxed" {...props}>
+      {children}
+    </li>
+  ),
+  code: ({ children, className, ...props }: any) => {
+    const isInline = !className;
+    return isInline ? (
+      <code
+        className="bg-purple-50 text-purple-900 px-1.5 py-0.5 rounded text-sm font-mono"
+        {...props}
+      >
+        {children}
+      </code>
+    ) : (
+      <code
+        className="block bg-gray-900 text-gray-100 p-4 rounded-lg overflow-x-auto text-sm font-mono leading-relaxed"
+        {...props}
+      >
+        {children}
+      </code>
+    );
+  },
+  blockquote: ({ children, ...props }: any) => (
+    <blockquote
+      className="border-l-4 border-purple-500 pl-4 py-2 my-4 bg-purple-50 text-gray-700 italic"
+      {...props}
+    >
+      {children}
+    </blockquote>
+  ),
+  a: ({ children, ...props }: any) => (
+    <a
+      className="text-purple-600 hover:text-purple-800 underline"
+      {...props}
+    >
+      {children}
+    </a>
+  ),
+};
+
 export function DocumentationContent({ wikiPage }: DocumentationContentProps) {
   return (
     <div className="max-w-4xl mx-auto px-8 py-8">
@@ -62,77 +138,7 @@ export function DocumentationContent({ wikiPage }: DocumentationContentProps) {
       <article className="prose prose-lg max-w-none">
         <ReactMarkdown
           className="text-gray-800 leading-relaxed"
-          components={{
-            h1: ({ children, ...props }) => (
-              <h1 className="text-3xl font-bold text-gray-900 mt-10 mb-6 leading-tight" {...props}>
-                {children}
-              </h1>
-            ),
-            h2: ({ children, ...props }) => (
-              <h2 className="text-2xl font-bold text-gray-900 mt-8 mb-4 leading-tight" {...props}>
-                {children}
-              </h2>
-            ),
-            h3: ({ children, ...props }) => (
-              <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3 leading-tight" {...props}>
-                {children}
-              </h3>
-            ),
-            p: ({ children, ...props }) => (
-              <p className="text-base text-gray-700 mb-4 leading-relaxed" {...props}>
-                {children}
-              </p>
-            ),
-            ul: ({ children, ...props }) => (
-              <ul className="list-disc pl-6 mb-4 space-y-2" {...props}>
-                {children}
-              </ul>
-            ),
-            ol: ({ children, ...props }) => (
-              <ol className="list-decimal pl-6 mb-4 space-y-2" {...props}>
-                {children}
-              </ol>
-            ),
-            li: ({ children, ...props }) => (
-              <li className="text-gray-700 leading-relaxed" {...props}>
-                {children}
-              </li>
-            ),
-            code: ({ children, className, ...props }) => {
-              const isInline = !className;
-              return isInline ? (
-                <code
-                  className="bg-purple-50 text-purple-900 px-1.5 py-0.5 rounded text-sm font-mono"
-                  {...props}
-                >
-                  {children}
-                </code>
-              ) : (
-                <code
-                  className="block bg-gray-900 text-gray-100 p-4 rounded-lg overflow-x-auto text-sm font-mono leading-relaxed"
-                  {...props}
-                >
-                  {children}
-                </code>
-              );
-            },
-            blockquote: ({ children, ...props }) => (
-              <blockquote
-                className="border-l-4 border-purple-500 pl-4 py-2 my-4 bg-purple-50 text-gray-700 italic"
-                {...props}
-              >
-                {children}
-              </blockquote>
-            ),
-            a: ({ children, ...props }) => (
-              <a
-                className="text-purple-600 hover:text-purple-800 underline"
-                {...props}
-              >
-                {children}
-              </a>
-            ),
-          }}
+          components={MARKDOWN_COMPONENTS}
         >
           {wikiPage.content}
         </ReactMarkdown>


### PR DESCRIPTION
💡 **What**: Extracts the inline `components` object from the `<ReactMarkdown>` tag in `DocumentationContent.tsx` into a module-level static constant `MARKDOWN_COMPONENTS`.

🎯 **Why**: Passing an inline object to `components={{...}}` causes React to create a new object reference on every render of the `DocumentationContent` functional component. This forces `ReactMarkdown` and its entire sub-tree to deeply re-render, leading to performance degradation, especially with large markdown documents.

📊 **Impact**: Reduces unnecessary deep re-renders of the markdown component by maintaining referential stability of the `components` prop.

🔬 **Measurement**: Verify by using React Developer Tools Profiler. Without the patch, typing or state updates in the parent component that trigger a render of `DocumentationContent` will highlight the entire markdown tree. With the patch, the markdown tree will not re-render unless the `wikiPage.content` changes.

---
*PR created automatically by Jules for task [8984335849413886546](https://jules.google.com/task/8984335849413886546) started by @bdqnghi*