### PR TITLE
fix Kimi streaming response parsing

### DIFF
--- a/crates/opendev-agents/src/llm_calls/mod.rs
+++ b/crates/opendev-agents/src/llm_calls/mod.rs
@@ -252,12 +252,15 @@ impl LlmCaller {
             }
         };
 
-        let raw_content = message.get("content").and_then(|c| c.as_str());
-        let cleaned_content = self.cleaner.clean(raw_content);
         let reasoning_content = message
             .get("reasoning_content")
             .and_then(|r| r.as_str())
             .map(|s| s.to_string());
+        let raw_content = message.get("content").and_then(|c| c.as_str());
+        let content = raw_content
+            .filter(|c| !c.is_empty())
+            .or(reasoning_content.as_deref());
+        let cleaned_content = self.cleaner.clean(content);
 
         debug!(
             has_content = raw_content.is_some(),

--- a/crates/opendev-agents/src/llm_calls/tests.rs
+++ b/crates/opendev-agents/src/llm_calls/tests.rs
@@ -140,6 +140,24 @@ fn test_parse_response_with_reasoning_content() {
 }
 
 #[test]
+fn test_parse_response_uses_reasoning_content_when_content_empty() {
+    let caller = make_caller();
+    let body = serde_json::json!({
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "reasoning_content": "I am Kimi Code 2.7."
+            }
+        }]
+    });
+    let resp = caller.parse_action_response(&body);
+    assert!(resp.success);
+    assert_eq!(resp.content.as_deref(), Some("I am Kimi Code 2.7."));
+    assert_eq!(resp.reasoning_content.as_deref(), Some("I am Kimi Code 2.7."));
+}
+
+#[test]
 fn test_parse_action_response_extracts_finish_reason() {
     let caller = make_caller();
     let body = serde_json::json!({

--- a/crates/opendev-http/src/adapted_client.rs
+++ b/crates/opendev-http/src/adapted_client.rs
@@ -424,7 +424,7 @@ impl AdaptedClient {
 
                 if line.is_empty() {
                     // Empty line = end of SSE event block
-                    if !line_buf.is_empty() && line_buf.trim() == "data: [DONE]" {
+                    if !line_buf.is_empty() && crate::streaming::is_sse_done(&line_buf) {
                         stream_done = true;
                         line_buf.clear();
                         event_type = None;
@@ -532,10 +532,10 @@ impl AdaptedClient {
 
                 if let Some(et) = line.strip_prefix("event: ") {
                     event_type = Some(et.to_string());
-                } else if line.starts_with("data: ") {
+                } else if line.starts_with("data:") {
                     // Process any previous pending data line before starting a new one
                     if !line_buf.is_empty() {
-                        if line_buf.trim() == "data: [DONE]" {
+                        if crate::streaming::is_sse_done(&line_buf) {
                             stream_done = true;
                         } else if let Some(data_json) = crate::streaming::parse_sse_data(&line_buf)
                         {
@@ -560,7 +560,7 @@ impl AdaptedClient {
             // Eagerly process pending line_buf for stream-terminating events
             // that arrive without a trailing blank line (e.g. last chunk).
             if !stream_done && !line_buf.is_empty() {
-                if line_buf.trim() == "data: [DONE]" {
+                if crate::streaming::is_sse_done(&line_buf) {
                     stream_done = true;
                 } else if let Some(data_json) = crate::streaming::parse_sse_data(&line_buf) {
                     let et = event_type.as_deref().unwrap_or_else(|| {
@@ -727,6 +727,7 @@ impl AdaptedClient {
             .ok_or_else(|| HttpError::Other("No stdout from curl".to_string()))?;
 
         let mut accumulated_text = String::new();
+        let mut accumulated_reasoning = String::new();
         let mut tool_calls: Vec<serde_json::Value> = Vec::new();
         let mut current_tool_args: std::collections::HashMap<usize, String> =
             std::collections::HashMap::new();
@@ -762,8 +763,8 @@ impl AdaptedClient {
             if trimmed.is_empty() || trimmed.starts_with(':') {
                 continue;
             }
-            let data = match trimmed.strip_prefix("data: ") {
-                Some(d) => d.trim(),
+            let data = match trimmed.strip_prefix("data:") {
+                Some(d) => d.trim_start(),
                 None => continue,
             };
             if data == "[DONE]" {
@@ -788,6 +789,13 @@ impl AdaptedClient {
                     {
                         accumulated_text.push_str(text);
                         callback.on_event(&StreamEvent::TextDelta(text.to_string()));
+                    }
+
+                    if let Some(text) = delta.get("reasoning_content").and_then(|c| c.as_str())
+                        && !text.is_empty()
+                    {
+                        accumulated_reasoning.push_str(text);
+                        callback.on_event(&StreamEvent::ReasoningDelta(text.to_string()));
                     }
 
                     if let Some(tc_deltas) = delta.get("tool_calls").and_then(|t| t.as_array()) {
@@ -859,6 +867,9 @@ impl AdaptedClient {
         if !tool_calls.is_empty() {
             message["tool_calls"] = serde_json::Value::Array(tool_calls);
         }
+        if !accumulated_reasoning.is_empty() {
+            message["reasoning_content"] = serde_json::Value::String(accumulated_reasoning);
+        }
 
         let finish = match stop_reason.as_deref() {
             Some("tool_calls") => "tool_calls",
@@ -872,7 +883,11 @@ impl AdaptedClient {
             }
         };
 
-        if !stream_done && message["content"].is_null() && message.get("tool_calls").is_none() {
+        if !stream_done
+            && message["content"].is_null()
+            && message.get("tool_calls").is_none()
+            && message.get("reasoning_content").is_none()
+        {
             warn!("curl stream ended with no content");
             return Ok(HttpResult::fail(
                 "No response received from curl stream",

--- a/crates/opendev-http/src/adapters/chat_completions.rs
+++ b/crates/opendev-http/src/adapters/chat_completions.rs
@@ -39,6 +39,12 @@ impl ChatCompletionsAdapter {
                 return Some(StreamEvent::TextDelta(text.to_string()));
             }
 
+            if let Some(text) = delta.get("reasoning_content").and_then(|c| c.as_str())
+                && !text.is_empty()
+            {
+                return Some(StreamEvent::ReasoningDelta(text.to_string()));
+            }
+
             if let Some(tc_deltas) = delta.get("tool_calls").and_then(|t| t.as_array()) {
                 for tc_delta in tc_deltas {
                     let idx = tc_delta.get("index").and_then(|i| i.as_u64()).unwrap_or(0) as usize;

--- a/crates/opendev-http/src/adapters/chat_completions_tests.rs
+++ b/crates/opendev-http/src/adapters/chat_completions_tests.rs
@@ -26,6 +26,25 @@ fn test_parse_tool_call_args_as_string_delta() {
     }
 }
 
+#[test]
+fn test_parse_reasoning_content_delta() {
+    let chunk = json!({
+        "choices": [{
+            "delta": {
+                "content": null,
+                "reasoning_content": "I am Kimi Code 2.7."
+            }
+        }]
+    });
+    let event = ChatCompletionsAdapter::parse_chat_completions_sse(&chunk);
+    match event {
+        Some(StreamEvent::ReasoningDelta(delta)) => {
+            assert_eq!(delta, "I am Kimi Code 2.7.");
+        }
+        other => panic!("expected ReasoningDelta, got {other:?}"),
+    }
+}
+
 /// Regression (z.ai GLM-5.1, observed 2026-04-19): GLM-5.1 in OpenAI-compat
 /// mode emits `function.arguments` as a JSON *object* instead of the
 /// spec-mandated JSON-encoded string. The previous adapter silently dropped

--- a/crates/opendev-http/src/streaming.rs
+++ b/crates/opendev-http/src/streaming.rs
@@ -81,13 +81,21 @@ impl StreamCallback for CompositeStreamCallback<'_> {
     }
 }
 
-/// Parse a single SSE data line (after "data: " prefix) as JSON.
+/// Parse a single SSE data line as JSON.
 pub fn parse_sse_data(line: &str) -> Option<Value> {
-    let data = line.strip_prefix("data: ")?;
+    let data = line.strip_prefix("data:")?.trim_start();
     if data == "[DONE]" {
         return None;
     }
     serde_json::from_str(data).ok()
+}
+
+/// Return true when an SSE data line is the stream terminator.
+pub fn is_sse_done(line: &str) -> bool {
+    matches!(
+        line.trim().strip_prefix("data:"),
+        Some(data) if data.trim() == "[DONE]"
+    )
 }
 
 /// Parse an SSE event block (event type + data) from raw lines.
@@ -102,3 +110,7 @@ pub fn parse_sse_block(event_line: Option<&str>, data_line: &str) -> Option<(Str
     let data = parse_sse_data(data_line)?;
     Some((event_type, data))
 }
+
+#[cfg(test)]
+#[path = "streaming_tests.rs"]
+mod tests;

--- a/crates/opendev-http/src/streaming_tests.rs
+++ b/crates/opendev-http/src/streaming_tests.rs
@@ -1,0 +1,13 @@
+use super::*;
+
+#[test]
+fn parse_sse_data_accepts_data_without_space() {
+    let parsed = parse_sse_data(r#"data:{"type":"chunk"}"#).expect("data line should parse");
+    assert_eq!(parsed["type"], "chunk");
+}
+
+#[test]
+fn is_sse_done_accepts_data_without_space() {
+    assert!(is_sse_done("data:[DONE]"));
+    assert!(is_sse_done("data: [DONE]"));
+}


### PR DESCRIPTION
## Summary

Fixes #190.

- Accept SSE `data:` lines with or without a space after the colon.
- Surface OpenAI-compatible `delta.reasoning_content` chunks as reasoning stream events.
- Preserve streamed reasoning in both reqwest and curl streaming paths.
- Fall back to `reasoning_content` as final assistant content when `message.content` is empty/null.

## Root Cause

Kimi Code 2.7 streams OpenAI-compatible chunks as `data:{...}` and puts the response text in `delta.reasoning_content` while leaving `delta.content` null. The streaming parser required `data: {...}`, ignored `reasoning_content`, and later only exposed `message.content` as final output.

## Validation

- `git diff --check` passed.
- `cargo test -p opendev-http parse_sse_data_accepts_data_without_space --lib` not run: local environment has no `cargo` binary.
- `cargo fmt --all -- --check` not run: local environment has no `cargo` binary.
- Full workspace checks and real LLM simulation were not run for the same local toolchain limitation.