### PR TITLE
⚡ Bolt: [performance improvement] Memoize repository filtering

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -20,3 +20,7 @@
 ## 2024-05-15 - Referential Stability of Component Props
 **Learning:** Passing inline objects to props (like the `components` prop of `ReactMarkdown`) in functional components breaks referential stability, causing the component and its entire subtree to re-render unnecessarily on every parent render.
 **Action:** Always extract static configuration objects and functions that don't depend on component state outside of the functional component definition.
+
+## 2024-05-20 - Expensive Filtering in Render Body
+**Learning:** Performing `Array.prototype.filter` operations directly within the component render body (e.g. `mockRepositories.filter(...)`) causes an O(N) operation on every single render. When tied to an uncontrolled text input prop or high-frequency render parent, this results in layout thrashing.
+**Action:** Always wrap array filtering and derived aggregates (like `.reduce`) in a `useMemo` block with the appropriate dependency array (like the `searchQuery` prop).

--- a/web-ui/src/components/CodeWiki/RepositoryExplorer.tsx
+++ b/web-ui/src/components/CodeWiki/RepositoryExplorer.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import {
   FolderIcon,
   DocumentTextIcon,
@@ -75,11 +75,17 @@ const mockRepositories: Repository[] = [
 export function RepositoryExplorer({ selectedRepo, onRepoSelect, searchQuery }: RepositoryExplorerProps) {
   const [expandedRepos, setExpandedRepos] = useState<Set<string>>(new Set());
 
-  const filteredRepos = mockRepositories.filter(repo =>
-    repo.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-    repo.fullName.toLowerCase().includes(searchQuery.toLowerCase()) ||
-    repo.description.toLowerCase().includes(searchQuery.toLowerCase())
-  );
+  // ⚡ Bolt Performance Optimization:
+  // Memoize the filtered repositories array to prevent redundant filtering
+  // calculations on every render, especially as the user types in the search query.
+  const filteredRepos = useMemo(() => {
+    const query = searchQuery.toLowerCase();
+    return mockRepositories.filter(repo =>
+      repo.name.toLowerCase().includes(query) ||
+      repo.fullName.toLowerCase().includes(query) ||
+      repo.description.toLowerCase().includes(query)
+    );
+  }, [searchQuery]);
 
   const toggleExpanded = (repoId: string) => {
     setExpandedRepos(prev => {

--- a/web-ui/src/components/CodeWiki/RepositoryGrid.tsx
+++ b/web-ui/src/components/CodeWiki/RepositoryGrid.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { MagnifyingGlassIcon, PlusIcon, Cog6ToothIcon } from '@heroicons/react/24/outline';
 import { RepositoryCard } from './RepositoryCard';
 import { Repository } from './RepositoryExplorer';
@@ -10,15 +11,24 @@ interface RepositoryGridProps {
 }
 
 export function RepositoryGrid({ repositories, searchQuery, onSearchChange, onAddRepository }: RepositoryGridProps) {
-  const filteredRepositories = repositories.filter(repo =>
-    repo.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-    repo.fullName.toLowerCase().includes(searchQuery.toLowerCase()) ||
-    repo.description.toLowerCase().includes(searchQuery.toLowerCase()) ||
-    repo.language.toLowerCase().includes(searchQuery.toLowerCase())
-  );
+  // ⚡ Bolt Performance Optimization:
+  // Memoize the filtered repositories and derived stats to prevent O(N) recalculations
+  // on every render (e.g., when typing in the search bar or parent components re-render).
+  const { filteredRepositories, totalFiles, totalDocs } = useMemo(() => {
+    const query = searchQuery.toLowerCase();
+    const filtered = repositories.filter(repo =>
+      repo.name.toLowerCase().includes(query) ||
+      repo.fullName.toLowerCase().includes(query) ||
+      repo.description.toLowerCase().includes(query) ||
+      repo.language.toLowerCase().includes(query)
+    );
 
-  const totalFiles = filteredRepositories.reduce((sum, repo) => sum + repo.files, 0);
-  const totalDocs = filteredRepositories.reduce((sum, repo) => sum + repo.docsFound, 0);
+    return {
+      filteredRepositories: filtered,
+      totalFiles: filtered.reduce((sum, repo) => sum + repo.files, 0),
+      totalDocs: filtered.reduce((sum, repo) => sum + repo.docsFound, 0)
+    };
+  }, [repositories, searchQuery]);
 
   return (
     <div className="min-h-screen bg-gray-50">


### PR DESCRIPTION
💡 What
Wrapped expensive array filtering and aggregation (`.reduce()`) operations in `RepositoryExplorer.tsx` and `RepositoryGrid.tsx` with `useMemo`.

🎯 Why
Performing `Array.prototype.filter` or `.reduce` directly within the render body causes an O(N) calculation on every render. Because the `searchQuery` prop might change frequently (e.g. uncontrolled keystrokes if the parent isn't fully debouncing, or just general parent updates), this causes layout thrashing and slows down the interface as the repository list grows. 

📊 Impact
Prevents N-operations from repeating needlessly. The calculation of the filtered lists and aggregated values (`totalFiles`, `totalDocs`) will now only happen when `searchQuery` or `repositories` actually change. Expected to noticeably improve rendering performance during active interactions.

🔬 Measurement
Verify that React components no longer freeze during rapid user typing. Added journal entry for this learning.

---
*PR created automatically by Jules for task [11688849793218914495](https://jules.google.com/task/11688849793218914495) started by @bdqnghi*