### PR TITLE
⚡ Bolt: Replace .shift() with index pointer in graph traversal

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -78,3 +78,7 @@
 ## 2024-07-30 - O(N log N) Array Allocations in Sort Comparators
 **Learning:** Computing minimums of component arrays inside a `sort` comparator using `Math.min(...array.map(...))` creates massive performance bottlenecks and O(N log N) redundant array allocations and spread operations. For large components, it can even trigger maximum call stack size exceeded errors.
 **Action:** Always precompute aggregate values like minimum times before sorting, or rely on already-cached values (like `compMinTime`) for O(1) lookups inside the sort comparator.
+
+## 2024-08-01 - Array.shift() Performance in Queue Loops
+**Learning:** Using `Array.shift()` inside a queue loop (like BFS traversals) causes an O(N^2) performance bottleneck because it shifts all remaining contiguous array elements.
+**Action:** Replace `.shift()` with an explicit index pointer (e.g., `let qIdx = 0; queue[qIdx++]`) to maintain O(N) complexity during array traversal operations.

--- a/web-ui/src/utils/trace/buildGraph.ts
+++ b/web-ui/src/utils/trace/buildGraph.ts
@@ -470,8 +470,11 @@ export function layoutGraph<T extends {
     queue.push({ id: r.id, lane: 0 });
     queued.add(r.id);
   }
-  while (queue.length > 0) {
-    const { id, lane } = queue.shift()!;
+  // OPTIMIZATION: Use an index pointer instead of queue.shift() to avoid O(N^2) complexity
+  // caused by shifting contiguous array elements.
+  let qIdx = 0;
+  while (qIdx < queue.length) {
+    const { id, lane } = queue[qIdx++];
     if (nodeLane.has(id)) continue;
     nodeLane.set(id, lane);
     const node = nodeMap.get(id);
@@ -560,8 +563,11 @@ export function layoutGraph<T extends {
     const visited = new Set<string>();
     const order: string[] = [];
     const bfsQ = compRoots.map(n => n.id);
-    while (bfsQ.length > 0) {
-      const id = bfsQ.shift()!;
+    // OPTIMIZATION: Use an index pointer instead of bfsQ.shift() to avoid O(N^2) complexity
+    // caused by shifting contiguous array elements.
+    let bfsQIdx = 0;
+    while (bfsQIdx < bfsQ.length) {
+      const id = bfsQ[bfsQIdx++];
       if (visited.has(id)) continue;
       visited.add(id);
       order.push(id);


### PR DESCRIPTION
💡 What: Replaced `Array.prototype.shift()` with an explicit index pointer (`qIdx` / `bfsQIdx`) in the BFS queue loops within `layoutGraph` inside `web-ui/src/utils/trace/buildGraph.ts`.

🎯 Why: In JavaScript, `.shift()` causes a reallocation/re-indexing of the entire array, which is an O(N) operation. Executing this inside an N-iteration loop creates an O(N²) time complexity bottleneck during graph traversal, causing unnecessary CPU overhead when laying out large sets of nodes.

📊 Impact: Reduces time complexity of graph traversal loops from O(N²) to O(N). For large agent execution graphs (hundreds of nodes), this eliminates a potential main-thread blocking bottleneck, yielding faster perceived render times in the trace viewer.

🔬 Measurement: Observe CPU execution time and main thread blocking duration when rendering very large traces in the web UI. Performance testing shows O(1) dequeue operations consistently resolving faster than O(N) shifts. All tests passing.

---
*PR created automatically by Jules for task [8047714596922915525](https://jules.google.com/task/8047714596922915525) started by @bdqnghi*