### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU and file permissions in state snapshot persistence

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Configuration files containing sensitive data (like MCP OAuth client secrets or access tokens) were written using `std::fs::write` or non-atomic serialization. This creates a Time-of-Check to Time-of-Use (TOCTOU) race condition and defaults to standard user permissions, potentially allowing unauthorized read access on multi-user systems.
 **Learning:** Directly modifying permissions after writing a file still leaves a short window where a local attacker can read or modify the file.
 **Prevention:** Always write sensitive files using an atomic pattern: create a temporary file using `std::fs::OpenOptions` with `.create(true).write(true).truncate(true).mode(0o600)` (on Unix via `std::os::unix::fs::OpenOptionsExt`), write the contents, and then use `std::fs::rename` to atomically replace the destination file.
+
+## 2025-02-27 - [TOCTOU in State Snapshot Persistence]
+**Vulnerability:** Time-of-Check to Time-of-Use (TOCTOU) vulnerability where sensitive application state snapshots were created using `std::fs::write`, which defaults to standard user permissions, before being renamed. Additionally, predictable temporary file names and path traversal risks via unsanitized `session_id` were present.
+**Learning:** Even internal snapshot or recovery files containing sensitive state (like tokens or session info) must use atomic write patterns with secure permissions to prevent local privilege escalation or information disclosure.
+**Prevention:** Always use `uuid::Uuid::new_v4()` for temporary file names, `std::fs::OpenOptions` with `.create_new(true).write(true)`, and `std::os::unix::fs::OpenOptionsExt::mode(0o600)` to securely create snapshot files before renaming them. Sanitize any user-controlled input (like `session_id`) used in paths.

--- a/crates/opendev-runtime/src/state_snapshot.rs
+++ b/crates/opendev-runtime/src/state_snapshot.rs
@@ -111,8 +111,9 @@ impl SnapshotPersistence {
 
     /// Return the path where a session's snapshot would be stored.
     pub fn snapshot_path(&self, session_id: &str) -> PathBuf {
+        let safe_session_id = session_id.replace(['/', '\\'], "_");
         self.snapshot_dir
-            .join(format!("{session_id}_{SNAPSHOT_FILENAME}"))
+            .join(format!("{safe_session_id}_{SNAPSHOT_FILENAME}"))
     }
 
     /// Save a snapshot to disk atomically (write tmp then rename).
@@ -121,13 +122,33 @@ impl SnapshotPersistence {
             .map_err(|e| format!("Failed to create snapshot dir: {e}"))?;
 
         let path = self.snapshot_path(&snapshot.session_id);
-        let tmp_path = path.with_extension("json.tmp");
+        let tmp_path = path.with_extension(format!("tmp.{}", uuid::Uuid::new_v4()));
 
         let json = serde_json::to_string_pretty(snapshot)
             .map_err(|e| format!("Failed to serialize snapshot: {e}"))?;
 
-        std::fs::write(&tmp_path, &json)
-            .map_err(|e| format!("Failed to write snapshot tmp: {e}"))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            let mut opts = std::fs::OpenOptions::new();
+            opts.write(true).create_new(true).mode(0o600);
+            let mut file = opts
+                .open(&tmp_path)
+                .map_err(|e| format!("Failed to open snapshot tmp {}: {e}", tmp_path.display()))?;
+            std::io::Write::write_all(&mut file, json.as_bytes())
+                .map_err(|e| format!("Failed to write snapshot tmp: {e}"))?;
+        }
+
+        #[cfg(not(unix))]
+        {
+            let mut opts = std::fs::OpenOptions::new();
+            opts.write(true).create_new(true);
+            let mut file = opts
+                .open(&tmp_path)
+                .map_err(|e| format!("Failed to open snapshot tmp {}: {e}", tmp_path.display()))?;
+            std::io::Write::write_all(&mut file, json.as_bytes())
+                .map_err(|e| format!("Failed to write snapshot tmp: {e}"))?;
+        }
 
         std::fs::rename(&tmp_path, &path).map_err(|e| format!("Failed to rename snapshot: {e}"))?;
 

--- a/crates/opendev-sandbox/src/sandbox.rs
+++ b/crates/opendev-sandbox/src/sandbox.rs
@@ -66,7 +66,7 @@ impl MicroSandbox {
     /// Inject a string variable into the sandbox environment.
     pub async fn inject_variable(&self, name: &str, content: &str) -> Result<()> {
         // Escape triple quotes in content to avoid Python syntax errors.
-        let escaped = content.replace("\\", "\\\\").replace("'''", "\\'\\'\\'");
+        let escaped = content.replace('\\', "\\\\").replace("'''", "\\'\\'\\'");
         let code = format!("{name} = '''{escaped}'''");
         self.run_code(&code).await?;
         Ok(())


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The state snapshot persistence mechanism (`SnapshotPersistence::save` in `opendev-runtime`) created temporary files using `std::fs::write` with predictable names and default permissions. This created a Time-of-Check to Time-of-Use (TOCTOU) vulnerability where sensitive application state (potentially including tokens or project secrets) could be accessed by local attackers before the file was renamed. Additionally, the `session_id` was not sanitized, creating a path traversal risk.
🎯 **Impact:** Local Privilege Escalation / Information Disclosure. Other users on the same system could potentially read sensitive snapshot data during the race condition window, or write to arbitrary locations if they could control the `session_id`.
🔧 **Fix:** 
1. Sanitized the `session_id` by replacing `/` and `\` with `_`.
2. Updated the temporary file naming to use a randomized `uuid::Uuid::new_v4()` extension to prevent predictable temp file attacks.
3. Updated file creation to use `std::fs::OpenOptions::new().write(true).create_new(true)`, and on Unix specifically used `std::os::unix::fs::OpenOptionsExt::mode(0o600)` to ensure the temporary file is created securely with restricted permissions.
✅ **Verification:** Ran `cargo test -p opendev-runtime` to confirm snapshot persistence still works as expected, and verified that `.jules/sentinel.md` has been updated with these learnings.

---
*PR created automatically by Jules for task [5162813311989544903](https://jules.google.com/task/5162813311989544903) started by @bdqnghi*