### PR TITLE
⚡ Bolt: [performance improvement] Replace synchronous `std::fs::read_to_string` with `tokio::fs::read_to_string` in async context

### DIFF
--- a/crates/opendev-tools-lsp/src/wrapper.rs
+++ b/crates/opendev-tools-lsp/src/wrapper.rs
@@ -318,8 +318,6 @@ async fn notify_did_open(
     file_path: &Path,
     uri: &str,
 ) -> Result<(), LspError> {
-    // ⚡ Bolt: Replace synchronous std::fs::read_to_string with tokio::fs::read_to_string().await
-    // to prevent blocking the async executor thread during file I/O.
     let content = tokio::fs::read_to_string(file_path)
         .await
         .map_err(|e| LspError::FileNotFound(format!("{}: {}", file_path.display(), e)))?;

--- a/crates/opendev-tools-lsp/src/wrapper.rs
+++ b/crates/opendev-tools-lsp/src/wrapper.rs
@@ -318,7 +318,10 @@ async fn notify_did_open(
     file_path: &Path,
     uri: &str,
 ) -> Result<(), LspError> {
-    let content = std::fs::read_to_string(file_path)
+    // ⚡ Bolt: Replace synchronous std::fs::read_to_string with tokio::fs::read_to_string().await
+    // to prevent blocking the async executor thread during file I/O.
+    let content = tokio::fs::read_to_string(file_path)
+        .await
         .map_err(|e| LspError::FileNotFound(format!("{}: {}", file_path.display(), e)))?;
 
     let language_id = handler.config().language_id.clone();


### PR DESCRIPTION
💡 What: Replaced `std::fs::read_to_string` with `tokio::fs::read_to_string().await` inside `notify_did_open` in `crates/opendev-tools-lsp/src/wrapper.rs`.

🎯 Why: The `notify_did_open` function is an `async fn` executing on an async task executor. However, it used the blocking, synchronous `std::fs::read_to_string`. This blocks the async executor's thread while waiting on disk I/O, preventing other async tasks from running and degrading the concurrency and performance of the LSP handler.

📊 Impact: Reduces async thread blocking and improves the concurrency and responsiveness of the LSP handler when opening files.

🔬 Measurement: Verify compilation and tests with `cargo check -p opendev-tools-lsp` and `cargo test -p opendev-tools-lsp`.

---
*PR created automatically by Jules for task [2381474961387738778](https://jules.google.com/task/2381474961387738778) started by @bdqnghi*