### PR TITLE
⚡ Bolt: Replace Math.max spread operator with loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -82,3 +82,6 @@
 ## 2024-08-01 - Array.shift() Performance in Queue Loops
 **Learning:** Using `Array.shift()` inside a queue loop (like BFS traversals) causes an O(N^2) performance bottleneck because it shifts all remaining contiguous array elements.
 **Action:** Replace `.shift()` with an explicit index pointer (e.g., `let qIdx = 0; queue[qIdx++]`) to maintain O(N) complexity during array traversal operations.
+## 2024-08-02 - Spread Operator Performance on Large Iterables
+**Learning:** Using `Math.max(...iterable)` with a spread operator on iterables like `Map.values()` causes O(N) array allocations and can exceed the JavaScript engine's maximum call stack size limit on large data structures.
+**Action:** Always compute the maximum value using a simple `for...of` loop for unbounded data sets to prevent application crashes and improve performance.

--- a/web-ui/src/utils/trace/buildGraph.ts
+++ b/web-ui/src/utils/trace/buildGraph.ts
@@ -548,7 +548,14 @@ export function layoutGraph<T extends {
     laneCurrentY.set(lane, yTop + NODE_HEIGHT + NODE_GAP);
   }
 
-  const maxPrimaryLane = nodeLane.size > 0 ? Math.max(...nodeLane.values()) : 0;
+  let maxPrimaryLane = 0;
+  // OPTIMIZATION: Avoid Math.max(...iter) which causes O(N) array allocation and can exceed stack limits
+  for (const lane of nodeLane.values()) {
+    if (lane > maxPrimaryLane) {
+      maxPrimaryLane = lane;
+    }
+  }
+
   let nextSecondaryLane = maxPrimaryLane + 1;
 
   const sortedSecondary = [...secondaryComps.entries()].sort((a, b) => {


### PR DESCRIPTION
💡 What: Replaced `Math.max(...nodeLane.values())` with a `for...of` loop in `buildGraph.ts`.
🎯 Why: Using the spread operator with `Math.max` on a large iterable causes O(N) array allocation and can exceed the JavaScript engine's maximum call stack size limit, leading to application crashes or slowdowns on very large graphs.
📊 Impact: Eliminates O(N) array allocation and prevents stack overflow errors, improving performance and reliability for large data sets.
🔬 Measurement: Verified with frontend test suite (`node --experimental-strip-types --test`) and manual code review. No change in behavior, purely a memory and safety optimization.

---
*PR created automatically by Jules for task [14654207675758173429](https://jules.google.com/task/14654207675758173429) started by @bdqnghi*