### PR TITLE
⚡ Bolt: Replace blocking std::fs with tokio::fs in memory_consolidation.rs

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -86,3 +86,7 @@
 ## 2024-08-02 - Maximum Call Stack Size Exceeded with Math.max and Spread
 **Learning:** Using `Math.max(...iterable)` with a spread operator on iterables like `Map.values()` (e.g., `Math.max(...nodeLane.values())` in `buildGraph.ts`) causes O(N) array allocations and passes all items as individual arguments. For large graphs, this exceeds the JavaScript engine's maximum call stack size limit (usually ~65,000), causing the application to crash.
 **Action:** Always compute the maximum value using a simple `for...of` loop over the iterable instead of using the spread operator with `Math.max` for unbounded data sets.
+
+## 2024-08-03 - Replacing synchronous std::fs operations with tokio::fs in memory_consolidation.rs
+**Learning:** In `crates/opendev-agents/src/memory_consolidation.rs`, using synchronous `std::fs` operations (e.g., `create_dir_all`, `copy`, `remove_file`, `rename`) inside the async functions `consolidate` and `run_consolidation` blocks the async executor thread, degrading concurrent performance.
+**Action:** Replace `std::fs` calls within async functions with `tokio::fs` equivalents (e.g., `tokio::fs::create_dir_all(...).await`) to ensure non-blocking file I/O operations and improve overall application concurrency.

--- a/crates/opendev-agents/src/memory_consolidation.rs
+++ b/crates/opendev-agents/src/memory_consolidation.rs
@@ -143,7 +143,7 @@ async fn run_consolidation(memory_dir: &Path, backup_dir: &Path) -> Option<Conso
     );
 
     // Phase 2: Backup
-    if let Err(e) = std::fs::create_dir_all(backup_dir) {
+    if let Err(e) = tokio::fs::create_dir_all(backup_dir).await {
         warn!("Failed to create backup directory: {e}");
         return None;
     }
@@ -151,7 +151,7 @@ async fn run_consolidation(memory_dir: &Path, backup_dir: &Path) -> Option<Conso
     let mut backed_up = 0;
     for file in &session_files {
         let dest = backup_dir.join(&file.filename);
-        if let Err(e) = std::fs::copy(&file.path, &dest) {
+        if let Err(e) = tokio::fs::copy(&file.path, &dest).await {
             warn!("Failed to backup {}: {e}", file.filename);
         } else {
             backed_up += 1;
@@ -217,19 +217,19 @@ async fn run_consolidation(memory_dir: &Path, backup_dir: &Path) -> Option<Conso
 
     if let Err(e) = write_result {
         warn!("Failed to write consolidated file: {e}");
-        let _ = std::fs::remove_file(&tmp_path);
+        let _ = tokio::fs::remove_file(&tmp_path).await;
         return None;
     }
-    if let Err(e) = std::fs::rename(&tmp_path, &consolidated_path) {
+    if let Err(e) = tokio::fs::rename(&tmp_path, &consolidated_path).await {
         warn!("Failed to rename consolidated file: {e}");
-        let _ = std::fs::remove_file(&tmp_path);
+        let _ = tokio::fs::remove_file(&tmp_path).await;
         return None;
     }
 
     // Phase 4: Prune — remove session files that were consolidated
     let mut pruned = 0;
     for file in &session_files {
-        if let Err(e) = std::fs::remove_file(&file.path) {
+        if let Err(e) = tokio::fs::remove_file(&file.path).await {
             warn!(
                 "Failed to remove consolidated session file {}: {e}",
                 file.filename


### PR DESCRIPTION
💡 What: Replaced synchronous `std::fs` calls with non-blocking `tokio::fs` in `memory_consolidation.rs` async functions.
🎯 Why: Synchronous I/O in async contexts blocks the executor thread, degrading concurrent performance.
📊 Impact: Prevents thread starvation and improves overall application concurrency when processing memory files.
🔬 Measurement: Observe CPU and thread utilization under heavy memory consolidation load, noting fewer blocked threads.

---
*PR created automatically by Jules for task [13927499885313175019](https://jules.google.com/task/13927499885313175019) started by @bdqnghi*