### PR TITLE
⚡ Bolt: Replace Array.shift() with index pointer in graph layout queues

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -75,3 +75,7 @@
 ## 2024-07-29 - O(N) Array Includes Lookups in Graph Traversal
 **Learning:** Using an array to track visited or absorbed nodes and performing `.includes()` checks on it during a graph traversal (like in `mergeToolCallNodes` within `buildGraph.ts`) introduces O(N^2) complexity and creates a performance bottleneck when processing large session traces with many parallel executions.
 **Action:** Always use a `Set` (e.g., `nodesToAbsorb = new Set<string>()`) and perform `.has()` checks for O(1) lookups when tracking elements during graph traversal algorithms.
+
+## 2024-08-01 - O(N^2) Performance Bottleneck in JavaScript Queues using Array.shift()
+**Learning:** Using `Array.shift()` inside a queue loop (like BFS traversals) causes an O(N^2) performance bottleneck because it shifts all remaining contiguous array elements in memory on every iteration.
+**Action:** Replace `.shift()` with an explicit index pointer (e.g., `let qIdx = 0; queue[qIdx++]`) to process elements sequentially without array mutation overhead, maintaining O(N) complexity.

--- a/web-ui/src/utils/trace/buildGraph.ts
+++ b/web-ui/src/utils/trace/buildGraph.ts
@@ -470,8 +470,9 @@ export function layoutGraph<T extends {
     queue.push({ id: r.id, lane: 0 });
     queued.add(r.id);
   }
-  while (queue.length > 0) {
-    const { id, lane } = queue.shift()!;
+  let qIdx = 0;
+  while (qIdx < queue.length) {
+    const { id, lane } = queue[qIdx++];
     if (nodeLane.has(id)) continue;
     nodeLane.set(id, lane);
     const node = nodeMap.get(id);
@@ -560,8 +561,9 @@ export function layoutGraph<T extends {
     const visited = new Set<string>();
     const order: string[] = [];
     const bfsQ = compRoots.map(n => n.id);
-    while (bfsQ.length > 0) {
-      const id = bfsQ.shift()!;
+    let bfsQIdx = 0;
+    while (bfsQIdx < bfsQ.length) {
+      const id = bfsQ[bfsQIdx++];
       if (visited.has(id)) continue;
       visited.add(id);
       order.push(id);


### PR DESCRIPTION
💡 What: Replaced `Array.prototype.shift()` operations within Breadth-First Search (BFS) loops in `web-ui/src/utils/trace/buildGraph.ts` with explicit index pointers (`qIdx` and `bfsQIdx`).

🎯 Why: Using `Array.shift()` inside a queue processing loop creates an O(N^2) performance bottleneck because shifting removes the first element and re-indexes all subsequent elements in memory. As the graph visualization parses increasingly large session traces, this caused significant UI stuttering and high CPU utilization.

📊 Impact: Converts O(N^2) queue iteration overhead into O(N) linear time parsing. While it consumes a small, negligible amount of temporary memory (as elements remain in the array until GC), it prevents layout thrashing on massive graphs.

🔬 Measurement: Verifiable by loading a very large trace containing deeply nested tool calls or parallel subgraph structures; the graph layout rendering time should drop significantly without blocking the React main thread.

---
*PR created automatically by Jules for task [6274097313763385025](https://jules.google.com/task/6274097313763385025) started by @bdqnghi*