### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TOCTOU vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -106,3 +106,8 @@
 ## 2025-09-08 - [Reverted overly strict permissions on file write tool]
 **Learning:** Enforcing restrictive `.mode(0o600)` on temporary files created during atomic writes in general-purpose file modification tools (like `file_write.rs`) is dangerous. Since the permissions carry over upon rename, it prevents other system users, web servers, or container volumes from reading codebase files, causing widespread access regressions.
 **Prevention:** Do not enforce `.mode(0o600)` during atomic writes unless the target file explicitly stores sensitive application state, secrets, or localized caching data. For generic codebase file updates, rely on the `umask` defaults (e.g., standard `std::fs::write` behavior) or preserve the existing file's permissions, while retaining `create_new(true)` with randomized names to provide defense-in-depth against TOCTOU.
+
+## 2026-06-17 - Fix TOCTOU vulnerability in memory consolidation
+**Vulnerability:** Using `std::fs::write` for creating a lock file (`.consolidation.lock`) is vulnerable to Time-of-Check to Time-of-Use (TOCTOU) symlink attacks. It doesn't guarantee exclusive creation, and could be exploited if an attacker symlinks the lock file to a sensitive location.
+**Learning:** The standard library's `std::fs::write` internally truncates and writes, which is unsafe for lock files. In a multi-user or concurrent environment, this can lead to privilege escalation or data corruption if symlinked to a different file.
+**Prevention:** Always use `std::fs::OpenOptions` with `.create_new(true)` when creating lock files. This ensures the file is created atomically and fails if it already exists or if it's a symlink to an existing file.

--- a/crates/opendev-agents/src/memory_consolidation.rs
+++ b/crates/opendev-agents/src/memory_consolidation.rs
@@ -95,7 +95,17 @@ pub async fn consolidate(working_dir: &Path) -> Option<ConsolidationReport> {
     let backup_dir = paths.memory_backup_dir();
 
     // Acquire lock
-    if let Err(e) = std::fs::write(&lock_path, "locked") {
+    let mut open_opts = std::fs::OpenOptions::new();
+    open_opts.write(true).create_new(true);
+
+    let lock_result = open_opts
+        .open(&lock_path)
+        .and_then(|mut f| {
+            use std::io::Write;
+            f.write_all(b"locked")
+        });
+
+    if let Err(e) = lock_result {
         warn!("Failed to acquire consolidation lock: {e}");
         return None;
     }

--- a/crates/opendev-agents/src/memory_consolidation.rs
+++ b/crates/opendev-agents/src/memory_consolidation.rs
@@ -98,12 +98,10 @@ pub async fn consolidate(working_dir: &Path) -> Option<ConsolidationReport> {
     let mut open_opts = std::fs::OpenOptions::new();
     open_opts.write(true).create_new(true);
 
-    let lock_result = open_opts
-        .open(&lock_path)
-        .and_then(|mut f| {
-            use std::io::Write;
-            f.write_all(b"locked")
-        });
+    let lock_result = open_opts.open(&lock_path).and_then(|mut f| {
+        use std::io::Write;
+        f.write_all(b"locked")
+    });
 
     if let Err(e) = lock_result {
         warn!("Failed to acquire consolidation lock: {e}");


### PR DESCRIPTION
🚨 **Severity:** CRITICAL

💡 **Vulnerability:**
The `consolidate()` function in `crates/opendev-agents/src/memory_consolidation.rs` used `std::fs::write(&lock_path, "locked")` to acquire a concurrency lock (`.consolidation.lock`). `std::fs::write` opens files without exclusive creation flags, which is vulnerable to Time-of-Check to Time-of-Use (TOCTOU) symlink attacks.

🎯 **Impact:**
An attacker could pre-create the `.consolidation.lock` file as a symlink pointing to an arbitrary file. Because `std::fs::write` blindly follows symlinks and truncates existing files, this would cause the application to overwrite sensitive system files or data with the string "locked", leading to data corruption or privilege escalation. Furthermore, it failed its intended purpose of providing strict mutual exclusion for concurrent execution.

🔧 **Fix:**
Replaced `std::fs::write` with an atomic open pattern using `std::fs::OpenOptions::new().write(true).create_new(true)`. This enforces the `O_CREAT | O_EXCL` flags at the operating system level, ensuring the lock file is created exclusively. If the file (or a symlink) already exists, the OS securely rejects the creation attempt.

✅ **Verification:**
- Verified that compiling the backend with `cargo test` and `cargo clippy` succeeds.
- Verified frontend tests succeed.
- Added a detailed entry to `.jules/sentinel.md` documenting the vulnerability and prevention strategy.

---
*PR created automatically by Jules for task [4990055249753722081](https://jules.google.com/task/4990055249753722081) started by @bdqnghi*