### PR TITLE
⚡ Bolt: [performance improvement] Use useDeferredValue for RepositoryExplorer search

### DIFF
--- a/web-ui/src/components/CodeWiki/RepositoryExplorer.tsx
+++ b/web-ui/src/components/CodeWiki/RepositoryExplorer.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useDeferredValue } from 'react';
 import {
   FolderIcon,
   DocumentTextIcon,
@@ -76,19 +76,25 @@ export function RepositoryExplorer({ selectedRepo, onRepoSelect, searchQuery }: 
   const [expandedRepos, setExpandedRepos] = useState<Set<string>>(new Set());
 
   // ⚡ Bolt Performance Optimization:
+  // Use useDeferredValue instead of useDebounce for local array filtering.
+  // This prevents artificial UI lag (waiting 300ms) and allows React to prioritize
+  // typing updates while rendering the filtered list in the background.
+  const deferredSearchQuery = useDeferredValue(searchQuery);
+
+  // ⚡ Bolt Performance Optimization:
   // Precompute case-insensitive RegExp instead of repeatedly invoking .toLowerCase()
   // inside the array filter loop. This prevents redundant string allocations per iteration.
   // We use useMemo to prevent excessive filtering and aggregations on every render.
   const filteredRepos = useMemo(() => {
-    if (!searchQuery) return mockRepositories;
+    if (!deferredSearchQuery) return mockRepositories;
 
-    const queryRegex = new RegExp(searchQuery.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
+    const queryRegex = new RegExp(deferredSearchQuery.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
     return mockRepositories.filter(repo =>
       queryRegex.test(repo.name) ||
       queryRegex.test(repo.fullName) ||
       queryRegex.test(repo.description)
     );
-  }, [searchQuery]);
+  }, [deferredSearchQuery]);
 
   const totalFiles = useMemo(() => {
     return filteredRepos.reduce((sum, repo) => sum + repo.files, 0);


### PR DESCRIPTION
💡 What
Replaced direct usage of the `searchQuery` prop with `useDeferredValue` for local array filtering in the `RepositoryExplorer` component.

🎯 Why
When `searchQuery` changes on every keystroke, the parent component updates synchronously. Running `useMemo` with the synchronous `searchQuery` blocks the main thread to perform a filtering operation on the repository list, which can cause artificial UI lag ("jank") while the user types.

📊 Impact
Using `useDeferredValue(searchQuery)` instructs React to prioritize the input field update and defer the expensive filtering array computation to a background render. This keeps the typing experience immediately responsive while updating the filtered results as soon as the main thread becomes idle.

🔬 Measurement
- Run `cd web-ui && node --experimental-strip-types --test` to verify frontend remains healthy.
- Run `cargo test` and `cargo clippy` to ensure backend integration passes.

---
*PR created automatically by Jules for task [2702425963183424850](https://jules.google.com/task/2702425963183424850) started by @bdqnghi*