### PR TITLE
⚡ Bolt: [performance improvement] fix Math.max call stack size exceeded on large graphs

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -82,3 +82,7 @@
 ## 2024-08-01 - Array.shift() Performance in Queue Loops
 **Learning:** Using `Array.shift()` inside a queue loop (like BFS traversals) causes an O(N^2) performance bottleneck because it shifts all remaining contiguous array elements.
 **Action:** Replace `.shift()` with an explicit index pointer (e.g., `let qIdx = 0; queue[qIdx++]`) to maintain O(N) complexity during array traversal operations.
+
+## 2024-08-02 - Maximum Call Stack Size Exceeded with Math.max and Spread
+**Learning:** Using `Math.max(...iterable)` with a spread operator on iterables like `Map.values()` (e.g., `Math.max(...nodeLane.values())` in `buildGraph.ts`) causes O(N) array allocations and passes all items as individual arguments. For large graphs, this exceeds the JavaScript engine's maximum call stack size limit (usually ~65,000), causing the application to crash.
+**Action:** Always compute the maximum value using a simple `for...of` loop over the iterable instead of using the spread operator with `Math.max` for unbounded data sets.

--- a/web-ui/src/utils/trace/buildGraph.ts
+++ b/web-ui/src/utils/trace/buildGraph.ts
@@ -548,7 +548,15 @@ export function layoutGraph<T extends {
     laneCurrentY.set(lane, yTop + NODE_HEIGHT + NODE_GAP);
   }
 
-  const maxPrimaryLane = nodeLane.size > 0 ? Math.max(...nodeLane.values()) : 0;
+  // OPTIMIZATION: Avoid using Math.max(...nodeLane.values()) to prevent
+  // "Maximum call stack size exceeded" errors on very large graphs
+  // and eliminate O(N) array allocation overhead from the spread operator.
+  let maxPrimaryLane = 0;
+  if (nodeLane.size > 0) {
+    for (const lane of nodeLane.values()) {
+      if (lane > maxPrimaryLane) maxPrimaryLane = lane;
+    }
+  }
   let nextSecondaryLane = maxPrimaryLane + 1;
 
   const sortedSecondary = [...secondaryComps.entries()].sort((a, b) => {


### PR DESCRIPTION
💡 What: Replaced `Math.max(...nodeLane.values())` with a standard `for...of` loop in `buildGraph.ts`.
🎯 Why: Spreading a large Map or Set iterator into `Math.max()` allocates an array of size N and passes all elements on the call stack. For massive graphs (tens of thousands of nodes), this triggers a "Maximum call stack size exceeded" exception and causes the UI to crash.
📊 Impact: Prevents catastrophic UI crashes on large session traces. Eliminates O(N) intermediate array allocation and spread operations during graph layout computation.
🔬 Measurement: Verify by loading an extremely large session trace with thousands of parallel executions. The UI should render without throwing stack overflow errors, and the layout engine should consume slightly less memory.

---
*PR created automatically by Jules for task [6098918380812078122](https://jules.google.com/task/6098918380812078122) started by @bdqnghi*