### PR TITLE
⚡ Bolt: [performance improvement] Replace array with Set for O(1) graph traversal lookups

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -71,3 +71,7 @@
 ## 2024-07-28 - RegExp test instead of repeated sequential includes
 **Learning:** Checking for multiple substring matches in React render methods by chaining sequential `.includes()` calls on the same target string (e.g., `str.includes('A') || str.includes('B')`) creates redundant operations. In components that render frequently or iterate over large arrays (like formatting log lines in `ToolCallMessage`), this results in excessive memory allocation and poor performance.
 **Action:** Replace sequences of `.includes()` calls with a single precompiled case-insensitive regular expression (e.g., `/a|b/i.test(str)`) defined outside of the component to improve rendering performance and minimize memory bloat.
+
+## 2024-07-29 - O(N) Array Includes Lookups in Graph Traversal
+**Learning:** Using an array to track visited or absorbed nodes and performing `.includes()` checks on it during a graph traversal (like in `mergeToolCallNodes` within `buildGraph.ts`) introduces O(N^2) complexity and creates a performance bottleneck when processing large session traces with many parallel executions.
+**Action:** Always use a `Set` (e.g., `nodesToAbsorb = new Set<string>()`) and perform `.has()` checks for O(1) lookups when tracking elements during graph traversal algorithms.

--- a/web-ui/src/utils/trace/buildGraph.ts
+++ b/web-ui/src/utils/trace/buildGraph.ts
@@ -221,7 +221,9 @@ export function mergeToolCallNodes(
     const childNode = nodeMap.get(childId)!;
 
     let toolCalls = collectToolCalls(node, childNode);
-    const nodesToAbsorb: string[] = [];
+    // ⚡ Bolt Performance Optimization:
+    // Replace array with Set to prevent O(N) .has() lookups during graph traversal
+    const nodesToAbsorb = new Set<string>();
 
     const parallelStack = allChildren.filter(cid => {
       if (cid === childId || toRemove.has(cid)) return false;
@@ -233,7 +235,7 @@ export function mergeToolCallNodes(
 
     while (parallelStack.length > 0) {
       const parId = parallelStack.pop()!;
-      if (toRemove.has(parId) || nodesToAbsorb.includes(parId)) continue;
+      if (toRemove.has(parId) || nodesToAbsorb.has(parId)) continue;
       const parNode = nodeMap.get(parId);
       if (!parNode) continue;
 
@@ -249,7 +251,8 @@ export function mergeToolCallNodes(
       if (parResultId) {
         const parResultNode = nodeMap.get(parResultId)!;
         toolCalls = [...toolCalls, ...collectToolCalls(parNode, parResultNode)];
-        nodesToAbsorb.push(parId, parResultId);
+        nodesToAbsorb.add(parId);
+        nodesToAbsorb.add(parResultId);
 
         for (const cid of parChildren) {
           if (cid === parResultId || toRemove.has(cid)) continue;


### PR DESCRIPTION
💡 What
Replaced the `nodesToAbsorb` array with a `Set<string>` in `mergeToolCallNodes` within `web-ui/src/utils/trace/buildGraph.ts`. Modified `.includes()` array checks to `.has()` Set checks and `.push()` to `.add()`.

🎯 Why
Using an array and calling `.includes()` during a deep graph traversal algorithm introduces an O(N^2) complexity bottleneck. When processing extremely large trace graphs with many parallel child nodes, this sequential array scan causes severe performance degradation and high CPU utilization.

📊 Impact
Reduces lookup complexity from O(N) to O(1) inside the `while` loop that resolves graph traversals. Drastically improves the speed of parsing and building the ReactFlow DAG for large agent traces, making the trace analyzer significantly faster and more responsive.

🔬 Measurement
Review the trace DAG load time on sessions containing many subagents or deeply nested parallel tool calls. Ensure the execution correctly compiles and passes tests via `cd web-ui && node --experimental-strip-types --test` and `cargo test`.

---
*PR created automatically by Jules for task [8556184732572015401](https://jules.google.com/task/8556184732572015401) started by @bdqnghi*