### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal and Insecure File Write in State Snapshots

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Configuration files containing sensitive data (like MCP OAuth client secrets or access tokens) were written using `std::fs::write` or non-atomic serialization. This creates a Time-of-Check to Time-of-Use (TOCTOU) race condition and defaults to standard user permissions, potentially allowing unauthorized read access on multi-user systems.
 **Learning:** Directly modifying permissions after writing a file still leaves a short window where a local attacker can read or modify the file.
 **Prevention:** Always write sensitive files using an atomic pattern: create a temporary file using `std::fs::OpenOptions` with `.create(true).write(true).truncate(true).mode(0o600)` (on Unix via `std::os::unix::fs::OpenOptionsExt`), write the contents, and then use `std::fs::rename` to atomically replace the destination file.
+
+## 2025-05-10 - Path Traversal in File Saving and Loading
+**Vulnerability:** Path traversal vulnerability in `SnapshotPersistence::snapshot_path` where `session_id` is directly embedded in the file path without sanitization. An attacker could use a malicious `session_id` like `"../malicious"` to write or read files outside the intended snapshot directory.
+**Learning:** Directly concatenating user-controlled strings to form file paths without verifying that they stay within the target directory leads to path traversal.
+**Prevention:** Sanitize user input used in file paths (e.g., replacing `/`, `\`, and `.` characters) or strictly validate that the generated path remains within the intended directory.

--- a/crates/opendev-runtime/src/approval/manager.rs
+++ b/crates/opendev-runtime/src/approval/manager.rs
@@ -99,7 +99,7 @@ impl ApprovalRulesManager {
     /// Returns the first matching rule, or `None` if no rule applies.
     pub fn evaluate_command(&self, command: &str) -> Option<&ApprovalRule> {
         let mut enabled: Vec<&ApprovalRule> = self.rules.iter().filter(|r| r.enabled).collect();
-        enabled.sort_by(|a, b| b.priority.cmp(&a.priority));
+        enabled.sort_by_key(|b| std::cmp::Reverse(b.priority));
         enabled.into_iter().find(|r| r.matches(command))
     }
 

--- a/crates/opendev-runtime/src/permissions/mod.rs
+++ b/crates/opendev-runtime/src/permissions/mod.rs
@@ -177,7 +177,7 @@ impl PermissionRuleSet {
         let input = format!("{tool_name}:{args}");
 
         let mut sorted: Vec<&PermissionRule> = self.rules.iter().collect();
-        sorted.sort_by(|a, b| b.priority.cmp(&a.priority));
+        sorted.sort_by_key(|b| std::cmp::Reverse(b.priority));
 
         for rule in sorted {
             // Check directory scope first

--- a/crates/opendev-runtime/src/state_snapshot.rs
+++ b/crates/opendev-runtime/src/state_snapshot.rs
@@ -196,7 +196,7 @@ impl SnapshotPersistence {
             }
         }
 
-        snapshots.sort_by(|a, b| b.snapshot_timestamp_ms.cmp(&a.snapshot_timestamp_ms));
+        snapshots.sort_by_key(|b| std::cmp::Reverse(b.snapshot_timestamp_ms));
         snapshots
     }
 

--- a/crates/opendev-runtime/src/state_snapshot.rs
+++ b/crates/opendev-runtime/src/state_snapshot.rs
@@ -3,6 +3,10 @@
 //! Periodically serializes essential session state to a temp file so that
 //! incomplete sessions can be detected and recovered on the next startup.
 
+use std::fs::OpenOptions;
+use std::io::Write;
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -111,8 +115,9 @@ impl SnapshotPersistence {
 
     /// Return the path where a session's snapshot would be stored.
     pub fn snapshot_path(&self, session_id: &str) -> PathBuf {
+        let safe_session_id = session_id.replace(['/', '\\'], "_");
         self.snapshot_dir
-            .join(format!("{session_id}_{SNAPSHOT_FILENAME}"))
+            .join(format!("{safe_session_id}_{SNAPSHOT_FILENAME}"))
     }
 
     /// Save a snapshot to disk atomically (write tmp then rename).
@@ -121,13 +126,35 @@ impl SnapshotPersistence {
             .map_err(|e| format!("Failed to create snapshot dir: {e}"))?;
 
         let path = self.snapshot_path(&snapshot.session_id);
-        let tmp_path = path.with_extension("json.tmp");
+        let tmp_filename = format!("{}.tmp", uuid::Uuid::new_v4());
+        let tmp_path = self.snapshot_dir.join(tmp_filename);
 
         let json = serde_json::to_string_pretty(snapshot)
             .map_err(|e| format!("Failed to serialize snapshot: {e}"))?;
 
-        std::fs::write(&tmp_path, &json)
+        #[cfg(unix)]
+        let options = {
+            let mut opt = OpenOptions::new();
+            opt.write(true).create_new(true).mode(0o600);
+            opt
+        };
+
+        #[cfg(not(unix))]
+        let options = {
+            let mut opt = OpenOptions::new();
+            opt.write(true).create_new(true);
+            opt
+        };
+
+        let mut file = options
+            .open(&tmp_path)
+            .map_err(|e| format!("Failed to create snapshot tmp: {e}"))?;
+
+        file.write_all(json.as_bytes())
             .map_err(|e| format!("Failed to write snapshot tmp: {e}"))?;
+
+        file.sync_all()
+            .map_err(|e| format!("Failed to sync snapshot tmp: {e}"))?;
 
         std::fs::rename(&tmp_path, &path).map_err(|e| format!("Failed to rename snapshot: {e}"))?;
 

--- a/crates/opendev-runtime/src/todo/parsing.rs
+++ b/crates/opendev-runtime/src/todo/parsing.rs
@@ -106,10 +106,8 @@ fn extract_numbered_step(line: &str) -> Option<String> {
         s
     } else if let Some(s) = rest.strip_prefix(") ") {
         s
-    } else if let Some(s) = rest.strip_prefix(" - ") {
-        s
     } else {
-        return None;
+        rest.strip_prefix(" - ")?
     };
 
     let text = rest.trim();


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** 
1. **Path Traversal:** The `snapshot_path` function directly embedded the `session_id` parameter into the snapshot file path without sanitization, allowing malicious inputs like `../` to access or overwrite files outside the intended directory.
2. **Time-of-Check to Time-of-Use (TOCTOU):** The `SnapshotPersistence::save` function used `std::fs::write` to create the temporary snapshot file with default permissions before moving it, leaving a brief window where sensitive snapshot data could be read by unauthorized local users.

🎯 **Impact:** An attacker could potentially escape the restricted `~/.opendev/data/recovery` directory and write to arbitrary locations (if permissions allow), or read sensitive session data like active paths and tool results during the race condition window.

🔧 **Fix:**
1. Sanitized the `session_id` string by replacing `/` and `\` with `_` using `.replace(['/', '\\'], "_")`.
2. Changed the `save` function to use a secure atomic write pattern. It now generates a randomized temporary filename using `uuid::Uuid::new_v4()` and securely creates the file using `std::fs::OpenOptions` with `.create_new(true)` and restricted permissions (`.mode(0o600)` on Unix).

✅ **Verification:**
Ran `cargo test --workspace` to ensure no regressions and `cargo clippy --workspace -- -D warnings` to verify no linting issues were introduced.

---
*PR created automatically by Jules for task [9055599572306161660](https://jules.google.com/task/9055599572306161660) started by @bdqnghi*