### PR TITLE
⚡ Bolt: [performance improvement] Replace useDebounce with useDeferredValue for local array filtering

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -59,3 +59,7 @@
 ## 2024-06-10 - Refactoring toLowerCase in React UseMemo
 **Learning:** Performing array filtering with repeated inner `.toLowerCase()` calls during every render cycle (even inside `useMemo`) introduces unnecessary memory allocations and O(N) redundant string operations. In `NewSessionModal` and `CommandPalette`, refactoring `.toLowerCase()` logic by safely escaping strings before feeding them to a new `RegExp` object for robust matching improves UI responsiveness.
 **Action:** Always precompute a case-insensitive `RegExp` object via `new RegExp(query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i')` instead of repeatedly invoking `.toLowerCase()` on every element in the loop.
+
+## 2024-06-25 - React useDeferredValue vs useDebounce for local filtering
+**Learning:** Using `useDebounce` with an arbitrary delay (like 300ms) on text inputs that filter local arrays artificially introduces UI latency and "jank" feeling, as the user has to wait even if their machine could compute the result instantly.
+**Action:** Always prefer React's built-in `useDeferredValue` for local array filtering or rendering. It allows the input field to remain immediately responsive while pushing the expensive filtering work to the background without enforcing a strict, arbitrary time delay.

--- a/web-ui/src/components/CodeWiki/RepositoryGrid.tsx
+++ b/web-ui/src/components/CodeWiki/RepositoryGrid.tsx
@@ -1,8 +1,7 @@
-import { useMemo } from 'react';
+import { useMemo, useDeferredValue } from 'react';
 import { MagnifyingGlassIcon, PlusIcon, Cog6ToothIcon } from '@heroicons/react/24/outline';
 import { RepositoryCard } from './RepositoryCard';
 import { Repository } from './RepositoryExplorer';
-import { useDebounce } from '../../hooks/useDebounce';
 
 interface RepositoryGridProps {
   repositories: Repository[];
@@ -12,20 +11,22 @@ interface RepositoryGridProps {
 }
 
 export function RepositoryGrid({ repositories, searchQuery, onSearchChange, onAddRepository }: RepositoryGridProps) {
-  // Debounce the searchQuery to prevent expensive array filtering and reductions
-  // on every single keystroke.
-  const debouncedSearchQuery = useDebounce(searchQuery, 300);
+  // ⚡ Bolt Performance Optimization:
+  // Use useDeferredValue instead of useDebounce for local array filtering.
+  // This prevents artificial UI lag (waiting 300ms) and allows React to prioritize
+  // typing updates while rendering the filtered list in the background.
+  const deferredSearchQuery = useDeferredValue(searchQuery);
 
   // ⚡ Bolt Performance Optimization:
   // Memoize the filtered repositories array so it is only recalculated
-  // when the repositories list or the debounced search query changes,
+  // when the repositories list or the deferred search query changes,
   // preventing unnecessary O(N) recalculations and layout thrashing.
   const filteredRepositories = useMemo(() => {
-    if (!debouncedSearchQuery) return repositories;
+    if (!deferredSearchQuery) return repositories;
 
     // Precompute case-insensitive RegExp instead of repeatedly invoking .toLowerCase()
     // inside the array filter loop. This prevents O(N) redundant string allocations.
-    const queryRegex = new RegExp(debouncedSearchQuery.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
+    const queryRegex = new RegExp(deferredSearchQuery.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
 
     return repositories.filter(repo =>
       queryRegex.test(repo.name) ||
@@ -33,7 +34,7 @@ export function RepositoryGrid({ repositories, searchQuery, onSearchChange, onAd
       queryRegex.test(repo.description) ||
       queryRegex.test(repo.language)
     );
-  }, [repositories, debouncedSearchQuery]);
+  }, [repositories, deferredSearchQuery]);
 
   // ⚡ Bolt Performance Optimization:
   // Memoize the aggregations derived from filteredRepositories.

--- a/web-ui/src/components/Settings/MCPToolsModal.tsx
+++ b/web-ui/src/components/Settings/MCPToolsModal.tsx
@@ -5,9 +5,8 @@
  * Uses a master-detail pattern for optimal information architecture.
  */
 
-import { useState, useMemo, useEffect } from 'react';
+import { useState, useMemo, useEffect, useDeferredValue } from 'react';
 import { XMarkIcon, MagnifyingGlassIcon, ClipboardIcon, CheckIcon } from '@heroicons/react/24/outline';
-import { useDebounce } from '../../hooks/useDebounce';
 import { WrenchScrewdriverIcon } from '@heroicons/react/24/solid';
 import type { MCPTool } from '../../types/mcp';
 
@@ -24,9 +23,10 @@ export function MCPToolsModal({ isOpen, serverName, tools, onClose }: MCPToolsMo
   const [copiedText, setCopiedText] = useState<string | null>(null);
 
   // ⚡ Bolt Performance Optimization:
-  // Debouncing the search query to prevent excessive array filtering on every keystroke.
-  // The query filters through an array `tools.filter`, which might cause UI jank (O(N) layout thrashing) for large sets of tools.
-  const debouncedSearchQuery = useDebounce(searchQuery, 300);
+  // Use useDeferredValue instead of useDebounce for local array filtering.
+  // This prevents artificial UI lag (waiting 300ms) and allows React to prioritize
+  // typing updates while rendering the filtered list in the background.
+  const deferredSearchQuery = useDeferredValue(searchQuery);
 
   // Reset state when modal opens or tools change
   useEffect(() => {
@@ -39,18 +39,18 @@ export function MCPToolsModal({ isOpen, serverName, tools, onClose }: MCPToolsMo
 
   // Filter tools based on search query
   const filteredTools = useMemo(() => {
-    if (!debouncedSearchQuery.trim()) return tools;
+    if (!deferredSearchQuery.trim()) return tools;
 
     // ⚡ Bolt Performance Optimization:
     // Precompute a case-insensitive RegExp instead of repeatedly invoking .toLowerCase()
     // inside the filter loop. This prevents O(N) redundant string allocations.
-    const queryRegex = new RegExp(debouncedSearchQuery.trim().replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
+    const queryRegex = new RegExp(deferredSearchQuery.trim().replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
     return tools.filter(
       tool =>
         queryRegex.test(tool.name) ||
         queryRegex.test(tool.description)
     );
-  }, [tools, debouncedSearchQuery]);
+  }, [tools, deferredSearchQuery]);
 
   // Auto-select first tool when filtered list changes
   useEffect(() => {

--- a/web-ui/src/components/TraceAnalysis/SearchPanel.tsx
+++ b/web-ui/src/components/TraceAnalysis/SearchPanel.tsx
@@ -1,8 +1,7 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useDeferredValue } from 'react';
 import type { AnyFlowNode } from '../../utils/trace/collapseGraph';
 import type { TraceNodeData, ToolNodeData, TaskNodeData, CollapsedNodeData, AnyNodeData, ContentBlock } from '../../types/trace';
 import { getToolNames } from '../../types/trace';
-import { useDebounce } from '../../hooks/useDebounce';
 
 const NODE_TYPE_DOT_CLASSES: Record<string, string> = {
   user: 'bg-accent-secondary-100',
@@ -124,11 +123,13 @@ export function SearchPanel({ nodes, onSelectNode }: Props) {
   const [query, setQuery] = useState('');
 
   // ⚡ Bolt Performance Optimization:
-  // Debouncing the search query to prevent excessive filtering of nodes on every keystroke
-  const debouncedQuery = useDebounce(query, 300);
+  // Use useDeferredValue instead of useDebounce for local array filtering.
+  // This prevents artificial UI lag (waiting 300ms) and allows React to prioritize
+  // typing updates while rendering the filtered list in the background.
+  const deferredQuery = useDeferredValue(query);
 
   const results = useMemo<SearchResult[]>(() => {
-    const q = debouncedQuery.trim();
+    const q = deferredQuery.trim();
     if (!q) return [];
     const queryRegex = new RegExp(escapeRegExp(q), 'i');
     const out: SearchResult[] = [];
@@ -168,9 +169,9 @@ export function SearchPanel({ nodes, onSelectNode }: Props) {
     }
 
     return out;
-  }, [nodes, debouncedQuery]);
+  }, [nodes, deferredQuery]);
 
-  const queryRegex = useMemo(() => debouncedQuery.trim() ? new RegExp(escapeRegExp(debouncedQuery.trim()), 'i') : null, [debouncedQuery]);
+  const queryRegex = useMemo(() => deferredQuery.trim() ? new RegExp(escapeRegExp(deferredQuery.trim()), 'i') : null, [deferredQuery]);
 
   return (
     <div className="w-[260px] shrink-0 flex flex-col bg-bg-100 border-r border-border-300/20 font-sans overflow-hidden">
@@ -195,7 +196,7 @@ export function SearchPanel({ nodes, onSelectNode }: Props) {
         )}
       </div>
 
-      {debouncedQuery.trim() && (
+      {deferredQuery.trim() && (
         <div className="px-3 pb-1.5 text-[10px] text-text-400">
           {results.length} result{results.length !== 1 ? 's' : ''}
         </div>


### PR DESCRIPTION
💡 **What**
Replaced `useDebounce(..., 300)` with `useDeferredValue(...)` in three critical frontend search components (`RepositoryGrid.tsx`, `MCPToolsModal.tsx`, and `SearchPanel.tsx`). Also removed the `useDebounce` imports in these files.

🎯 **Why**
While `useDebounce` is perfect for reducing network requests, it's an anti-pattern for filtering local, in-memory arrays. Using a 300ms debounce forces the user to wait a third of a second for results to appear *even when the browser could calculate them instantly*. By switching to React 18's `useDeferredValue`, we tell React: "Keep the typing input completely responsive at 60fps, but render the filtered list in the background as fast as possible without any artificial waiting."

📊 **Impact**
- Eliminates 300ms of artificial latency from local UI searches.
- Prevents UI layout thrashing when typing quickly.
- Input fields will feel instantly responsive even when filtering very large lists.

🔬 **Measurement**
Type quickly in any of the modified search boxes (CodeWiki Repositories, MCP Tools list, Trace Search Panel). Notice that the input cursor never stutters, but the results now update immediately (as fast as the CPU allows) instead of waiting for a pause in typing.

---
*PR created automatically by Jules for task [8565464264644495407](https://jules.google.com/task/8565464264644495407) started by @bdqnghi*