### PR TITLE
⚡ Bolt: [performance improvement] Optimize tool filtering in MCPToolsModal

### DIFF
--- a/web-ui/src/components/Settings/MCPToolsModal.tsx
+++ b/web-ui/src/components/Settings/MCPToolsModal.tsx
@@ -7,6 +7,7 @@
 
 import { useState, useMemo, useEffect } from 'react';
 import { XMarkIcon, MagnifyingGlassIcon, ClipboardIcon, CheckIcon } from '@heroicons/react/24/outline';
+import { useDebounce } from '../../hooks/useDebounce';
 import { WrenchScrewdriverIcon } from '@heroicons/react/24/solid';
 import type { MCPTool } from '../../types/mcp';
 
@@ -22,6 +23,11 @@ export function MCPToolsModal({ isOpen, serverName, tools, onClose }: MCPToolsMo
   const [selectedTool, setSelectedTool] = useState<MCPTool | null>(null);
   const [copiedText, setCopiedText] = useState<string | null>(null);
 
+  // ⚡ Bolt Performance Optimization:
+  // Debouncing the search query to prevent excessive array filtering on every keystroke.
+  // The query filters through an array `tools.filter`, which might cause UI jank (O(N) layout thrashing) for large sets of tools.
+  const debouncedSearchQuery = useDebounce(searchQuery, 300);
+
   // Reset state when modal opens or tools change
   useEffect(() => {
     if (isOpen) {
@@ -33,21 +39,21 @@ export function MCPToolsModal({ isOpen, serverName, tools, onClose }: MCPToolsMo
 
   // Filter tools based on search query
   const filteredTools = useMemo(() => {
-    if (!searchQuery.trim()) return tools;
+    if (!debouncedSearchQuery.trim()) return tools;
 
     // ⚡ Bolt Performance Optimization:
     // Precompute a case-insensitive RegExp instead of repeatedly invoking .toLowerCase()
     // inside the filter loop. This prevents O(N) redundant string allocations.
-    const queryRegex = new RegExp(searchQuery.trim().replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
+    const queryRegex = new RegExp(debouncedSearchQuery.trim().replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
     return tools.filter(
       tool =>
         queryRegex.test(tool.name) ||
         queryRegex.test(tool.description)
     );
-  }, [tools, searchQuery]);
+  }, [tools, debouncedSearchQuery]);
 
   // Auto-select first tool when filtered list changes
-  useMemo(() => {
+  useEffect(() => {
     if (filteredTools.length > 0 && !filteredTools.find(t => t.name === selectedTool?.name)) {
       setSelectedTool(filteredTools[0]);
     } else if (filteredTools.length === 0) {


### PR DESCRIPTION
💡 What:
1. Replaced the `useMemo` hook that caused side-effects (`setSelectedTool`) with `useEffect` to fix a React rule violation that triggered double-rendering.
2. Added debouncing to the `searchQuery` via `useDebounce(searchQuery, 300)` before filtering tools to prevent UI lag on every keystroke.

🎯 Why:
Filtering large lists of tools repeatedly inside `useMemo` block via `searchQuery` was causing a lot of array iterations and unnecessary regular expression instantiations leading to O(N) thrashing on every user keystroke. Also `useMemo` triggering state changes caused a side-effect that resulted in the component to render once with updated tools, run the effect, and then render again with the new selected tool leading to double renders and layout thrashing.

📊 Impact:
- Eliminated an artificial React double-render, making updates to the UI more synchronous and visually stable.
- Reduced the frequency of executing array filtering operations when users type, avoiding CPU thrashing.

🔬 Measurement:
- Type in the MCP tools search bar. The tool list will update after the user stops typing for 300ms, not blocking the UI thread and preventing freezing.
- Run `cd web-ui && node --experimental-strip-types --test` to ensure React UI changes didn't break builds.

---
*PR created automatically by Jules for task [9137453780644033618](https://jules.google.com/task/9137453780644033618) started by @bdqnghi*