### PR TITLE
⚡ Bolt: [performance improvement] Hoist .toLowerCase() in SearchPanel to prevent redundant string allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -44,3 +44,7 @@
 ## 2024-04-18 - Replacing synchronous std::fs operations with tokio::fs in async contexts
 **Learning:** In the `SymbolCache` implementation in `crates/opendev-tools-lsp/src/cache.rs`, using synchronous `std::fs` operations (e.g., `read_to_string`, `write`, `create_dir_all`, `remove_dir_all`) inside async functions blocks the async executor thread. This is a common performance bottleneck in Rust async applications, as it prevents other async tasks from making progress on the thread handling the I/O.
 **Action:** Always verify if `std::fs` is being called within an `async fn` or an executor's context. When identifying such usage, refactor to use `tokio::fs` equivalents (e.g., `tokio::fs::read_to_string().await`) to ensure non-blocking file I/O operations and improve overall application concurrency.
+
+## 2025-06-01 - Hoisting toLowerCase in Search Panels
+**Learning:** Placing `query.toLowerCase()` inside recursive tree-search helper functions (like `searchNodeData` and `matchesQuery` in `SearchPanel.tsx`) causes massive O(N) redundant string allocations when filtering large lists inside `useMemo`, even if the input is debounced.
+**Action:** Always compute `lowerQuery = query.toLowerCase()` exactly once at the start of the `useMemo` block, and pass the already-lowercased string down to all helper functions.

--- a/web-ui/src/components/TraceAnalysis/SearchPanel.tsx
+++ b/web-ui/src/components/TraceAnalysis/SearchPanel.tsx
@@ -31,17 +31,17 @@ interface SearchResult {
   chainLabel?: string;
 }
 
-function matchesQuery(text: string, query: string): boolean {
-  return text.toLowerCase().includes(query.toLowerCase());
+function matchesQuery(text: string, lowerQuery: string): boolean {
+  return text.toLowerCase().includes(lowerQuery);
 }
 
-function highlightMatch(text: string, query: string): React.ReactNode {
-  if (!query) return text;
-  const idx = text.toLowerCase().indexOf(query.toLowerCase());
+function highlightMatch(text: string, lowerQuery: string): React.ReactNode {
+  if (!lowerQuery) return text;
+  const idx = text.toLowerCase().indexOf(lowerQuery);
   if (idx === -1) return text;
   const before = text.slice(0, idx);
-  const match = text.slice(idx, idx + query.length);
-  const after = text.slice(idx + query.length);
+  const match = text.slice(idx, idx + lowerQuery.length);
+  const after = text.slice(idx + lowerQuery.length);
   return (
     <>
       {before}
@@ -83,31 +83,31 @@ function getFullContent(data: AnyNodeData): string {
   return contentBlocksToText(ev.message?.content);
 }
 
-function searchNodeData(data: AnyNodeData, query: string): string | null {
-  if (matchesQuery(data.preview, query)) return data.preview;
+function searchNodeData(data: AnyNodeData, lowerQuery: string): string | null {
+  if (matchesQuery(data.preview, lowerQuery)) return data.preview;
   const toolNames = getToolNames(data);
   for (const name of toolNames) {
-    if (matchesQuery(name, query)) return name;
+    if (matchesQuery(name, lowerQuery)) return name;
   }
-  if (matchesQuery(data.eventType, query)) return data.eventType;
+  if (matchesQuery(data.eventType, lowerQuery)) return data.eventType;
   if (data.eventType === 'tool-call' || data.eventType === 'task-call') {
     const tools = (data as ToolNodeData | TaskNodeData).tools;
     for (const tool of tools) {
-      if (tool.result && matchesQuery(tool.result, query)) return truncateAround(tool.result, query, 80);
+      if (tool.result && matchesQuery(tool.result, lowerQuery)) return truncateAround(tool.result, lowerQuery, 80);
       const inputStr = JSON.stringify(tool.input);
-      if (matchesQuery(inputStr, query)) return truncateAround(inputStr, query, 80);
+      if (matchesQuery(inputStr, lowerQuery)) return truncateAround(inputStr, lowerQuery, 80);
     }
   }
   const fullText = getFullContent(data);
-  if (fullText && matchesQuery(fullText, query)) return truncateAround(fullText, query, 80);
+  if (fullText && matchesQuery(fullText, lowerQuery)) return truncateAround(fullText, lowerQuery, 80);
   return null;
 }
 
-function truncateAround(text: string, query: string, maxLen: number): string {
+function truncateAround(text: string, lowerQuery: string, maxLen: number): string {
   if (text.length <= maxLen) return text;
-  const idx = text.toLowerCase().indexOf(query.toLowerCase());
+  const idx = text.toLowerCase().indexOf(lowerQuery);
   if (idx === -1) return text.slice(0, maxLen);
-  const start = Math.max(0, idx - Math.floor((maxLen - query.length) / 2));
+  const start = Math.max(0, idx - Math.floor((maxLen - lowerQuery.length) / 2));
   const slice = text.slice(start, start + maxLen);
   return (start > 0 ? '\u2026' : '') + slice + (start + maxLen < text.length ? '\u2026' : '');
 }
@@ -122,6 +122,7 @@ export function SearchPanel({ nodes, onSelectNode }: Props) {
   const results = useMemo<SearchResult[]>(() => {
     const q = debouncedQuery.trim();
     if (!q) return [];
+    const lowerQuery = q.toLowerCase();
     const out: SearchResult[] = [];
 
     for (const node of nodes) {
@@ -129,7 +130,7 @@ export function SearchPanel({ nodes, onSelectNode }: Props) {
         const cData = node.data as CollapsedNodeData;
         for (let i = 0; i < cData.events.length; i++) {
           const ev = cData.events[i];
-          const matchText = searchNodeData(ev, q);
+          const matchText = searchNodeData(ev, lowerQuery);
           if (matchText) {
             out.push({
               nodeId: node.id,
@@ -145,7 +146,7 @@ export function SearchPanel({ nodes, onSelectNode }: Props) {
         }
       } else {
         const data = node.data as TraceNodeData | ToolNodeData | TaskNodeData;
-        const matchText = searchNodeData(data, q);
+        const matchText = searchNodeData(data, lowerQuery);
         if (matchText) {
           out.push({
             nodeId: node.id,
@@ -160,6 +161,8 @@ export function SearchPanel({ nodes, onSelectNode }: Props) {
 
     return out;
   }, [nodes, debouncedQuery]);
+
+  const lowerDebouncedQuery = debouncedQuery.trim().toLowerCase();
 
   return (
     <div className="w-[260px] shrink-0 flex flex-col bg-bg-100 border-r border-border-300/20 font-sans overflow-hidden">
@@ -205,7 +208,7 @@ export function SearchPanel({ nodes, onSelectNode }: Props) {
               )}
             </div>
             <div className="text-[11px] text-text-200 leading-4 overflow-hidden text-ellipsis whitespace-nowrap">
-              {highlightMatch(r.matchSnippet, debouncedQuery.trim())}
+              {highlightMatch(r.matchSnippet, lowerDebouncedQuery)}
             </div>
             {r.toolNames.length > 0 && (
               <div className="flex gap-1 mt-1 flex-wrap">


### PR DESCRIPTION
💡 **What:** 
Hoisted `query.toLowerCase()` out of recursive tree-search helper functions (`searchNodeData`, `matchesQuery`, `highlightMatch`, `truncateAround`) in `SearchPanel.tsx` into the main `useMemo` block.

🎯 **Why:** 
Previously, `query.toLowerCase()` was being called inside `matchesQuery` for every single string field of every node on every debounced keystroke update. Since the trace tree can be large and deep, this triggered thousands of redundant string allocations, degrading filtering performance and layout snappiness.

📊 **Impact:** 
Significantly reduces memory churn and garbage collection pressure when typing in the search box by performing the `.toLowerCase()` calculation exactly once per query update rather than N times.

🔬 **Measurement:** 
Load a large trace DAG and type quickly into the search panel. Profile the heap allocations and main-thread blocking time; both should be noticeably reduced. Tests have been verified via `cargo test` and `vitest`.

---
*PR created automatically by Jules for task [814043244291272701](https://jules.google.com/task/814043244291272701) started by @bdqnghi*