### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal and insecure file write in state snapshots

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Configuration files containing sensitive data (like MCP OAuth client secrets or access tokens) were written using `std::fs::write` or non-atomic serialization. This creates a Time-of-Check to Time-of-Use (TOCTOU) race condition and defaults to standard user permissions, potentially allowing unauthorized read access on multi-user systems.
 **Learning:** Directly modifying permissions after writing a file still leaves a short window where a local attacker can read or modify the file.
 **Prevention:** Always write sensitive files using an atomic pattern: create a temporary file using `std::fs::OpenOptions` with `.create(true).write(true).truncate(true).mode(0o600)` (on Unix via `std::os::unix::fs::OpenOptionsExt`), write the contents, and then use `std::fs::rename` to atomically replace the destination file.
+
+## 2026-05-11 - Path Traversal and TOCTOU in State Snapshots
+**Vulnerability:** Application state snapshots containing sensitive tool outputs and session data were susceptible to Path Traversal via the `session_id` parameter and TOCTOU/symlink attacks because they were written to a predictable `json.tmp` file using `std::fs::write` without restricted permissions.
+**Learning:** Temporary files used for crash recovery or atomic writes must be randomized (e.g., using UUIDs) and securely created with `OpenOptions` and `.create_new(true)` to prevent attackers from pre-creating symlinks to overwrite arbitrary files, and dynamic ID parameters must be sanitized before being interpolated into file paths.
+**Prevention:** Combine path sanitization (`.replace(['/', '\', '.', ':'], "_")`) with secure atomic write patterns (`uuid::Uuid::new_v4()`, `OpenOptions`, `.create_new(true)`, and `.mode(0o600)` on Unix).

--- a/crates/opendev-runtime/src/state_snapshot.rs
+++ b/crates/opendev-runtime/src/state_snapshot.rs
@@ -111,8 +111,9 @@ impl SnapshotPersistence {
 
     /// Return the path where a session's snapshot would be stored.
     pub fn snapshot_path(&self, session_id: &str) -> PathBuf {
+        let safe_id = session_id.replace(['/', '\\', '.', ':'], "_");
         self.snapshot_dir
-            .join(format!("{session_id}_{SNAPSHOT_FILENAME}"))
+            .join(format!("{safe_id}_{SNAPSHOT_FILENAME}"))
     }
 
     /// Save a snapshot to disk atomically (write tmp then rename).
@@ -121,13 +122,27 @@ impl SnapshotPersistence {
             .map_err(|e| format!("Failed to create snapshot dir: {e}"))?;
 
         let path = self.snapshot_path(&snapshot.session_id);
-        let tmp_path = path.with_extension("json.tmp");
+        let tmp_path = path.with_extension(format!("json.tmp.{}", uuid::Uuid::new_v4()));
 
         let json = serde_json::to_string_pretty(snapshot)
             .map_err(|e| format!("Failed to serialize snapshot: {e}"))?;
 
-        std::fs::write(&tmp_path, &json)
-            .map_err(|e| format!("Failed to write snapshot tmp: {e}"))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            let mut opts = std::fs::OpenOptions::new();
+            opts.write(true).create_new(true).mode(0o600);
+            std::io::Write::write_all(&mut opts.open(&tmp_path).map_err(|e| format!("Failed to open snapshot tmp: {e}"))?, json.as_bytes())
+                .map_err(|e| format!("Failed to write snapshot tmp: {e}"))?;
+        }
+
+        #[cfg(not(unix))]
+        {
+            let mut opts = std::fs::OpenOptions::new();
+            opts.write(true).create_new(true);
+            std::io::Write::write_all(&mut opts.open(&tmp_path).map_err(|e| format!("Failed to open snapshot tmp: {e}"))?, json.as_bytes())
+                .map_err(|e| format!("Failed to write snapshot tmp: {e}"))?;
+        }
 
         std::fs::rename(&tmp_path, &path).map_err(|e| format!("Failed to rename snapshot: {e}"))?;
 

--- a/crates/opendev-runtime/src/state_snapshot.rs
+++ b/crates/opendev-runtime/src/state_snapshot.rs
@@ -132,16 +132,26 @@ impl SnapshotPersistence {
             use std::os::unix::fs::OpenOptionsExt;
             let mut opts = std::fs::OpenOptions::new();
             opts.write(true).create_new(true).mode(0o600);
-            std::io::Write::write_all(&mut opts.open(&tmp_path).map_err(|e| format!("Failed to open snapshot tmp: {e}"))?, json.as_bytes())
-                .map_err(|e| format!("Failed to write snapshot tmp: {e}"))?;
+            std::io::Write::write_all(
+                &mut opts
+                    .open(&tmp_path)
+                    .map_err(|e| format!("Failed to open snapshot tmp: {e}"))?,
+                json.as_bytes(),
+            )
+            .map_err(|e| format!("Failed to write snapshot tmp: {e}"))?;
         }
 
         #[cfg(not(unix))]
         {
             let mut opts = std::fs::OpenOptions::new();
             opts.write(true).create_new(true);
-            std::io::Write::write_all(&mut opts.open(&tmp_path).map_err(|e| format!("Failed to open snapshot tmp: {e}"))?, json.as_bytes())
-                .map_err(|e| format!("Failed to write snapshot tmp: {e}"))?;
+            std::io::Write::write_all(
+                &mut opts
+                    .open(&tmp_path)
+                    .map_err(|e| format!("Failed to open snapshot tmp: {e}"))?,
+                json.as_bytes(),
+            )
+            .map_err(|e| format!("Failed to write snapshot tmp: {e}"))?;
         }
 
         std::fs::rename(&tmp_path, &path).map_err(|e| format!("Failed to rename snapshot: {e}"))?;


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Path Traversal and Time-of-Check to Time-of-Use (TOCTOU) vulnerabilities in `crates/opendev-runtime/src/state_snapshot.rs`. The `snapshot_path` method previously injected an unsanitized `session_id` directly into the path, allowing directory traversal. Additionally, the `save` method used a predictable temporary filename (`json.tmp`) and `std::fs::write` without restricting permissions, allowing local users to potentially read sensitive snapshot data or conduct symlink attacks.
🎯 **Impact:** Attackers could overwrite arbitrary files via path traversal or predictable symlink targets, and unauthorized local users could read sensitive tool outputs and application states saved during crash recovery.
🔧 **Fix:** Added path sanitization for `session_id` (`.replace(['/', '\\', '.', ':'], "_")`), changed the temporary filename to append a UUID (`uuid::Uuid::new_v4()`), and implemented secure, atomic file creation using `OpenOptions` with `.create_new(true)` and `.mode(0o600)` (on Unix).
✅ **Verification:** Verified by running `cargo test -p opendev-runtime` and `cargo clippy --workspace -- -D warnings`, which both completed successfully with zero failures.

---
*PR created automatically by Jules for task [1107120031723612874](https://jules.google.com/task/1107120031723612874) started by @bdqnghi*