### PR TITLE
feat(auth): add experimental ChatGPT subscription setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4199,6 +4199,7 @@ name = "opendev-http"
 version = "0.1.9"
 dependencies = [
  "async-trait",
+ "base64 0.22.1",
  "chrono",
  "dirs 5.0.1",
  "fastrand",
@@ -4209,11 +4210,13 @@ dependencies = [
  "reqwest 0.13.2",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
+ "url",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,3 +116,5 @@ opendev-hooks = { version = "0.1.6", path = "crates/opendev-hooks" }
 opendev-plugins = { version = "0.1.6", path = "crates/opendev-plugins" }
 opendev-sandbox = { version = "0.1.6", path = "crates/opendev-sandbox" }
 url = "2"
+base64 = "0.22"
+sha2 = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ clap = { version = "4", features = ["derive"] }
 dirs-next = "2"
 
 # TypeScript type generation
-ts-rs = { version = "10", features = ["serde-json-impl", "chrono-impl"] }
+ts-rs = { version = "10", features = ["serde-json-impl", "chrono-impl", "no-serde-warnings"] }
 
 # Testing
 tempfile = "3"

--- a/crates/opendev-agents/src/prompts/composer/factories.rs
+++ b/crates/opendev-agents/src/prompts/composer/factories.rs
@@ -130,7 +130,7 @@ pub fn create_default_composer(templates_dir: impl AsRef<Path>) -> PromptCompose
     composer.register_section_with_policy(
         "provider_openai",
         "system/main/main-provider-openai.md",
-        Some(ctx_eq("model_provider", "openai")),
+        Some(ctx_in("model_provider", &["openai", "openai-chatgpt"])),
         80,
         CachePolicy::Static,
     );

--- a/crates/opendev-cli/src/cli.rs
+++ b/crates/opendev-cli/src/cli.rs
@@ -160,6 +160,10 @@ pub enum ConfigAction {
     Show,
 }
 
+#[cfg(test)]
+#[path = "cli_tests.rs"]
+mod tests;
+
 /// MCP subcommands.
 #[derive(Subcommand, Debug)]
 pub enum McpAction {

--- a/crates/opendev-cli/src/cli_tests.rs
+++ b/crates/opendev-cli/src/cli_tests.rs
@@ -1,0 +1,16 @@
+use super::*;
+use clap::Parser;
+
+#[test]
+fn chatgpt_login_is_available_only_through_setup() {
+    let setup = Cli::try_parse_from(["opendev", "setup"]).unwrap();
+    assert!(matches!(setup.command, Some(Commands::Setup)));
+
+    for arguments in [
+        ["opendev", "auth", "chatgpt", "login"].as_slice(),
+        ["opendev", "auth", "chatgpt", "status"].as_slice(),
+        ["opendev", "auth", "chatgpt", "logout"].as_slice(),
+    ] {
+        assert!(Cli::try_parse_from(arguments).is_err());
+    }
+}

--- a/crates/opendev-cli/src/runtime/mod.rs
+++ b/crates/opendev-cli/src/runtime/mod.rs
@@ -17,7 +17,7 @@ pub use tools::build_system_prompt;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
-use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue};
+use reqwest::header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue};
 use tracing::{debug, info};
 
 use opendev_agents::llm_calls::{LlmCallConfig, LlmCaller};
@@ -25,9 +25,9 @@ use opendev_agents::react_loop::{ReactLoop, ReactLoopConfig};
 use opendev_context::{ArtifactIndex, ContextCompactor};
 use opendev_history::SessionManager;
 use opendev_history::topic_detector::TopicDetector;
-use opendev_http::HttpClient;
 use opendev_http::adapted_client::AdaptedClient;
 use opendev_http::adapters::base::ProviderAdapter;
+use opendev_http::{CredentialStore, HttpClient};
 use opendev_mcp::McpManager;
 use opendev_models::AppConfig;
 use opendev_repl::HandlerRegistry;
@@ -103,6 +103,10 @@ impl AgentRuntime {
         working_dir: &Path,
         session_manager: SessionManager,
     ) -> Result<Self, String> {
+        if config.model_provider == "openai-chatgpt" && !config.experimental.chatgpt_auth {
+            return Err("openai-chatgpt requires experimental.chatgpt_auth = true".to_string());
+        }
+
         // Set up tool registry with overflow storage for truncated tool outputs.
         let overflow_dir = working_dir.join(".opendev").join("tool-output");
         // Clean up overflow files older than 7 days on startup.
@@ -223,174 +227,15 @@ impl AgentRuntime {
         // Effective base URL: config override > registry > provider default
         let effective_base_url = config.api_base_url.clone().or(registry_base_url);
 
-        let (api_url, headers, adapter): (
-            String,
-            HeaderMap,
-            Option<Box<dyn opendev_http::adapters::base::ProviderAdapter>>,
-        ) = match provider.as_str() {
-            "anthropic" => {
-                let adapter = opendev_http::adapters::anthropic::AnthropicAdapter::new();
-                let url = effective_base_url.unwrap_or_else(|| adapter.api_url().to_string());
-                let mut hdrs = HeaderMap::new();
-                // Anthropic uses x-api-key header (not Bearer)
-                if let Ok(val) = HeaderValue::from_str(&api_key) {
-                    hdrs.insert("x-api-key", val);
-                }
-                hdrs.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
-                for (key, value) in adapter.extra_headers() {
-                    if let (Ok(k), Ok(v)) = (
-                        reqwest::header::HeaderName::from_bytes(key.as_bytes()),
-                        HeaderValue::from_str(&value),
-                    ) {
-                        hdrs.insert(k, v);
-                    }
-                }
-                (
-                    url,
-                    hdrs,
-                    Some(
-                        Box::new(adapter) as Box<dyn opendev_http::adapters::base::ProviderAdapter>
-                    ),
-                )
-            }
-            "openai" => {
-                // OpenAI uses /v1/responses (Responses API) with Bearer auth
-                let adapter = opendev_http::adapters::openai::OpenAiAdapter::new();
-                let url = effective_base_url.unwrap_or_else(|| adapter.api_url().to_string());
-                let mut hdrs = HeaderMap::new();
-                if let Ok(val) = HeaderValue::from_str(&format!("Bearer {api_key}")) {
-                    hdrs.insert(AUTHORIZATION, val);
-                }
-                hdrs.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
-                (
-                    url,
-                    hdrs,
-                    Some(
-                        Box::new(adapter) as Box<dyn opendev_http::adapters::base::ProviderAdapter>
-                    ),
-                )
-            }
-            "ollama" => {
-                let adapter = opendev_http::adapters::ollama::OllamaAdapter::new();
-                let url = effective_base_url.unwrap_or_else(|| adapter.api_url().to_string());
-                let mut hdrs = HeaderMap::new();
-                hdrs.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
-                (
-                    url,
-                    hdrs,
-                    Some(
-                        Box::new(adapter) as Box<dyn opendev_http::adapters::base::ProviderAdapter>
-                    ),
-                )
-            }
-            "gemini" | "google" => {
-                let adapter = opendev_http::adapters::gemini::GeminiAdapter::new(&config.model);
-                let api_url = effective_base_url
-                    .map(|base| {
-                        opendev_http::adapters::gemini::gemini_api_url(&base, &config.model)
-                    })
-                    .unwrap_or_else(|| {
-                        opendev_http::adapters::gemini::gemini_api_url(
-                            adapter.api_url(),
-                            &config.model,
-                        )
-                    });
-                let mut hdrs = HeaderMap::new();
-                // Gemini uses x-goog-api-key header
-                if let Ok(val) = HeaderValue::from_str(&api_key) {
-                    hdrs.insert("x-goog-api-key", val);
-                }
-                hdrs.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
-                (
-                    api_url,
-                    hdrs,
-                    Some(
-                        Box::new(adapter) as Box<dyn opendev_http::adapters::base::ProviderAdapter>
-                    ),
-                )
-            }
-            "azure" => {
-                let base = effective_base_url
-                    .as_deref()
-                    .unwrap_or("https://api.openai.com");
-                let deployment = &config.model;
-                let url = format!(
-                    "{}/openai/deployments/{deployment}/chat/completions?api-version=2024-10-21",
-                    base.trim_end_matches('/')
-                );
-                let mut hdrs = HeaderMap::new();
-                if let Ok(val) = HeaderValue::from_str(&api_key) {
-                    hdrs.insert("api-key", val);
-                }
-                hdrs.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
-                let adapter = opendev_http::adapters::chat_completions::ChatCompletionsAdapter::new(
-                    url.clone(),
-                );
-                (
-                    url,
-                    hdrs,
-                    Some(
-                        Box::new(adapter) as Box<dyn opendev_http::adapters::base::ProviderAdapter>
-                    ),
-                )
-            }
-            provider => {
-                // OpenAI-compatible providers — use registry/config base URL or fall back
-                let url = effective_base_url
-                    .map(|base| {
-                        let trimmed = base.trim_end_matches('/');
-                        if trimmed.ends_with("/chat/completions") {
-                            trimmed.to_string()
-                        } else {
-                            format!("{trimmed}/chat/completions")
-                        }
-                    })
-                    .unwrap_or_else(|| "https://api.openai.com/v1/chat/completions".to_string());
-
-                let mut hdrs = HeaderMap::new();
-                if let Ok(val) = HeaderValue::from_str(&format!("Bearer {api_key}")) {
-                    hdrs.insert(AUTHORIZATION, val);
-                }
-                hdrs.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
-                if provider == "openrouter"
-                    && let Ok(val) = HeaderValue::from_str("https://opendev.ai")
-                {
-                    hdrs.insert("HTTP-Referer", val);
-                }
-                let adapter = opendev_http::adapters::chat_completions::ChatCompletionsAdapter::new(
-                    url.clone(),
-                );
-                (
-                    url,
-                    hdrs,
-                    Some(
-                        Box::new(adapter) as Box<dyn opendev_http::adapters::base::ProviderAdapter>
-                    ),
-                )
-            }
-        };
-
-        let circuit_breaker =
-            std::sync::Arc::new(opendev_http::CircuitBreaker::with_defaults(&provider));
-        let raw_http_client = HttpClient::new(api_url.clone(), headers, None)
-            .map_err(|e| format!("Failed to create HTTP client: {e}"))?
-            .with_circuit_breaker(circuit_breaker);
-
-        // DashScope Coding Plan endpoint rejects reqwest — must use curl subprocess.
-        let needs_curl = api_url.contains("coding-intl.dashscope.aliyuncs.com");
-        let curl_auth = needs_curl.then(|| format!("Authorization: Bearer {api_key}"));
-
-        let http_client = Arc::new({
-            let client = match adapter {
-                Some(a) => AdaptedClient::with_adapter(raw_http_client, a),
-                None => AdaptedClient::new(raw_http_client),
-            };
-            if let Some(auth) = curl_auth {
-                client.with_curl_transport(auth)
-            } else {
-                client
-            }
-        });
+        // Keep startup and model-switch construction on the same path.  In
+        // particular, this prevents an OpenAI-owned model switch from quietly
+        // changing a ChatGPT OAuth session into Platform API-key auth.
+        let http_client = Arc::new(Self::build_http_client(
+            &provider,
+            &api_key,
+            &config.model,
+            effective_base_url.as_deref(),
+        )?);
 
         // Check model capabilities via models.dev metadata
         let (supports_temperature, model_max_tokens, model_context_length) = {
@@ -716,13 +561,18 @@ impl AgentRuntime {
 }
 
 impl AgentRuntime {
-    /// Drop the tool-approval channel sender so Bash and MCP tools auto-execute
-    /// without prompting. The corresponding receiver is only consumed by the TUI;
-    /// callers that don't run a TUI (non-interactive `-p` mode, or interactive with
-    /// `--dangerously-skip-permissions`) must call this or the approval gate will
-    /// block forever on a response that never comes.
+    /// Drop interactive approval channels for headless execution.
+    ///
+    /// The corresponding receivers are only consumed by the TUI. In particular,
+    /// `EnterPlanMode` must be re-registered without its TUI approval sender:
+    /// otherwise a non-interactive `-p` request that creates a plan waits forever
+    /// for an approval response no process can provide.
     pub fn disable_tool_approvals(&mut self) {
         self.tool_approval_tx = None;
+        self.tool_registry
+            .register(Arc::new(PresentPlanTool::with_todo_manager(Arc::clone(
+                &self.todo_manager,
+            ))));
     }
 
     /// Compose the system prompt for the current turn.
@@ -803,14 +653,20 @@ impl AgentRuntime {
             };
 
         // Detect current provider
-        let current_provider = {
-            if let Some((pid, _, _)) = registry.find_model_by_id(old_model) {
-                pid.to_string()
-            } else {
-                // Can't determine current provider — force rebuild
-                String::new()
-            }
+        let current_provider = if self.config.model_provider == "openai-chatgpt"
+            && registry
+                .find_model_by_id(old_model)
+                .is_some_and(|(provider, _, _)| provider == "openai")
+        {
+            "openai-chatgpt".to_string()
+        } else if let Some((pid, _, _)) = registry.find_model_by_id(old_model) {
+            pid.to_string()
+        } else {
+            // Can't determine current provider — force rebuild.
+            String::new()
         };
+        let target_provider =
+            select_transport_provider(&new_provider_id, &self.config.model_provider);
 
         // Update model name
         self.llm_caller.config.model = new_model.to_string();
@@ -843,18 +699,14 @@ impl AgentRuntime {
         }
 
         // If provider changed, rebuild the HTTP client
-        if new_provider_id != current_provider {
+        if target_provider != current_provider {
             let (api_key, base_url) =
-                resolve_switch_credentials(&registry, &new_provider_id, &self.config)?;
-            let new_client = Self::build_http_client(
-                &new_provider_id,
-                &api_key,
-                new_model,
-                base_url.as_deref(),
-            )?;
+                resolve_switch_credentials(&registry, target_provider, &self.config)?;
+            let new_client =
+                Self::build_http_client(target_provider, &api_key, new_model, base_url.as_deref())?;
             self.http_client = Arc::new(new_client);
             info!(
-                provider = %new_provider_id,
+                provider = %target_provider,
                 model = new_model,
                 "Rebuilt HTTP client for new provider"
             );
@@ -908,6 +760,20 @@ impl AgentRuntime {
                     hdrs.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
                     (
                         url,
+                        hdrs,
+                        Some(Box::new(adapter) as Box<dyn ProviderAdapter>),
+                    )
+                }
+                "openai-chatgpt" => {
+                    let adapter =
+                        opendev_http::adapters::openai_chatgpt::OpenAiChatGptAdapter::new();
+                    let mut hdrs = HeaderMap::new();
+                    hdrs.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+                    // The ChatGPT Codex endpoint only emits its streaming event
+                    // protocol when the client explicitly requests it.
+                    hdrs.insert(ACCEPT, HeaderValue::from_static("text/event-stream"));
+                    (
+                        adapter.api_url().to_string(),
                         hdrs,
                         Some(Box::new(adapter) as Box<dyn ProviderAdapter>),
                     )
@@ -1006,6 +872,14 @@ impl AgentRuntime {
         let raw = HttpClient::new(api_url, headers, None)
             .map_err(|e| format!("Failed to create HTTP client: {e}"))?
             .with_circuit_breaker(circuit_breaker);
+        let raw = if provider == "openai-chatgpt" {
+            let auth =
+                opendev_http::chatgpt_auth::ChatGptAuthenticator::new(CredentialStore::new(None))
+                    .map_err(|e| format!("Failed to initialize ChatGPT authentication: {e}"))?;
+            raw.with_request_authenticator(Arc::new(auth))
+        } else {
+            raw
+        };
 
         let client = match adapter {
             Some(a) => AdaptedClient::with_adapter(raw, a),
@@ -1021,6 +895,17 @@ impl AgentRuntime {
     }
 }
 
+/// Model metadata identifies capability ownership, not necessarily billing or
+/// authentication. A ChatGPT OAuth session must keep its transport mode when
+/// moving between OpenAI-owned models.
+fn select_transport_provider<'a>(model_owner: &'a str, configured_provider: &str) -> &'a str {
+    if model_owner == "openai" && configured_provider == "openai-chatgpt" {
+        "openai-chatgpt"
+    } else {
+        model_owner
+    }
+}
+
 /// Resolve the API key and base URL for a provider switch.
 ///
 /// Falls back to built-in provider defaults when the registry has no entry
@@ -1032,6 +917,13 @@ fn resolve_switch_credentials(
     provider_id: &str,
     config: &opendev_models::AppConfig,
 ) -> Result<(String, Option<String>), String> {
+    if provider_id == "openai-chatgpt" {
+        if !config.experimental.chatgpt_auth {
+            return Err("openai-chatgpt requires experimental.chatgpt_auth = true".to_string());
+        }
+        return Ok((String::new(), None));
+    }
+
     let provider_info = registry.get_provider_or_builtin(provider_id);
     let registry_env = provider_info.as_ref().map(|pi| pi.api_key_env.as_str());
     let api_key = config

--- a/crates/opendev-cli/src/runtime/tests.rs
+++ b/crates/opendev-cli/src/runtime/tests.rs
@@ -64,6 +64,51 @@ fn test_resolve_switch_credentials_keyless_builtin_fallback() {
 }
 
 #[test]
+fn test_chatgpt_switch_never_falls_back_to_platform_api_key_authentication() {
+    let registry = opendev_config::ModelRegistry::new();
+    let config = AppConfig {
+        model_provider: "openai-chatgpt".to_string(),
+        api_key: Some("must-not-be-used".to_string()),
+        experimental: opendev_models::ExperimentalConfig { chatgpt_auth: true },
+        ..AppConfig::default()
+    };
+
+    let (key, base_url) = resolve_switch_credentials(&registry, "openai-chatgpt", &config).unwrap();
+    assert!(key.is_empty());
+    assert!(base_url.is_none());
+}
+
+#[test]
+fn test_shared_provider_factory_builds_keyless_chatgpt_client() {
+    let client = AgentRuntime::build_http_client("openai-chatgpt", "", "gpt-5.2-codex", None)
+        .expect("ChatGPT OAuth transport must not require a Platform API key");
+    assert_eq!(
+        client.api_url(),
+        "https://chatgpt.com/backend-api/codex/responses"
+    );
+    assert!(!client.uses_curl_transport());
+}
+
+#[test]
+fn test_chatgpt_provider_accepts_dynamically_discovered_models() {
+    AgentRuntime::build_http_client("openai-chatgpt", "", "gpt-5.4", None)
+        .expect("dynamic catalogue entries must reach the ChatGPT transport");
+}
+
+#[test]
+fn test_model_switch_keeps_chatgpt_transport_for_openai_models() {
+    assert_eq!(
+        select_transport_provider("openai", "openai-chatgpt"),
+        "openai-chatgpt"
+    );
+    assert_eq!(
+        select_transport_provider("anthropic", "openai-chatgpt"),
+        "anthropic"
+    );
+    assert_eq!(select_transport_provider("openai", "openai"), "openai");
+}
+
+#[test]
 fn test_resolve_switch_credentials_missing_key_errors() {
     // Provider that declares an API key env var which is not set, with no
     // key stored in config: must error with the env var hint.

--- a/crates/opendev-cli/src/setup/mod.rs
+++ b/crates/opendev-cli/src/setup/mod.rs
@@ -11,6 +11,8 @@ use std::io;
 
 use opendev_config::models_dev::{ModelRegistry, sync_provider_cache};
 use opendev_config::{ConfigLoader, Paths};
+use opendev_http::CredentialStore;
+use opendev_http::chatgpt_auth::ChatGptAuthenticator;
 use opendev_models::AppConfig;
 use thiserror::Error;
 use tracing::info;
@@ -111,13 +113,27 @@ pub async fn run_setup_wizard() -> Result<AppConfig, SetupError> {
     // ─── Section 1: Provider & Authentication ───────────────────────────
     rail_section("Provider & Authentication");
 
-    let provider_id = select_provider(&registry)?;
+    let selected_provider_id = select_provider(&registry)?;
+    let authentication = if selected_provider_id == "openai" {
+        Some(select_openai_authentication()?)
+    } else {
+        None
+    };
+    let (provider_id, chatgpt_headless) = resolve_provider_authentication(
+        selected_provider_id,
+        authentication.unwrap_or(OpenAiAuthentication::ApiKey),
+    );
     let provider_config = ProviderSetup::get_provider_config(&registry, &provider_id)
         .ok_or(SetupError::NoProvider)?;
+    let is_chatgpt = provider_id == "openai-chatgpt";
+    let api_key = if is_chatgpt {
+        run_chatgpt_setup_login(chatgpt_headless).await?;
+        String::new()
+    } else {
+        get_api_key(&provider_config)?
+    };
 
-    let api_key = get_api_key(&provider_config)?;
-
-    if !api_key.is_empty() && rail_confirm("Validate API key?", true)? {
+    if !is_chatgpt && !api_key.is_empty() && rail_confirm("Validate API key?", true)? {
         let spinner = rail_spinner_start("Validating API key...");
         let result = ProviderSetup::validate_api_key(&provider_config, &api_key).await;
         spinner.stop();
@@ -145,7 +161,9 @@ pub async fn run_setup_wizard() -> Result<AppConfig, SetupError> {
     rail_dim("These use your main model by default. Override only if needed.");
 
     let mut collected_keys: HashMap<String, String> = HashMap::new();
-    collected_keys.insert(provider_id.clone(), api_key.clone());
+    if !is_chatgpt {
+        collected_keys.insert(provider_id.clone(), api_key.clone());
+    }
 
     let (vlm_provider, vlm_model) = configure_slot(
         &registry,
@@ -184,7 +202,10 @@ pub async fn run_setup_wizard() -> Result<AppConfig, SetupError> {
     let config = AppConfig {
         model_provider: provider_id.clone(),
         model: model_id.clone(),
-        api_key: Some(api_key),
+        api_key: (!is_chatgpt).then_some(api_key),
+        experimental: opendev_models::ExperimentalConfig {
+            chatgpt_auth: is_chatgpt,
+        },
         auto_save_interval: 5,
         model_vlm: Some(vlm_model.clone()),
         model_vlm_provider: Some(vlm_provider.clone()),
@@ -217,6 +238,58 @@ pub async fn run_setup_wizard() -> Result<AppConfig, SetupError> {
     rail_outro();
 
     Ok(config)
+}
+
+async fn run_chatgpt_setup_login(headless: bool) -> Result<(), SetupError> {
+    let authenticator = ChatGptAuthenticator::new(CredentialStore::new(None))
+        .map_err(|error| SetupError::ValidationFailed(error.to_string()))?;
+    rail_dim(
+        "Signing in with ChatGPT. A successful login replaces any previous local ChatGPT credential.",
+    );
+    if headless {
+        let login = authenticator
+            .begin_device_login(None)
+            .await
+            .map_err(|error| SetupError::ValidationFailed(error.to_string()))?;
+        rail_dim(&format!(
+            "Visit {} and enter {}. Never share this device code.",
+            login.verification_url, login.user_code
+        ));
+        authenticator
+            .finish_device_login(login, None)
+            .await
+            .map_err(|error| SetupError::ValidationFailed(error.to_string()))?;
+    } else {
+        let login = authenticator
+            .begin_browser_login()
+            .await
+            .map_err(|error| SetupError::ValidationFailed(error.to_string()))?;
+        rail_dim(&format!(
+            "Open this URL to authenticate: {}",
+            login.authorization_url
+        ));
+        open_browser(&login.authorization_url);
+        authenticator
+            .finish_browser_login(login, None)
+            .await
+            .map_err(|error| SetupError::ValidationFailed(error.to_string()))?;
+    }
+    rail_success("ChatGPT/Codex login saved in OpenDev's local credential store");
+    Ok(())
+}
+
+fn open_browser(url: &str) {
+    #[cfg(target_os = "macos")]
+    let mut command = std::process::Command::new("open");
+    #[cfg(target_os = "windows")]
+    let mut command = {
+        let mut value = std::process::Command::new("cmd");
+        value.args(["/C", "start"]);
+        value
+    };
+    #[cfg(all(unix, not(target_os = "macos")))]
+    let mut command = std::process::Command::new("xdg-open");
+    let _ = command.arg(url).spawn();
 }
 
 // ── Slot configuration ─────────────────────────────────────────────────────
@@ -439,6 +512,77 @@ fn select_provider(registry: &ModelRegistry) -> Result<String, SetupError> {
         .unwrap_or(&provider_id);
     rail_answer(provider_name);
     Ok(provider_id)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OpenAiAuthentication {
+    ApiKey,
+    ChatGptBrowser,
+    ChatGptHeadless,
+}
+
+fn select_openai_authentication() -> Result<OpenAiAuthentication, SetupError> {
+    let choices = vec![
+        (
+            "api_key".to_string(),
+            "OpenAI API key".to_string(),
+            "Use Platform API credit and OPENAI_API_KEY".to_string(),
+        ),
+        (
+            "chatgpt_browser".to_string(),
+            "ChatGPT Pro/Plus (browser)".to_string(),
+            "Sign in with an eligible ChatGPT/Codex account".to_string(),
+        ),
+        (
+            "chatgpt_headless".to_string(),
+            "ChatGPT Pro/Plus (headless)".to_string(),
+            "Use device-code login on a remote or headless machine".to_string(),
+        ),
+    ];
+
+    rail_label("Authentication", "choose how to authenticate with OpenAI");
+    let mut menu = InteractiveMenu::new(choices, "Select OpenAI Authentication", 9);
+    let choice = menu.show()?.ok_or(SetupError::Cancelled)?;
+
+    match choice.as_str() {
+        "api_key" => {
+            rail_answer("OpenAI API key");
+            Ok(OpenAiAuthentication::ApiKey)
+        }
+        "chatgpt_browser" => {
+            acknowledge_chatgpt_account_risk()?;
+            rail_answer("ChatGPT Pro/Plus (browser)");
+            Ok(OpenAiAuthentication::ChatGptBrowser)
+        }
+        "chatgpt_headless" => {
+            acknowledge_chatgpt_account_risk()?;
+            rail_answer("ChatGPT Pro/Plus (headless)");
+            Ok(OpenAiAuthentication::ChatGptHeadless)
+        }
+        _ => Err(SetupError::Cancelled),
+    }
+}
+
+fn acknowledge_chatgpt_account_risk() -> Result<(), SetupError> {
+    if rail_confirm(
+        "Use experimental ChatGPT/Codex account authentication (not Platform API credit)?",
+        false,
+    )? {
+        Ok(())
+    } else {
+        Err(SetupError::Cancelled)
+    }
+}
+
+fn resolve_provider_authentication(
+    provider_id: String,
+    authentication: OpenAiAuthentication,
+) -> (String, bool) {
+    match (provider_id.as_str(), authentication) {
+        ("openai", OpenAiAuthentication::ChatGptBrowser) => ("openai-chatgpt".to_string(), false),
+        ("openai", OpenAiAuthentication::ChatGptHeadless) => ("openai-chatgpt".to_string(), true),
+        _ => (provider_id, false),
+    }
 }
 
 fn get_api_key(provider_config: &ProviderConfig) -> Result<String, SetupError> {

--- a/crates/opendev-cli/src/setup/providers.rs
+++ b/crates/opendev-cli/src/setup/providers.rs
@@ -56,15 +56,29 @@ pub struct ProviderSetup;
 impl ProviderSetup {
     /// Return a list of `(id, name, description)` for the wizard menu.
     pub fn provider_choices(registry: &ModelRegistry) -> Vec<(String, String, String)> {
-        registry
+        let choices: Vec<_> = registry
             .list_providers()
             .iter()
             .map(|p| (p.id.clone(), p.name.clone(), p.description.clone()))
-            .collect()
+            .collect();
+        choices
     }
 
     /// Get full config for a provider by ID.
     pub fn get_provider_config(registry: &ModelRegistry, id: &str) -> Option<ProviderConfig> {
+        if id == "openai-chatgpt" {
+            return Some(ProviderConfig {
+                id: id.to_string(),
+                name: "ChatGPT/Codex OAuth (experimental)".to_string(),
+                description: "Standalone ChatGPT subscription authentication".to_string(),
+                env_var: String::new(),
+                api_base_url: String::new(),
+                api_format: ApiFormat::OpenAi,
+                // OpenAI owns model metadata. The chooser below uses its
+                // current registry list instead of pinning a stale default.
+                models: Vec::new(),
+            });
+        }
         let provider = registry.get_provider(id)?;
         let api_format = if id == "anthropic" {
             ApiFormat::Anthropic
@@ -99,8 +113,17 @@ impl ProviderSetup {
         registry: &ModelRegistry,
         provider_id: &str,
     ) -> Vec<(String, String, String)> {
+        // ChatGPT OAuth shares OpenAI's model catalogue for picker purposes.
+        // The registry is dynamically refreshed from models.dev, matching
+        // OpenCode's no-Codex-executable setup flow. Availability is still
+        // determined by the authenticated ChatGPT backend at request time.
+        let catalog_provider_id = if provider_id == "openai-chatgpt" {
+            "openai"
+        } else {
+            provider_id
+        };
         registry
-            .get_provider(provider_id)
+            .get_provider(catalog_provider_id)
             .map(|p| {
                 p.list_models(None)
                     .iter()

--- a/crates/opendev-cli/src/setup/providers_tests.rs
+++ b/crates/opendev-cli/src/setup/providers_tests.rs
@@ -81,6 +81,20 @@ fn test_provider_choices() {
     assert!(choices.len() >= 2);
     assert!(choices.iter().any(|(id, _, _)| id == "openai"));
     assert!(choices.iter().any(|(id, _, _)| id == "anthropic"));
+    assert!(!choices.iter().any(|(id, _, _)| id == "openai-chatgpt"));
+}
+
+#[test]
+fn test_chatgpt_provider_config_does_not_request_an_api_key() {
+    let config = ProviderSetup::get_provider_config(&test_registry(), "openai-chatgpt").unwrap();
+    assert!(config.env_var.is_empty());
+    assert!(config.models.is_empty());
+}
+
+#[test]
+fn test_chatgpt_model_choices_use_the_dynamic_openai_catalog() {
+    let models = ProviderSetup::get_provider_models(&test_registry(), "openai-chatgpt");
+    assert!(models.iter().any(|(id, _, _)| id == "gpt-4o"));
 }
 
 #[test]

--- a/crates/opendev-cli/src/setup/tests.rs
+++ b/crates/opendev-cli/src/setup/tests.rs
@@ -95,6 +95,25 @@ fn test_get_api_key_allows_keyless_providers() {
 }
 
 #[test]
+fn test_openai_chatgpt_authentication_selects_the_oauth_provider() {
+    assert_eq!(
+        resolve_provider_authentication("openai".to_string(), OpenAiAuthentication::ChatGptBrowser,),
+        ("openai-chatgpt".to_string(), false)
+    );
+    assert_eq!(
+        resolve_provider_authentication(
+            "openai".to_string(),
+            OpenAiAuthentication::ChatGptHeadless,
+        ),
+        ("openai-chatgpt".to_string(), true)
+    );
+    assert_eq!(
+        resolve_provider_authentication("openai".to_string(), OpenAiAuthentication::ApiKey),
+        ("openai".to_string(), false)
+    );
+}
+
+#[test]
 fn test_setup_error_variants() {
     let errors: Vec<SetupError> = vec![
         SetupError::Cancelled,

--- a/crates/opendev-config/src/loader/tests.rs
+++ b/crates/opendev-config/src/loader/tests.rs
@@ -153,6 +153,25 @@ fn test_validate_zero_max_tokens() {
 }
 
 #[test]
+fn test_validate_chatgpt_provider_requires_explicit_opt_in_and_rejects_key_settings() {
+    let mut config = AppConfig {
+        model_provider: "openai-chatgpt".to_string(),
+        ..AppConfig::default()
+    };
+    let err = ConfigLoader::validate(&config).unwrap_err().to_string();
+    assert!(err.contains("experimental.chatgpt_auth"));
+
+    config.experimental.chatgpt_auth = true;
+    assert!(ConfigLoader::validate(&config).is_ok());
+
+    config.api_key = Some("not-allowed".to_string());
+    config.api_base_url = Some("https://untrusted.invalid".to_string());
+    let err = ConfigLoader::validate(&config).unwrap_err().to_string();
+    assert!(err.contains("does not accept api_key"));
+    assert!(err.contains("does not accept api_base_url"));
+}
+
+#[test]
 fn test_validate_multiple_errors() {
     let mut config = AppConfig::default();
     config.model = String::new();

--- a/crates/opendev-config/src/loader/validation.rs
+++ b/crates/opendev-config/src/loader/validation.rs
@@ -57,6 +57,7 @@ impl ConfigLoader {
         [
             "model_provider",
             "model",
+            "experimental",
             "model_vlm",
             "model_vlm_provider",
             "api_key",
@@ -170,6 +171,20 @@ impl ConfigLoader {
         }
         if config.max_tokens == 0 {
             errors.push("max_tokens must be positive".to_string());
+        }
+        if config.model_provider == "openai-chatgpt" {
+            if !config.experimental.chatgpt_auth {
+                errors.push(
+                    "model_provider openai-chatgpt requires experimental.chatgpt_auth = true"
+                        .to_string(),
+                );
+            }
+            if config.api_key.is_some() {
+                errors.push("openai-chatgpt does not accept api_key".to_string());
+            }
+            if config.api_base_url.is_some() {
+                errors.push("openai-chatgpt does not accept api_base_url".to_string());
+            }
         }
 
         if errors.is_empty() {

--- a/crates/opendev-config/src/paths.rs
+++ b/crates/opendev-config/src/paths.rs
@@ -95,11 +95,14 @@ impl Paths {
             };
         }
 
-        // Legacy: if ~/.opendev exists, use it (don't force migration)
+        // Legacy: use ~/.opendev only when it contains an actual configuration.
+        //
+        // Runtime artifacts such as a plans directory must not make a fresh
+        // legacy directory shadow an existing XDG settings.json file.
         let legacy_dir = dirs::home_dir()
             .unwrap_or_else(|| PathBuf::from("/tmp"))
             .join(APP_DIR_NAME);
-        if legacy_dir.exists() {
+        if legacy_dir.join(SETTINGS_FILE_NAME).is_file() {
             warn_legacy_dir_once(&legacy_dir);
             return Self {
                 working_dir,

--- a/crates/opendev-config/src/paths_tests.rs
+++ b/crates/opendev-config/src/paths_tests.rs
@@ -151,8 +151,12 @@ fn test_legacy_detection_and_fresh_install_layout() {
     // Fresh install: no ~/.opendev — all base dirs must avoid it.
     let fresh = Paths::new(Some(PathBuf::from("/tmp/wd")));
 
-    // Legacy install: ~/.opendev exists — everything points at it.
+    // A directory containing only runtime artifacts is not a legacy install.
     std::fs::create_dir_all(home.join(APP_DIR_NAME)).unwrap();
+    let artifact_only = Paths::new(Some(PathBuf::from("/tmp/wd")));
+
+    // Legacy install: a legacy settings file exists — everything points at it.
+    std::fs::write(home.join(APP_DIR_NAME).join(SETTINGS_FILE_NAME), "{}").unwrap();
     #[cfg_attr(windows, allow(unused_variables))]
     let legacy = Paths::new(Some(PathBuf::from("/tmp/wd")));
 
@@ -174,6 +178,14 @@ fn test_legacy_detection_and_fresh_install_layout() {
         assert!(
             !dir.starts_with(&legacy_dir),
             "fresh install must not use legacy dir: {}",
+            dir.display()
+        );
+    }
+
+    for dir in artifact_only.all_base_dirs() {
+        assert!(
+            !dir.starts_with(&legacy_dir),
+            "artifact-only legacy dir must not shadow XDG paths: {}",
             dir.display()
         );
     }

--- a/crates/opendev-http/Cargo.toml
+++ b/crates/opendev-http/Cargo.toml
@@ -22,7 +22,10 @@ futures = { workspace = true }
 dirs = "5"
 fastrand = "2"
 httpdate = "1"
+url = { workspace = true }
+base64 = { workspace = true }
+sha2 = { workspace = true }
+tempfile = { workspace = true }
 
 [dev-dependencies]
-tempfile = { workspace = true }
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/opendev-http/src/adapted_client.rs
+++ b/crates/opendev-http/src/adapted_client.rs
@@ -8,8 +8,92 @@ use crate::adapters::detect_provider_from_key;
 use crate::client::HttpClient;
 use crate::models::{HttpError, HttpResult};
 use crate::streaming::{StreamCallback, StreamEvent};
+use std::io::Write;
+use std::path::Path;
+use tempfile::NamedTempFile;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
+
+/// Create a short-lived curl configuration file for secret headers. Passing
+/// bearer tokens with `--header` exposes them in the child process argument
+/// list; curl's config format keeps the value out of argv instead. The file is
+/// unlinked when its guard drops after the subprocess exits.
+fn curl_header_config(headers: &[String]) -> Result<NamedTempFile, HttpError> {
+    let mut config = tempfile::Builder::new()
+        .prefix("opendev-curl-")
+        .suffix(".conf")
+        .tempfile()?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(config.path(), std::fs::Permissions::from_mode(0o600))?;
+    }
+
+    for header in headers {
+        // HTTP header values cannot legally contain a line break. Reject one
+        // instead of allowing it to introduce arbitrary curl config options.
+        if header.contains(['\r', '\n']) {
+            return Err(HttpError::Auth(
+                "invalid header value for curl transport".into(),
+            ));
+        }
+        let escaped = header.replace('\\', "\\\\").replace('"', "\\\"");
+        writeln!(config, "header = \"{escaped}\"")?;
+    }
+    config.flush()?;
+    Ok(config)
+}
+
+fn curl_response_status(headers_path: &Path) -> Option<u16> {
+    let headers = std::fs::read_to_string(headers_path).ok()?;
+    // `--location` may produce multiple response blocks; use the final one.
+    headers
+        .split("\r\n\r\n")
+        .filter_map(|block| block.lines().next())
+        .filter_map(|line| line.split_whitespace().nth(1))
+        .filter_map(|status| status.parse::<u16>().ok())
+        .last()
+}
+
+fn curl_header_value(headers_path: &Path, name: &str) -> Option<String> {
+    let headers = std::fs::read_to_string(headers_path).ok()?;
+    let final_block = headers
+        .split("\r\n\r\n")
+        .filter(|block| block.starts_with("HTTP/"))
+        .last()?;
+    final_block.lines().find_map(|line| {
+        let (key, value) = line.split_once(':')?;
+        key.eq_ignore_ascii_case(name)
+            .then(|| value.trim().to_string())
+    })
+}
+
+/// Make an unexpected HTTP response useful for diagnosis without copying an
+/// unbounded body (which may contain private provider output) into an error.
+fn response_body_preview(bytes: &[u8]) -> String {
+    const MAX_CHARS: usize = 512;
+
+    let mut preview = String::from_utf8_lossy(bytes)
+        .chars()
+        .take(MAX_CHARS)
+        .collect::<String>();
+    if bytes.len() > preview.len() {
+        preview.push('…');
+    }
+    preview.replace(['\r', '\n', '\t'], " ")
+}
+
+/// ChatGPT's Codex endpoint currently streams valid SSE while omitting the
+/// Content-Type header.  A present, non-SSE content type remains the signal for
+/// the JSON fallback; an absent header is handled as an SSE stream.
+fn is_sse_response(content_type: &str, is_chatgpt: bool) -> bool {
+    let content_type = content_type.trim();
+    content_type.contains("text/event-stream") || (is_chatgpt && content_type.is_empty())
+}
+
+fn should_merge_streamed_chatgpt_output(provider: &str) -> bool {
+    provider == "openai-chatgpt"
+}
 
 /// Per-block accumulator for Anthropic extended-thinking output during SSE streaming.
 ///
@@ -76,6 +160,7 @@ impl AdaptedClient {
     /// Recognized providers:
     /// - `"anthropic"` → [`AnthropicAdapter`](crate::adapters::anthropic::AnthropicAdapter)
     /// - `"openai"` → [`OpenAiAdapter`](crate::adapters::openai::OpenAiAdapter)
+    /// - `"openai-chatgpt"` → ChatGPT Codex Responses adapter
     /// - `"gemini"` | `"google"` → [`GeminiAdapter`](crate::adapters::gemini::GeminiAdapter)
     ///
     /// Returns `None` for providers that use the Chat Completions format natively
@@ -84,6 +169,9 @@ impl AdaptedClient {
         match provider {
             "anthropic" => Some(Box::new(crate::adapters::anthropic::AnthropicAdapter::new())),
             "openai" => Some(Box::new(crate::adapters::openai::OpenAiAdapter::new())),
+            "openai-chatgpt" => Some(Box::new(
+                crate::adapters::openai_chatgpt::OpenAiChatGptAdapter::new(),
+            )),
             "gemini" | "google" => {
                 Some(Box::new(crate::adapters::gemini::GeminiAdapter::default()))
             }
@@ -163,6 +251,13 @@ impl AdaptedClient {
 
         let body = serde_json::to_vec(payload)
             .map_err(|e| HttpError::Other(format!("serialize error: {e}")))?;
+        let curl_config = curl_header_config(&[
+            auth_header.to_string(),
+            "Content-Type: application/json".to_string(),
+        ])?;
+        let response_headers = tempfile::Builder::new()
+            .prefix("opendev-curl-response-")
+            .tempfile()?;
 
         let mut child = tokio::process::Command::new("curl")
             .args([
@@ -173,10 +268,14 @@ impl AdaptedClient {
                 "--request",
                 "POST",
                 url,
-                "--header",
-                auth_header,
-                "--header",
-                "Content-Type: application/json",
+                "--config",
+                curl_config.path().to_str().ok_or_else(|| {
+                    HttpError::Other("curl config path was not valid UTF-8".to_string())
+                })?,
+                "--dump-header",
+                response_headers.path().to_str().ok_or_else(|| {
+                    HttpError::Other("curl header path was not valid UTF-8".to_string())
+                })?,
                 "--data-binary",
                 "@-",
             ])
@@ -213,8 +312,38 @@ impl AdaptedClient {
         }
 
         let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let status = curl_response_status(response_headers.path());
+        let retry_after = curl_header_value(response_headers.path(), "retry-after");
+        let retry_after_ms = curl_header_value(response_headers.path(), "retry-after-ms");
         match serde_json::from_str::<serde_json::Value>(&stdout) {
             Ok(body_val) => {
+                let status = status.unwrap_or(200);
+                if self.client.is_retryable_status(status) {
+                    let mut result =
+                        HttpResult::retryable_status(status, Some(body_val), retry_after)
+                            .with_request_id(request_id);
+                    result.retry_after_ms = retry_after_ms;
+                    return Ok(result);
+                }
+                if status >= 400 {
+                    let msg = body_val
+                        .get("error")
+                        .and_then(|error| error.get("message"))
+                        .and_then(|message| message.as_str())
+                        .unwrap_or("API error")
+                        .to_string();
+                    return Ok(HttpResult {
+                        success: false,
+                        status: Some(status),
+                        body: Some(body_val),
+                        error: Some(format!("[request_id={request_id}] {msg}")),
+                        interrupted: false,
+                        retryable: false,
+                        request_id: Some(request_id),
+                        retry_after: None,
+                        retry_after_ms: None,
+                    });
+                }
                 if let Some(err_obj) = body_val.get("error") {
                     let msg = err_obj
                         .get("message")
@@ -234,7 +363,7 @@ impl AdaptedClient {
                         retry_after_ms: None,
                     });
                 }
-                Ok(HttpResult::ok(200, body_val).with_request_id(request_id))
+                Ok(HttpResult::ok(status, body_val).with_request_id(request_id))
             }
             Err(e) => {
                 let msg = format!("parse error: {e}");
@@ -336,15 +465,24 @@ impl AdaptedClient {
             .get("content-type")
             .and_then(|v| v.to_str().ok())
             .unwrap_or("")
+            .trim()
             .to_string();
         debug!(content_type = %content_type, status = %response.status(), "Streaming response headers received");
-        // If the response isn't SSE, fall back to reading as JSON
-        if !content_type.contains("text/event-stream") {
+        // If the response explicitly isn't SSE, fall back to reading as JSON.
+        // The ChatGPT Codex endpoint may omit Content-Type on valid SSE; do
+        // not apply that compatibility exception to unrelated providers.
+        if !is_sse_response(&content_type, adapter.provider_name() == "openai-chatgpt") {
             warn!(content_type = %content_type, "Streaming fallback: response is not SSE, reading as JSON");
-            let body = response
-                .json::<serde_json::Value>()
-                .await
-                .map_err(|e| HttpError::Other(format!("Failed to parse response: {e}")))?;
+            let status = response.status();
+            let bytes = response.bytes().await.map_err(|e| {
+                HttpError::Other(format!("Failed to read non-SSE response body: {e}"))
+            })?;
+            let body = serde_json::from_slice::<serde_json::Value>(&bytes).map_err(|e| {
+                HttpError::Other(format!(
+                    "Unexpected non-SSE response (status {status}, content-type {content_type:?}): {e}; body: {}",
+                    response_body_preview(&bytes)
+                ))
+            })?;
 
             // Check for API error
             if let Some(error_obj) = body.get("error") {
@@ -356,7 +494,7 @@ impl AdaptedClient {
             }
 
             let converted_body = adapter.convert_response(body);
-            return Ok(HttpResult::ok(200, converted_body));
+            return Ok(HttpResult::ok(status.as_u16(), converted_body));
         }
 
         // Read SSE events from the response body
@@ -653,7 +791,64 @@ impl AdaptedClient {
         // Convert the final accumulated response through the adapter
         match final_body {
             Some(body) => {
-                let converted = adapter.convert_response(body);
+                let mut converted = adapter.convert_response(body);
+
+                // The ChatGPT Codex stream can emit a complete function-call
+                // sequence while its final `response.completed` payload omits
+                // the corresponding `output` item. Preserve the streamed call
+                // when that converted final payload has no tool calls.
+                if should_merge_streamed_chatgpt_output(adapter.provider_name())
+                    && let Some(choice) = converted
+                        .get_mut("choices")
+                        .and_then(serde_json::Value::as_array_mut)
+                        .and_then(|choices| choices.first_mut())
+                {
+                    let needs_streamed_tool_calls = choice
+                        .get("message")
+                        .and_then(|message| message.get("tool_calls"))
+                        .and_then(serde_json::Value::as_array)
+                        .is_none_or(|calls| calls.is_empty());
+                    let needs_streamed_text = choice
+                        .get("message")
+                        .and_then(|message| message.get("content"))
+                        .is_none_or(|content| {
+                            content.is_null() || content.as_str().is_none_or(str::is_empty)
+                        });
+                    if needs_streamed_text
+                        && !accumulated_text.is_empty()
+                        && let Some(message) = choice.get_mut("message")
+                    {
+                        message["content"] = serde_json::Value::String(accumulated_text.clone());
+                    }
+                    let needs_streamed_reasoning = choice
+                        .get("message")
+                        .and_then(|message| message.get("reasoning_content"))
+                        .is_none_or(|content| {
+                            content.is_null() || content.as_str().is_none_or(str::is_empty)
+                        });
+                    if needs_streamed_reasoning
+                        && !accumulated_reasoning.is_empty()
+                        && let Some(message) = choice.get_mut("message")
+                    {
+                        message["reasoning_content"] =
+                            serde_json::Value::String(accumulated_reasoning.clone());
+                    }
+                    if needs_streamed_tool_calls && !tool_calls.is_empty() {
+                        let mut finalized = tool_calls;
+                        for (idx, args) in &current_tool_args {
+                            if let Some(call) = finalized.get_mut(*idx)
+                                && let Some(function) = call.get_mut("function")
+                            {
+                                function["arguments"] = serde_json::Value::String(args.clone());
+                            }
+                        }
+                        if let Some(message) = choice.get_mut("message") {
+                            message["tool_calls"] = serde_json::Value::Array(finalized);
+                            choice["finish_reason"] =
+                                serde_json::Value::String("tool_calls".to_string());
+                        }
+                    }
+                }
                 debug!("Streaming complete, final response converted");
                 Ok(HttpResult::ok(200, converted))
             }
@@ -753,6 +948,13 @@ impl AdaptedClient {
 
         let body = serde_json::to_vec(payload)
             .map_err(|e| HttpError::Other(format!("serialize error: {e}")))?;
+        let curl_config = curl_header_config(&[
+            auth_header.to_string(),
+            "Content-Type: application/json".to_string(),
+        ])?;
+        let response_headers = tempfile::Builder::new()
+            .prefix("opendev-curl-response-")
+            .tempfile()?;
 
         let mut child = tokio::process::Command::new("curl")
             .args([
@@ -764,10 +966,14 @@ impl AdaptedClient {
                 "--request",
                 "POST",
                 url,
-                "--header",
-                auth_header,
-                "--header",
-                "Content-Type: application/json",
+                "--config",
+                curl_config.path().to_str().ok_or_else(|| {
+                    HttpError::Other("curl config path was not valid UTF-8".to_string())
+                })?,
+                "--dump-header",
+                response_headers.path().to_str().ok_or_else(|| {
+                    HttpError::Other("curl header path was not valid UTF-8".to_string())
+                })?,
                 "--data-binary",
                 "@-",
             ])
@@ -909,6 +1115,29 @@ impl AdaptedClient {
         }
 
         let _ = child.wait().await;
+        let status = curl_response_status(response_headers.path()).unwrap_or(200);
+        if self.client.is_retryable_status(status) {
+            let mut result = HttpResult::retryable_status(
+                status,
+                None,
+                curl_header_value(response_headers.path(), "retry-after"),
+            );
+            result.retry_after_ms = curl_header_value(response_headers.path(), "retry-after-ms");
+            return Ok(result);
+        }
+        if status >= 400 {
+            return Ok(HttpResult {
+                success: false,
+                status: Some(status),
+                body: None,
+                error: Some(format!("curl streaming request failed with HTTP {status}")),
+                interrupted: false,
+                retryable: false,
+                request_id: None,
+                retry_after: None,
+                retry_after_ms: None,
+            });
+        }
 
         // Finalize tool call arguments
         for (idx, args) in &current_tool_args {

--- a/crates/opendev-http/src/adapted_client_tests.rs
+++ b/crates/opendev-http/src/adapted_client_tests.rs
@@ -13,6 +13,16 @@ fn test_adapter_for_provider_openai() {
 }
 
 #[test]
+fn test_adapter_for_provider_openai_chatgpt() {
+    let adapter = AdaptedClient::adapter_for_provider("openai-chatgpt").unwrap();
+    assert_eq!(adapter.provider_name(), "openai-chatgpt");
+    assert_eq!(
+        adapter.api_url(),
+        "https://chatgpt.com/backend-api/codex/responses"
+    );
+}
+
+#[test]
 fn test_adapter_for_provider_gemini() {
     let adapter = AdaptedClient::adapter_for_provider("gemini").unwrap();
     assert_eq!(adapter.provider_name(), "gemini");
@@ -32,6 +42,22 @@ fn test_adapter_for_provider_groq_is_none() {
 #[test]
 fn test_adapter_for_provider_unknown_is_none() {
     assert!(AdaptedClient::adapter_for_provider("custom").is_none());
+}
+
+#[test]
+fn headerless_chatgpt_responses_are_treated_as_sse() {
+    assert!(is_sse_response("", true));
+    assert!(is_sse_response(" ", true));
+    assert!(is_sse_response("text/event-stream; charset=utf-8", false));
+    assert!(!is_sse_response("", false));
+    assert!(!is_sse_response("application/json", true));
+}
+
+#[test]
+fn only_chatgpt_merges_streamed_output_into_a_sparse_final_response() {
+    assert!(should_merge_streamed_chatgpt_output("openai-chatgpt"));
+    assert!(!should_merge_streamed_chatgpt_output("openai"));
+    assert!(!should_merge_streamed_chatgpt_output("anthropic"));
 }
 
 #[test]
@@ -63,6 +89,113 @@ fn test_resolve_provider_auto_detect() {
 #[test]
 fn test_resolve_provider_fallback_to_openai() {
     assert_eq!(AdaptedClient::resolve_provider("", "unknown-key"), "openai");
+}
+
+#[test]
+fn curl_headers_are_written_to_a_private_config_file() {
+    let config = curl_header_config(&["Authorization: Bearer not-in-argv".to_string()]).unwrap();
+    let contents = std::fs::read_to_string(config.path()).unwrap();
+    assert!(contents.contains("Authorization: Bearer not-in-argv"));
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        assert_eq!(
+            std::fs::metadata(config.path())
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+    }
+}
+
+#[tokio::test]
+async fn curl_transport_preserves_a_401_status_and_sends_auth_from_config() {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut request = vec![0; 4096];
+        let count = socket.read(&mut request).await.unwrap();
+        assert!(
+            String::from_utf8_lossy(&request[..count])
+                .to_ascii_lowercase()
+                .contains("authorization: bearer config-only-token")
+        );
+        let body = r#"{"error":{"message":"expired"}}"#;
+        socket
+            .write_all(
+                format!(
+                    "HTTP/1.1 401 Unauthorized\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                    body.len()
+                )
+                .as_bytes(),
+            )
+            .await
+            .unwrap();
+    });
+
+    let client = AdaptedClient::new(
+        HttpClient::new(format!("http://{address}"), HeaderMap::new(), None).unwrap(),
+    )
+    .with_curl_transport("Authorization: Bearer config-only-token".to_string());
+    let result = client
+        .post_json(&serde_json::json!({"ping": true}), None)
+        .await
+        .unwrap();
+    assert_eq!(result.status, Some(401));
+    assert!(!result.retryable);
+}
+
+#[tokio::test]
+async fn curl_transport_preserves_redirects_for_dashscope_compatibility() {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let (mut first, _) = listener.accept().await.unwrap();
+        let mut request = vec![0; 4096];
+        let _ = first.read(&mut request).await.unwrap();
+        first
+            .write_all(
+                format!(
+                    "HTTP/1.1 307 Temporary Redirect\r\nlocation: http://{address}/final\r\ncontent-length: 0\r\nconnection: close\r\n\r\n"
+                )
+                .as_bytes(),
+            )
+            .await
+            .unwrap();
+
+        let (mut second, _) = listener.accept().await.unwrap();
+        let count = second.read(&mut request).await.unwrap();
+        assert!(String::from_utf8_lossy(&request[..count]).starts_with("POST /final"));
+        let body = r#"{"ok":true}"#;
+        second
+            .write_all(
+                format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                    body.len()
+                )
+                .as_bytes(),
+            )
+            .await
+            .unwrap();
+    });
+
+    let client = AdaptedClient::new(
+        HttpClient::new(format!("http://{address}/start"), HeaderMap::new(), None).unwrap(),
+    )
+    .with_curl_transport("Authorization: Bearer redirect-token".to_string());
+    let result = client
+        .post_json(&serde_json::json!({"ping": true}), None)
+        .await
+        .unwrap();
+    assert!(result.success);
+    assert_eq!(result.body.unwrap()["ok"], true);
 }
 
 // --- Streaming error classification (issues #13, #110) ---
@@ -210,5 +343,32 @@ async fn test_streaming_503_stays_retryable_after_exhausted_retries() {
     assert!(
         result.retryable,
         "transient 503 must stay retryable so the react loop can back off and retry"
+    );
+}
+
+#[tokio::test]
+async fn test_streaming_non_sse_body_is_reported_for_diagnosis() {
+    let url = spawn_static_server("HTTP/1.1 200 OK", "upstream protocol mismatch").await;
+    let client = streaming_client_for(&url);
+
+    let cb = FnStreamCallback(|_| {});
+    let error = client
+        .post_json_streaming(
+            &serde_json::json!({"model": "gpt-4o", "messages": []}),
+            None,
+            &cb,
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+
+    assert!(
+        error.contains("Unexpected non-SSE response"),
+        "error was: {error}"
+    );
+    assert!(error.contains("application/json"), "error was: {error}");
+    assert!(
+        error.contains("upstream protocol mismatch"),
+        "error was: {error}"
     );
 }

--- a/crates/opendev-http/src/adapters/mod.rs
+++ b/crates/opendev-http/src/adapters/mod.rs
@@ -14,6 +14,7 @@ pub mod groq;
 pub mod mistral;
 pub mod ollama;
 pub mod openai;
+pub mod openai_chatgpt;
 pub mod schema_adapter;
 
 pub use base::ProviderAdapter;

--- a/crates/opendev-http/src/adapters/openai_chatgpt.rs
+++ b/crates/opendev-http/src/adapters/openai_chatgpt.rs
@@ -1,0 +1,93 @@
+//! ChatGPT Codex Responses adapter.
+//!
+//! Payload conversion starts from the Platform Responses adapter, then removes
+//! fields the ChatGPT Codex backend rejects. Authentication and the trusted
+//! endpoint stay outside the adapter.
+
+use serde_json::Value;
+
+use super::base::ProviderAdapter;
+use super::openai::OpenAiAdapter;
+use crate::chatgpt_auth::protocol::CHATGPT_CODEX_RESPONSES_URL;
+use crate::streaming::StreamEvent;
+
+/// Converts OpenDev's internal Chat Completions payload to the stateless
+/// ChatGPT Codex Responses contract.
+#[derive(Debug, Clone, Default)]
+pub struct OpenAiChatGptAdapter {
+    openai: OpenAiAdapter,
+}
+
+impl OpenAiChatGptAdapter {
+    pub fn new() -> Self {
+        Self {
+            openai: OpenAiAdapter::with_url(CHATGPT_CODEX_RESPONSES_URL),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ProviderAdapter for OpenAiChatGptAdapter {
+    fn provider_name(&self) -> &str {
+        "openai-chatgpt"
+    }
+
+    fn convert_request(&self, payload: Value) -> Value {
+        // OpenAiAdapter produces `store: false` and preserves function-call
+        // history in the Responses input form, both required for stateless use.
+        let mut converted = self.openai.convert_request(payload);
+
+        let Some(body) = converted.as_object_mut() else {
+            return converted;
+        };
+
+        // This backend does not accept the generic Platform output-token
+        // parameter. OpenCode removes it before sending its direct Codex
+        // request; doing the same avoids a 400 for dynamically discovered
+        // models such as gpt-5.4.
+        body.remove("max_output_tokens");
+
+        // Preserve encrypted reasoning content across stateless turns and use
+        // the Codex-compatible summary mode rather than the Platform adapter's
+        // detailed-only default.
+        let include = body
+            .entry("include".to_string())
+            .or_insert_with(|| Value::Array(Vec::new()));
+        if let Some(include) = include.as_array_mut()
+            && !include
+                .iter()
+                .any(|item| item.as_str() == Some("reasoning.encrypted_content"))
+        {
+            include.push(Value::String("reasoning.encrypted_content".to_string()));
+        }
+        if let Some(reasoning) = body.get_mut("reasoning").and_then(Value::as_object_mut) {
+            reasoning.insert("summary".to_string(), Value::String("auto".to_string()));
+        }
+
+        converted
+    }
+
+    fn convert_response(&self, response: Value) -> Value {
+        self.openai.convert_response(response)
+    }
+
+    fn api_url(&self) -> &str {
+        CHATGPT_CODEX_RESPONSES_URL
+    }
+
+    fn supports_streaming(&self) -> bool {
+        self.openai.supports_streaming()
+    }
+
+    fn enable_streaming(&self, payload: &mut Value) {
+        self.openai.enable_streaming(payload);
+    }
+
+    fn parse_stream_event(&self, event_type: &str, data: &Value) -> Option<StreamEvent> {
+        self.openai.parse_stream_event(event_type, data)
+    }
+}
+
+#[cfg(test)]
+#[path = "openai_chatgpt_tests.rs"]
+mod tests;

--- a/crates/opendev-http/src/adapters/openai_chatgpt_tests.rs
+++ b/crates/opendev-http/src/adapters/openai_chatgpt_tests.rs
@@ -1,0 +1,35 @@
+use super::*;
+
+#[test]
+fn test_chatgpt_adapter_uses_only_trusted_stateless_responses_endpoint() {
+    let adapter = OpenAiChatGptAdapter::new();
+    assert_eq!(adapter.provider_name(), "openai-chatgpt");
+    assert_eq!(adapter.api_url(), CHATGPT_CODEX_RESPONSES_URL);
+
+    let converted = adapter.convert_request(serde_json::json!({
+        "model": "codex-model",
+        "messages": [{"role": "user", "content": "hello"}]
+    }));
+    assert_eq!(converted["store"], false);
+    assert!(converted.get("previous_response_id").is_none());
+}
+
+#[test]
+fn test_chatgpt_adapter_removes_platform_token_limit_and_uses_codex_reasoning_shape() {
+    let adapter = OpenAiChatGptAdapter::new();
+    let converted = adapter.convert_request(serde_json::json!({
+        "model": "gpt-5.4",
+        "max_completion_tokens": 128000,
+        "_reasoning_effort": "medium",
+        "messages": [{"role": "user", "content": "hello"}]
+    }));
+
+    assert!(converted.get("max_output_tokens").is_none());
+    assert_eq!(converted["reasoning"]["effort"], "medium");
+    assert_eq!(converted["reasoning"]["summary"], "auto");
+    assert!(converted["include"].as_array().is_some_and(|items| {
+        items
+            .iter()
+            .any(|item| item == "reasoning.encrypted_content")
+    }));
+}

--- a/crates/opendev-http/src/adapters/schema_adapter.rs
+++ b/crates/opendev-http/src/adapters/schema_adapter.rs
@@ -15,7 +15,10 @@ pub fn adapt_for_provider(schemas: &[Value], provider: &str) -> Vec<Value> {
     let provider = provider.to_lowercase();
 
     // No adaptation needed for standard providers
-    if matches!(provider.as_str(), "openai" | "anthropic" | "openrouter") {
+    if matches!(
+        provider.as_str(),
+        "openai" | "openai-chatgpt" | "anthropic" | "openrouter"
+    ) {
         return schemas.to_vec();
     }
 

--- a/crates/opendev-http/src/auth.rs
+++ b/crates/opendev-http/src/auth.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use tracing::{info, warn};
+use uuid::Uuid;
 
 use crate::models::HttpError;
 
@@ -31,6 +32,33 @@ struct AuthData {
     keys: HashMap<String, String>,
     #[serde(default)]
     tokens: HashMap<String, TokenEntry>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    chatgpt_oauth: Option<ChatGptOAuthCredential>,
+}
+
+/// OAuth credentials for the explicit `openai-chatgpt` provider.
+///
+/// This type is intentionally separate from generic token metadata so callers
+/// cannot accidentally treat it as an API key or forward it to another
+/// provider. Its custom `Debug` implementation never reveals a secret.
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ChatGptOAuthCredential {
+    pub access_token: String,
+    pub refresh_token: String,
+    pub expires_at_ms: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub account_id: Option<String>,
+}
+
+impl std::fmt::Debug for ChatGptOAuthCredential {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ChatGptOAuthCredential")
+            .field("access_token", &"[REDACTED]")
+            .field("refresh_token", &"[REDACTED]")
+            .field("expires_at_ms", &self.expires_at_ms)
+            .field("account_id", &self.account_id)
+            .finish()
+    }
 }
 
 /// A stored token with optional metadata.
@@ -151,6 +179,34 @@ impl CredentialStore {
         data.tokens.get(name).map(|e| e.token.clone())
     }
 
+    /// Persist the sole ChatGPT OAuth credential under its fixed namespace.
+    pub fn store_chatgpt_oauth(
+        &mut self,
+        credential: ChatGptOAuthCredential,
+    ) -> Result<(), HttpError> {
+        let mut data = self.load_fresh();
+        data.chatgpt_oauth = Some(credential);
+        self.save(&data)
+    }
+
+    /// Load the ChatGPT OAuth credential from disk, bypassing the in-memory
+    /// cache. Refresh-token rotation by another OpenDev process must not be
+    /// overwritten by a stale store snapshot.
+    pub fn get_chatgpt_oauth(&mut self) -> Option<ChatGptOAuthCredential> {
+        self.load_fresh().chatgpt_oauth
+    }
+
+    /// Remove locally stored ChatGPT OAuth credentials. This does not revoke a
+    /// remote OAuth grant.
+    pub fn remove_chatgpt_oauth(&mut self) -> Result<bool, HttpError> {
+        let mut data = self.load_fresh();
+        let removed = data.chatgpt_oauth.take().is_some();
+        if removed {
+            self.save(&data)?;
+        }
+        Ok(removed)
+    }
+
     /// Load credentials from file, caching the result.
     fn load(&mut self) -> &AuthData {
         if let Some(ref cached) = self.cache {
@@ -178,6 +234,30 @@ impl CredentialStore {
         self.cache.as_ref().expect("cache was just set to Some")
     }
 
+    /// Read the credentials from disk even when a cache is already populated.
+    fn load_fresh(&mut self) -> AuthData {
+        let data = self.read_from_disk();
+        self.cache = Some(data.clone());
+        data
+    }
+
+    fn read_from_disk(&self) -> AuthData {
+        if !self.path.exists() {
+            return AuthData::default();
+        }
+
+        #[cfg(unix)]
+        self.check_permissions();
+
+        match std::fs::read_to_string(&self.path) {
+            Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
+            Err(e) => {
+                warn!("Failed to load credentials from {:?}: {}", self.path, e);
+                AuthData::default()
+            }
+        }
+    }
+
     /// Save credentials with restrictive permissions.
     fn save(&mut self, data: &AuthData) -> Result<(), HttpError> {
         self.cache = Some(data.clone());
@@ -186,8 +266,17 @@ impl CredentialStore {
             std::fs::create_dir_all(parent)?;
         }
 
-        // Write to temp file, then rename (atomic)
-        let tmp_path = self.path.with_extension("tmp");
+        // Write to a unique same-directory temp file, then rename atomically.
+        // A fixed filename races concurrent OpenDev processes and can expose a
+        // partially written credential file.
+        let filename = self
+            .path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("auth.json");
+        let tmp_path = self
+            .path
+            .with_file_name(format!(".{filename}.{}.tmp", Uuid::new_v4()));
         let json = serde_json::to_string_pretty(data)?;
 
         #[cfg(unix)]
@@ -195,7 +284,13 @@ impl CredentialStore {
             use std::os::unix::fs::OpenOptionsExt;
             let mut opts = std::fs::OpenOptions::new();
             opts.write(true).create_new(true).mode(0o600);
-            std::io::Write::write_all(&mut opts.open(&tmp_path)?, json.as_bytes())?;
+            let write_result = (|| -> Result<(), std::io::Error> {
+                std::io::Write::write_all(&mut opts.open(&tmp_path)?, json.as_bytes())
+            })();
+            if let Err(error) = write_result {
+                let _ = std::fs::remove_file(&tmp_path);
+                return Err(error.into());
+            }
         }
 
         #[cfg(not(unix))]

--- a/crates/opendev-http/src/auth_tests.rs
+++ b/crates/opendev-http/src/auth_tests.rs
@@ -106,3 +106,95 @@ fn test_nonexistent_file() {
     // Use a provider with no env var to avoid interference
     assert!(store.get_key("testprovider").is_none());
 }
+
+#[test]
+fn test_chatgpt_oauth_credentials_are_typed_redacted_and_persistent() {
+    let dir = tempfile::tempdir().unwrap();
+    let auth_path = dir.path().join("auth.json");
+    let credential = ChatGptOAuthCredential {
+        access_token: "access-secret".to_string(),
+        refresh_token: "refresh-secret".to_string(),
+        expires_at_ms: 1_700_000_000_000,
+        account_id: Some("workspace-123".to_string()),
+    };
+
+    let mut store = CredentialStore::new(Some(auth_path.clone()));
+    store.store_chatgpt_oauth(credential.clone()).unwrap();
+    assert_eq!(store.get_chatgpt_oauth(), Some(credential));
+    let debug = format!("{:?}", store.get_chatgpt_oauth().unwrap());
+    assert!(!debug.contains("access-secret"));
+    assert!(!debug.contains("refresh-secret"));
+    assert!(debug.contains("[REDACTED]"));
+
+    let mut reloaded = CredentialStore::new(Some(auth_path));
+    assert!(reloaded.get_chatgpt_oauth().is_some());
+    assert!(reloaded.remove_chatgpt_oauth().unwrap());
+    assert!(reloaded.get_chatgpt_oauth().is_none());
+}
+
+#[test]
+fn test_chatgpt_oauth_read_bypasses_stale_cache() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("auth.json");
+    let mut first = CredentialStore::new(Some(path.clone()));
+    let mut second = CredentialStore::new(Some(path));
+
+    first
+        .store_chatgpt_oauth(ChatGptOAuthCredential {
+            access_token: "first-access".to_string(),
+            refresh_token: "first-refresh".to_string(),
+            expires_at_ms: 1,
+            account_id: None,
+        })
+        .unwrap();
+    assert_eq!(
+        second.get_chatgpt_oauth().unwrap().access_token,
+        "first-access"
+    );
+
+    first
+        .store_chatgpt_oauth(ChatGptOAuthCredential {
+            access_token: "rotated-access".to_string(),
+            refresh_token: "rotated-refresh".to_string(),
+            expires_at_ms: 2,
+            account_id: None,
+        })
+        .unwrap();
+    assert_eq!(
+        second.get_chatgpt_oauth().unwrap().access_token,
+        "rotated-access"
+    );
+}
+
+#[test]
+fn test_chatgpt_oauth_successful_login_replaces_the_previous_credential() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut store = CredentialStore::new(Some(dir.path().join("auth.json")));
+
+    store
+        .store_chatgpt_oauth(ChatGptOAuthCredential {
+            access_token: "old-access".to_string(),
+            refresh_token: "old-refresh".to_string(),
+            expires_at_ms: 1,
+            account_id: Some("old-account".to_string()),
+        })
+        .unwrap();
+    store
+        .store_chatgpt_oauth(ChatGptOAuthCredential {
+            access_token: "new-access".to_string(),
+            refresh_token: "new-refresh".to_string(),
+            expires_at_ms: 2,
+            account_id: Some("new-account".to_string()),
+        })
+        .unwrap();
+
+    assert_eq!(
+        store.get_chatgpt_oauth(),
+        Some(ChatGptOAuthCredential {
+            access_token: "new-access".to_string(),
+            refresh_token: "new-refresh".to_string(),
+            expires_at_ms: 2,
+            account_id: Some("new-account".to_string()),
+        })
+    );
+}

--- a/crates/opendev-http/src/chatgpt_auth/authenticator.rs
+++ b/crates/opendev-http/src/chatgpt_auth/authenticator.rs
@@ -1,0 +1,681 @@
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use async_trait::async_trait;
+use base64::Engine;
+use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue};
+use serde::Deserialize;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::sync::Mutex as AsyncMutex;
+use tokio_util::sync::CancellationToken;
+use tracing::warn;
+use url::Url;
+
+use crate::auth::{ChatGptOAuthCredential, CredentialStore};
+use crate::models::HttpError;
+
+use super::protocol;
+
+/// Supplies short-lived OAuth headers immediately before each physical send.
+#[async_trait]
+pub trait RequestAuthenticator: Send + Sync {
+    async fn headers_for_request(
+        &self,
+        cancel: Option<&CancellationToken>,
+    ) -> Result<HeaderMap, HttpError>;
+    async fn force_refresh(&self, cancel: Option<&CancellationToken>) -> Result<(), HttpError>;
+}
+
+/// Browser authorization-code login state. Its verifier stays in memory only.
+pub struct BrowserLogin {
+    pub authorization_url: String,
+    state: String,
+    verifier: String,
+    listener_ipv4: Option<TcpListener>,
+    listener_ipv6: Option<TcpListener>,
+}
+
+#[cfg(test)]
+impl BrowserLogin {
+    pub(crate) fn state_for_test(&self) -> &str {
+        &self.state
+    }
+
+    pub(crate) fn has_ipv6_listener_for_test(&self) -> bool {
+        self.listener_ipv6.is_some()
+    }
+}
+
+/// Device-login state shown to a headless user. Secrets required to complete
+/// the exchange stay private to this module.
+pub struct DeviceLogin {
+    pub verification_url: String,
+    pub user_code: String,
+    device_auth_id: String,
+    interval: Duration,
+}
+
+/// Non-secret local credential state for CLI display.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LoginStatus {
+    LoggedOut,
+    Active {
+        account_id: Option<String>,
+        expires_at_ms: i64,
+    },
+    Expired {
+        account_id: Option<String>,
+        expires_at_ms: i64,
+    },
+}
+
+/// Refresh-aware ChatGPT OAuth authenticator. The mutex prevents multiple
+/// OpenDev tasks in this process from racing a rotating refresh token.
+pub struct ChatGptAuthenticator {
+    store: Arc<Mutex<CredentialStore>>,
+    refresh_lock: AsyncMutex<()>,
+    oauth_client: reqwest::Client,
+    token_url: String,
+    device_code_url: String,
+    device_poll_url: String,
+    device_poll_min_interval: u64,
+}
+
+impl ChatGptAuthenticator {
+    pub fn new(store: CredentialStore) -> Result<Self, HttpError> {
+        warn!(
+            "ChatGPT OAuth refresh is single-flight within one OpenDev process; avoid concurrent OpenDev processes using the same local credential because refresh tokens may rotate"
+        );
+        let oauth_client = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(10))
+            .timeout(Duration::from_secs(30))
+            .redirect(reqwest::redirect::Policy::none())
+            .build()?;
+        Ok(Self {
+            store: Arc::new(Mutex::new(store)),
+            refresh_lock: AsyncMutex::new(()),
+            oauth_client,
+            token_url: protocol::TOKEN_URL.to_string(),
+            device_code_url: protocol::DEVICE_CODE_URL.to_string(),
+            device_poll_url: protocol::DEVICE_POLL_URL.to_string(),
+            device_poll_min_interval: protocol::DEVICE_POLL_MIN_INTERVAL_SECS,
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_token_url(store: CredentialStore, token_url: String) -> Self {
+        Self {
+            store: Arc::new(Mutex::new(store)),
+            refresh_lock: AsyncMutex::new(()),
+            oauth_client: reqwest::Client::new(),
+            token_url,
+            device_code_url: protocol::DEVICE_CODE_URL.to_string(),
+            device_poll_url: protocol::DEVICE_POLL_URL.to_string(),
+            device_poll_min_interval: protocol::DEVICE_POLL_MIN_INTERVAL_SECS,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_endpoints(
+        store: CredentialStore,
+        token_url: String,
+        device_code_url: String,
+        device_poll_url: String,
+    ) -> Self {
+        Self {
+            store: Arc::new(Mutex::new(store)),
+            refresh_lock: AsyncMutex::new(()),
+            oauth_client: reqwest::Client::new(),
+            token_url,
+            device_code_url,
+            device_poll_url,
+            device_poll_min_interval: 0,
+        }
+    }
+
+    pub async fn begin_browser_login(&self) -> Result<BrowserLogin, HttpError> {
+        // The registered redirect uses `localhost`, which can resolve to
+        // either loopback family. Prefer IPv6, then retain IPv4 whenever the
+        // platform permits both listeners on the registered port.
+        let listener_ipv6 = TcpListener::bind(("::1", protocol::CALLBACK_PORT))
+            .await
+            .ok();
+        let listener_ipv4 = TcpListener::bind((protocol::CALLBACK_HOST, protocol::CALLBACK_PORT))
+            .await
+            .ok();
+        if listener_ipv4.is_none() && listener_ipv6.is_none() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::AddrInUse,
+                "could not bind the localhost OAuth callback port",
+            )
+            .into());
+        }
+        let state = random_urlsafe(32);
+        let verifier = random_urlsafe(64);
+        let challenge = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(Sha256::digest(verifier.as_bytes()));
+        let mut url = Url::parse(protocol::AUTHORIZE_URL)
+            .map_err(|e| HttpError::Auth(format!("invalid trusted authorization URL: {e}")))?;
+        url.query_pairs_mut()
+            .append_pair("response_type", "code")
+            .append_pair("client_id", protocol::OAUTH_CLIENT_ID)
+            .append_pair("redirect_uri", protocol::REDIRECT_URI)
+            .append_pair("scope", protocol::SCOPES)
+            .append_pair("code_challenge", &challenge)
+            .append_pair("code_challenge_method", "S256")
+            .append_pair("state", &state)
+            .append_pair("id_token_add_organizations", "true")
+            .append_pair("codex_cli_simplified_flow", "true")
+            .append_pair("originator", protocol::ORIGINATOR_HEADER_VALUE);
+        Ok(BrowserLogin {
+            authorization_url: url.into(),
+            state,
+            verifier,
+            listener_ipv4,
+            listener_ipv6,
+        })
+    }
+
+    /// Start the approved device-login flow. This is not RFC 8628 token
+    /// polling: the service returns an authorization code and PKCE verifier
+    /// which are exchanged at the normal OAuth token endpoint.
+    pub async fn begin_device_login(
+        &self,
+        cancel: Option<&CancellationToken>,
+    ) -> Result<DeviceLogin, HttpError> {
+        let response = self
+            .request_json(
+                &self.device_code_url,
+                serde_json::json!({ "client_id": protocol::OAUTH_CLIENT_ID }),
+                cancel,
+            )
+            .await?;
+        let device_auth_id = required_string(&response, "device_auth_id", "device login response")?;
+        let user_code = response
+            .get("user_code")
+            .or_else(|| response.get("usercode"))
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned)
+            .ok_or_else(|| HttpError::Auth("device login response omitted user_code".into()))?;
+        let interval = response
+            .get("interval")
+            .and_then(Value::as_u64)
+            .unwrap_or(self.device_poll_min_interval)
+            .max(self.device_poll_min_interval);
+        Ok(DeviceLogin {
+            verification_url: protocol::DEVICE_VERIFY_URL.to_string(),
+            user_code,
+            device_auth_id,
+            interval: Duration::from_secs(interval),
+        })
+    }
+
+    /// Poll device authorization until success, cancellation, or a bounded
+    /// deadline, then exchange the returned code with its verifier.
+    pub async fn finish_device_login(
+        &self,
+        login: DeviceLogin,
+        cancel: Option<&CancellationToken>,
+    ) -> Result<(), HttpError> {
+        let deadline =
+            tokio::time::Instant::now() + Duration::from_secs(protocol::DEVICE_LOGIN_TIMEOUT_SECS);
+        loop {
+            if tokio::time::Instant::now() >= deadline {
+                return Err(HttpError::Auth(
+                    "device login timed out; run `opendev setup` and choose OpenAI > ChatGPT Pro/Plus (headless) again".into(),
+                ));
+            }
+            let request = self
+                .oauth_client
+                .post(&self.device_poll_url)
+                .json(&serde_json::json!({
+                    "device_auth_id": login.device_auth_id,
+                    "user_code": login.user_code,
+                }))
+                .send();
+            let response = match cancel {
+                Some(token) => {
+                    tokio::select! { value = request => value?, _ = token.cancelled() => return Err(HttpError::Interrupted) }
+                }
+                None => request.await?,
+            };
+            match response.status().as_u16() {
+                200 => {
+                    let response: Value = response.json().await?;
+                    let code = required_string(
+                        &response,
+                        "authorization_code",
+                        "device authorization response",
+                    )?;
+                    let verifier = required_string(
+                        &response,
+                        "code_verifier",
+                        "device authorization response",
+                    )?;
+                    self.exchange_device_code(&code, &verifier, cancel).await?;
+                    return Ok(());
+                }
+                // These two statuses are the verified pending responses for this
+                // profile; do not invent generic OAuth pending/slow_down rules.
+                403 | 404 => self.sleep_or_cancel(login.interval, cancel).await?,
+                status => {
+                    return Err(HttpError::Auth(format!(
+                        "device login was rejected (HTTP {status}); enable device login in ChatGPT security settings or ask your workspace administrator"
+                    )));
+                }
+            }
+        }
+    }
+
+    pub async fn finish_browser_login(
+        &self,
+        login: BrowserLogin,
+        cancel: Option<&CancellationToken>,
+    ) -> Result<(), HttpError> {
+        let BrowserLogin {
+            state,
+            verifier,
+            listener_ipv4,
+            listener_ipv6,
+            ..
+        } = login;
+        let (mut stream, _) = {
+            let accept_callback = async {
+                match (&listener_ipv4, &listener_ipv6) {
+                    (Some(listener_ipv4), Some(listener_ipv6)) => {
+                        tokio::select! {
+                            accepted = listener_ipv4.accept() => accepted,
+                            accepted = listener_ipv6.accept() => accepted,
+                        }
+                    }
+                    (Some(listener_ipv4), None) => listener_ipv4.accept().await,
+                    (None, Some(listener_ipv6)) => listener_ipv6.accept().await,
+                    (None, None) => unreachable!("browser login has no callback listener"),
+                }
+            };
+            match cancel {
+                Some(token) => tokio::select! {
+                    accepted = accept_callback => accepted?,
+                    _ = token.cancelled() => return Err(HttpError::Interrupted),
+                },
+                None => accept_callback.await?,
+            }
+        };
+        // The callback was accepted; release both listening sockets before
+        // exchanging the authorization code so a subsequent login can start.
+        drop(listener_ipv4);
+        drop(listener_ipv6);
+        let mut request = vec![0_u8; 16 * 1024];
+        let size = stream.read(&mut request).await?;
+        let raw = std::str::from_utf8(&request[..size])
+            .map_err(|_| HttpError::Auth("malformed OAuth callback".into()))?;
+        let target = raw
+            .split_whitespace()
+            .nth(1)
+            .ok_or_else(|| HttpError::Auth("malformed OAuth callback".into()))?;
+        let callback = Url::parse(&format!("http://localhost{target}"))
+            .map_err(|_| HttpError::Auth("malformed OAuth callback".into()))?;
+        let pairs: std::collections::HashMap<_, _> = callback.query_pairs().into_owned().collect();
+        let code = match (
+            callback.path() == protocol::CALLBACK_PATH,
+            pairs.get("state"),
+            pairs.get("error"),
+            pairs.get("code"),
+        ) {
+            (false, _, _, _) => Err(HttpError::Auth("unexpected OAuth callback path".into())),
+            (_, _, Some(error), _) => Err(HttpError::Auth(format!(
+                "OAuth authorization was denied: {error}"
+            ))),
+            (_, Some(callback_state), None, Some(code)) if callback_state == &state => {
+                Ok(code.clone())
+            }
+            _ => Err(HttpError::Auth(
+                "OAuth callback state or code was invalid".into(),
+            )),
+        };
+        let body = if code.is_ok() {
+            "Login complete. You may close this window."
+        } else {
+            "Login failed. Return to OpenDev for details."
+        };
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let _ = stream.write_all(response.as_bytes()).await;
+        self.exchange_code(&code?, &verifier, cancel).await
+    }
+
+    pub fn status(&self) -> LoginStatus {
+        let credential = self
+            .store
+            .lock()
+            .expect("credential mutex poisoned")
+            .get_chatgpt_oauth();
+        match credential {
+            None => LoginStatus::LoggedOut,
+            Some(value) if value.expires_at_ms <= now_ms() => LoginStatus::Expired {
+                account_id: value.account_id,
+                expires_at_ms: value.expires_at_ms,
+            },
+            Some(value) => LoginStatus::Active {
+                account_id: value.account_id,
+                expires_at_ms: value.expires_at_ms,
+            },
+        }
+    }
+
+    pub fn logout(&self) -> Result<bool, HttpError> {
+        self.store
+            .lock()
+            .expect("credential mutex poisoned")
+            .remove_chatgpt_oauth()
+    }
+
+    async fn exchange_code(
+        &self,
+        code: &str,
+        verifier: &str,
+        cancel: Option<&CancellationToken>,
+    ) -> Result<(), HttpError> {
+        let token = self
+            .request_token(
+                &[
+                    ("grant_type", "authorization_code"),
+                    ("client_id", protocol::OAUTH_CLIENT_ID),
+                    ("code", code),
+                    ("redirect_uri", protocol::REDIRECT_URI),
+                    ("code_verifier", verifier),
+                ],
+                cancel,
+            )
+            .await?;
+        self.store_token_response(token, None)
+    }
+
+    async fn exchange_device_code(
+        &self,
+        code: &str,
+        verifier: &str,
+        cancel: Option<&CancellationToken>,
+    ) -> Result<(), HttpError> {
+        let token = self
+            .request_token(
+                &[
+                    ("grant_type", "authorization_code"),
+                    ("client_id", protocol::OAUTH_CLIENT_ID),
+                    ("code", code),
+                    ("redirect_uri", protocol::DEVICE_REDIRECT_URI),
+                    ("code_verifier", verifier),
+                ],
+                cancel,
+            )
+            .await?;
+        self.store_token_response(token, None)
+    }
+
+    async fn refresh(&self, cancel: Option<&CancellationToken>) -> Result<(), HttpError> {
+        let _guard = self.refresh_lock.lock().await;
+        let current = self
+            .store
+            .lock()
+            .expect("credential mutex poisoned")
+            .get_chatgpt_oauth()
+            .ok_or_else(|| {
+                HttpError::Auth(
+                    "ChatGPT login is required; run `opendev setup` and choose OpenAI > ChatGPT Pro/Plus".into(),
+                )
+            })?;
+        if !is_expiring(&current) {
+            return Ok(());
+        }
+        let token = self
+            .request_token(
+                &[
+                    ("grant_type", "refresh_token"),
+                    ("client_id", protocol::OAUTH_CLIENT_ID),
+                    ("refresh_token", &current.refresh_token),
+                ],
+                cancel,
+            )
+            .await;
+        match token {
+            Ok(token) => self.store_token_response(token, Some(current)),
+            Err(error) => {
+                if error.to_string().contains("invalid_grant") {
+                    let _ = self.logout();
+                    Err(HttpError::Auth(
+                        "ChatGPT login expired; run `opendev setup` and choose OpenAI > ChatGPT Pro/Plus again".into(),
+                    ))
+                } else {
+                    Err(error)
+                }
+            }
+        }
+    }
+
+    async fn request_token(
+        &self,
+        form: &[(&str, &str)],
+        cancel: Option<&CancellationToken>,
+    ) -> Result<TokenResponse, HttpError> {
+        let encoded = url::form_urlencoded::Serializer::new(String::new())
+            .extend_pairs(form.iter().copied())
+            .finish();
+        let request = self
+            .oauth_client
+            .post(&self.token_url)
+            .header(CONTENT_TYPE, "application/x-www-form-urlencoded")
+            .body(encoded)
+            .send();
+        let response = match cancel {
+            Some(token) => {
+                tokio::select! { value = request => value?, _ = token.cancelled() => return Err(HttpError::Interrupted) }
+            }
+            None => request.await?,
+        };
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(HttpError::Auth(format!(
+                "OAuth token request failed ({status}): {}",
+                safe_oauth_error(&body)
+            )));
+        }
+        response.json().await.map_err(HttpError::from)
+    }
+
+    async fn request_json(
+        &self,
+        url: &str,
+        body: Value,
+        cancel: Option<&CancellationToken>,
+    ) -> Result<Value, HttpError> {
+        let request = self.oauth_client.post(url).json(&body).send();
+        let response = match cancel {
+            Some(token) => {
+                tokio::select! { value = request => value?, _ = token.cancelled() => return Err(HttpError::Interrupted) }
+            }
+            None => request.await?,
+        };
+        if !response.status().is_success() {
+            return Err(HttpError::Auth(format!(
+                "device login request failed (HTTP {})",
+                response.status()
+            )));
+        }
+        response.json().await.map_err(HttpError::from)
+    }
+
+    async fn sleep_or_cancel(
+        &self,
+        duration: Duration,
+        cancel: Option<&CancellationToken>,
+    ) -> Result<(), HttpError> {
+        match cancel {
+            Some(token) => {
+                tokio::select! { _ = tokio::time::sleep(duration) => Ok(()), _ = token.cancelled() => Err(HttpError::Interrupted) }
+            }
+            None => {
+                tokio::time::sleep(duration).await;
+                Ok(())
+            }
+        }
+    }
+
+    fn store_token_response(
+        &self,
+        token: TokenResponse,
+        previous: Option<ChatGptOAuthCredential>,
+    ) -> Result<(), HttpError> {
+        let expires_in = token.expires_in.unwrap_or(3600).clamp(1, 86_400);
+        let account_id = token
+            .id_token
+            .as_deref()
+            .and_then(account_claim)
+            .or_else(|| account_claim(&token.access_token));
+        let credential = ChatGptOAuthCredential {
+            access_token: token.access_token,
+            refresh_token: token
+                .refresh_token
+                .or_else(|| previous.map(|value| value.refresh_token))
+                .ok_or_else(|| {
+                    HttpError::Auth("OAuth token response omitted a refresh token".into())
+                })?,
+            expires_at_ms: now_ms() + i64::from(expires_in) * 1000,
+            account_id,
+        };
+        self.store
+            .lock()
+            .expect("credential mutex poisoned")
+            .store_chatgpt_oauth(credential)
+    }
+}
+
+#[async_trait]
+impl RequestAuthenticator for ChatGptAuthenticator {
+    async fn headers_for_request(
+        &self,
+        cancel: Option<&CancellationToken>,
+    ) -> Result<HeaderMap, HttpError> {
+        self.refresh(cancel).await?;
+        let credential = self
+            .store
+            .lock()
+            .expect("credential mutex poisoned")
+            .get_chatgpt_oauth()
+            .ok_or_else(|| {
+                HttpError::Auth(
+                    "ChatGPT login is required; run `opendev setup` and choose OpenAI > ChatGPT Pro/Plus".into(),
+                )
+            })?;
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_str(&format!("Bearer {}", credential.access_token)).map_err(
+                |_| HttpError::Auth("OAuth access token contained invalid header bytes".into()),
+            )?,
+        );
+        headers.insert(
+            "openai-beta",
+            HeaderValue::from_static(protocol::BETA_HEADER_VALUE),
+        );
+        headers.insert(
+            "originator",
+            HeaderValue::from_static(protocol::ORIGINATOR_HEADER_VALUE),
+        );
+        if let Some(account_id) = credential.account_id
+            && let Ok(value) = HeaderValue::from_str(&account_id)
+        {
+            headers.insert("chatgpt-account-id", value);
+        }
+        Ok(headers)
+    }
+
+    async fn force_refresh(&self, cancel: Option<&CancellationToken>) -> Result<(), HttpError> {
+        let current = self
+            .store
+            .lock()
+            .expect("credential mutex poisoned")
+            .get_chatgpt_oauth()
+            .ok_or_else(|| {
+                HttpError::Auth(
+                    "ChatGPT login is required; run `opendev setup` and choose OpenAI > ChatGPT Pro/Plus".into(),
+                )
+            })?;
+        // Make the token visibly stale then run the normal single-flight path.
+        self.store
+            .lock()
+            .expect("credential mutex poisoned")
+            .store_chatgpt_oauth(ChatGptOAuthCredential {
+                expires_at_ms: 0,
+                ..current
+            })?;
+        self.refresh(cancel).await
+    }
+}
+
+#[derive(Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    refresh_token: Option<String>,
+    expires_in: Option<i32>,
+    id_token: Option<String>,
+}
+
+fn random_urlsafe(bytes: usize) -> String {
+    let mut raw = vec![0_u8; bytes];
+    for chunk in raw.chunks_mut(16) {
+        chunk.copy_from_slice(uuid::Uuid::new_v4().as_bytes());
+    }
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(raw)
+}
+
+fn now_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64
+}
+fn is_expiring(value: &ChatGptOAuthCredential) -> bool {
+    value.expires_at_ms <= now_ms() + protocol::REFRESH_SKEW_SECS * 1000
+}
+fn safe_oauth_error(body: &str) -> &str {
+    if body.contains("invalid_grant") {
+        "invalid_grant"
+    } else {
+        "request rejected"
+    }
+}
+pub(crate) fn account_claim(token: &str) -> Option<String> {
+    let payload = token.split('.').nth(1)?;
+    let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload)
+        .ok()?;
+    let json: serde_json::Value = serde_json::from_slice(&decoded).ok()?;
+    json.get("https://api.openai.com/auth")
+        .and_then(|value| {
+            value
+                .get("chatgpt_account_id")
+                .or_else(|| value.get("account_id"))
+                .or_else(|| value.get("id"))
+        })
+        .or_else(|| json.get("account_id"))
+        .or_else(|| json.get("organization_id"))
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+}
+
+fn required_string(value: &Value, field: &str, context: &str) -> Result<String, HttpError> {
+    value
+        .get(field)
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| HttpError::Auth(format!("{context} omitted {field}")))
+}

--- a/crates/opendev-http/src/chatgpt_auth/mod.rs
+++ b/crates/opendev-http/src/chatgpt_auth/mod.rs
@@ -1,0 +1,14 @@
+//! Shared types and trusted protocol constants for ChatGPT OAuth.
+//!
+//! The login protocol intentionally has no configurable production endpoints:
+//! OAuth credentials must never be sent to a URL from user configuration.
+
+mod authenticator;
+pub mod protocol;
+
+pub use authenticator::{
+    BrowserLogin, ChatGptAuthenticator, DeviceLogin, LoginStatus, RequestAuthenticator,
+};
+
+#[cfg(test)]
+mod tests;

--- a/crates/opendev-http/src/chatgpt_auth/protocol.rs
+++ b/crates/opendev-http/src/chatgpt_auth/protocol.rs
@@ -1,0 +1,31 @@
+//! Source-pinned protocol compatibility profile for ChatGPT Codex OAuth.
+//!
+//! These are deliberately constants rather than OpenDev settings: accepting
+//! user supplied issuer, token, or API URLs would permit credential exfiltration.
+
+/// Approved public OAuth compatibility client profile.
+pub const OAUTH_CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
+pub const AUTHORIZE_URL: &str = "https://auth.openai.com/oauth/authorize";
+pub const TOKEN_URL: &str = "https://auth.openai.com/oauth/token";
+pub const DEVICE_CODE_URL: &str = "https://auth.openai.com/api/accounts/deviceauth/usercode";
+pub const DEVICE_POLL_URL: &str = "https://auth.openai.com/api/accounts/deviceauth/token";
+pub const DEVICE_VERIFY_URL: &str = "https://auth.openai.com/codex/device";
+pub const DEVICE_REDIRECT_URI: &str = "https://auth.openai.com/deviceauth/callback";
+pub const CALLBACK_HOST: &str = "127.0.0.1";
+pub const CALLBACK_PORT: u16 = 1455;
+pub const CALLBACK_PATH: &str = "/auth/callback";
+pub const REDIRECT_URI: &str = "http://localhost:1455/auth/callback";
+pub const SCOPES: &str = "openid profile email offline_access";
+
+/// Trusted Responses endpoint used by the ChatGPT Codex backend.
+pub const CHATGPT_CODEX_RESPONSES_URL: &str = "https://chatgpt.com/backend-api/codex/responses";
+/// Fixed credential-store namespace for this transport mode.
+pub const CHATGPT_OAUTH_CREDENTIAL_KEY: &str = "openai-chatgpt";
+/// Refresh slightly before expiry so a request never starts with a stale token.
+pub const REFRESH_SKEW_SECS: i64 = 60;
+pub const DEVICE_LOGIN_TIMEOUT_SECS: u64 = 15 * 60;
+pub const DEVICE_POLL_MIN_INTERVAL_SECS: u64 = 5;
+
+/// Required static, non-secret protocol headers.
+pub const BETA_HEADER_VALUE: &str = "responses=experimental";
+pub const ORIGINATOR_HEADER_VALUE: &str = "codex_cli_rs";

--- a/crates/opendev-http/src/chatgpt_auth/tests.rs
+++ b/crates/opendev-http/src/chatgpt_auth/tests.rs
@@ -1,0 +1,406 @@
+use super::authenticator::RequestAuthenticator;
+use super::*;
+use crate::{ChatGptOAuthCredential, CredentialStore, HttpClient};
+use base64::Engine;
+use std::sync::{Arc, OnceLock};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+fn browser_login_test_lock() -> &'static tokio::sync::Mutex<()> {
+    static LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
+#[tokio::test]
+async fn missing_chatgpt_credential_directs_users_to_setup() {
+    let temp = tempfile::tempdir().unwrap();
+    let auth = ChatGptAuthenticator::with_token_url(
+        CredentialStore::new(Some(temp.path().join("auth.json"))),
+        "http://127.0.0.1:1/token".to_string(),
+    );
+
+    let error = auth
+        .headers_for_request(None)
+        .await
+        .unwrap_err()
+        .to_string();
+
+    assert!(error.contains("opendev setup"));
+    assert!(!error.contains("opendev auth"));
+}
+
+#[tokio::test]
+async fn expiring_credential_refreshes_and_preserves_rotated_token_when_omitted() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("auth.json");
+    let mut store = CredentialStore::new(Some(path.clone()));
+    store
+        .store_chatgpt_oauth(ChatGptOAuthCredential {
+            access_token: "old-access".into(),
+            refresh_token: "keep-refresh".into(),
+            expires_at_ms: 0,
+            account_id: None,
+        })
+        .unwrap();
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = format!("http://{}", listener.local_addr().unwrap());
+    tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let mut bytes = [0; 4096];
+        let size = stream.read(&mut bytes).await.unwrap();
+        let request = String::from_utf8_lossy(&bytes[..size]);
+        assert!(request.contains("grant_type=refresh_token"));
+        assert!(request.contains("refresh_token=keep-refresh"));
+        let body = r#"{"access_token":"new-access","expires_in":3600}"#;
+        stream.write_all(format!("HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}", body.len(), body).as_bytes()).await.unwrap();
+    });
+    let auth = ChatGptAuthenticator::with_token_url(CredentialStore::new(Some(path)), url);
+    let headers = auth.headers_for_request(None).await.unwrap();
+    assert_eq!(headers["authorization"], "Bearer new-access");
+    assert_eq!(headers["openai-beta"], "responses=experimental");
+    let credential = CredentialStore::new(Some(temp.path().join("auth.json")))
+        .get_chatgpt_oauth()
+        .unwrap();
+    assert_eq!(credential.refresh_token, "keep-refresh");
+}
+
+#[tokio::test]
+async fn concurrent_requests_share_one_refresh() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("auth.json");
+    CredentialStore::new(Some(path.clone()))
+        .store_chatgpt_oauth(ChatGptOAuthCredential {
+            access_token: "old-access".into(),
+            refresh_token: "shared-refresh".into(),
+            expires_at_ms: 0,
+            account_id: None,
+        })
+        .unwrap();
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = format!("http://{}", listener.local_addr().unwrap());
+    tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let mut bytes = [0; 4096];
+        let _ = stream.read(&mut bytes).await.unwrap();
+        let body = r#"{"access_token":"fresh-access","expires_in":3600}"#;
+        stream.write_all(format!("HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}", body.len()).as_bytes()).await.unwrap();
+    });
+    let auth = ChatGptAuthenticator::with_token_url(CredentialStore::new(Some(path)), url);
+    let (first, second) = tokio::join!(
+        auth.headers_for_request(None),
+        auth.headers_for_request(None)
+    );
+    assert_eq!(first.unwrap()["authorization"], "Bearer fresh-access");
+    assert_eq!(second.unwrap()["authorization"], "Bearer fresh-access");
+}
+
+#[tokio::test]
+async fn invalid_grant_refresh_removes_the_unusable_local_credential() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("auth.json");
+    CredentialStore::new(Some(path.clone()))
+        .store_chatgpt_oauth(ChatGptOAuthCredential {
+            access_token: "expired-access".into(),
+            refresh_token: "revoked-refresh".into(),
+            expires_at_ms: 0,
+            account_id: None,
+        })
+        .unwrap();
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let token_url = format!("http://{}", listener.local_addr().unwrap());
+    tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let mut request = [0; 4096];
+        let _ = stream.read(&mut request).await.unwrap();
+        let body = r#"{"error":"invalid_grant"}"#;
+        stream
+            .write_all(
+                format!("HTTP/1.1 400 Bad Request\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}", body.len()).as_bytes(),
+            )
+            .await
+            .unwrap();
+    });
+    let auth =
+        ChatGptAuthenticator::with_token_url(CredentialStore::new(Some(path.clone())), token_url);
+    let error = auth.headers_for_request(None).await.unwrap_err();
+    assert!(error.to_string().contains("login expired"));
+    assert!(
+        CredentialStore::new(Some(path))
+            .get_chatgpt_oauth()
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn browser_login_uses_loopback_pkce_callback_and_rejects_wrong_state() {
+    let _lock = browser_login_test_lock().lock().await;
+    let temp = tempfile::tempdir().unwrap();
+    let auth = ChatGptAuthenticator::new(CredentialStore::new(Some(temp.path().join("auth.json"))))
+        .unwrap();
+    let login = auth.begin_browser_login().await.unwrap();
+    assert!(
+        login
+            .authorization_url
+            .contains("code_challenge_method=S256")
+    );
+    assert!(
+        login
+            .authorization_url
+            .contains("redirect_uri=http%3A%2F%2Flocalhost%3A1455%2Fauth%2Fcallback")
+    );
+    let state = "wrong-state";
+    let callback_host = if login.has_ipv6_listener_for_test() {
+        "[::1]"
+    } else {
+        "127.0.0.1"
+    };
+    tokio::spawn(async move {
+        let mut stream = tokio::net::TcpStream::connect(format!("{callback_host}:1455"))
+            .await
+            .unwrap();
+        let request = format!(
+            "GET /auth/callback?code=do-not-exchange&state={state} HTTP/1.1\r\nHost: localhost\r\n\r\n"
+        );
+        stream.write_all(request.as_bytes()).await.unwrap();
+    });
+    let error = auth.finish_browser_login(login, None).await.unwrap_err();
+    assert!(error.to_string().contains("state or code was invalid"));
+}
+
+#[tokio::test]
+async fn browser_login_exchanges_a_valid_callback_code_and_reports_denial() {
+    let _lock = browser_login_test_lock().lock().await;
+    let temp = tempfile::tempdir().unwrap();
+    let token_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let token_url = format!("http://{}/token", token_listener.local_addr().unwrap());
+    tokio::spawn(async move {
+        let (mut stream, _) = token_listener.accept().await.unwrap();
+        let mut request = [0_u8; 4096];
+        let count = stream.read(&mut request).await.unwrap();
+        let request = String::from_utf8_lossy(&request[..count]);
+        assert!(request.contains("code=accepted-code"));
+        let body = r#"{"access_token":"browser-access","refresh_token":"browser-refresh","expires_in":3600}"#;
+        stream
+            .write_all(
+                format!("HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}", body.len()).as_bytes(),
+            )
+            .await
+            .unwrap();
+    });
+
+    let path = temp.path().join("auth.json");
+    let auth =
+        ChatGptAuthenticator::with_token_url(CredentialStore::new(Some(path.clone())), token_url);
+    let login = auth.begin_browser_login().await.unwrap();
+    let state = login.state_for_test().to_string();
+    let callback_host = if login.has_ipv6_listener_for_test() {
+        "[::1]"
+    } else {
+        "127.0.0.1"
+    };
+    tokio::spawn(async move {
+        let mut stream = tokio::net::TcpStream::connect(format!("{callback_host}:1455"))
+            .await
+            .unwrap();
+        let request = format!(
+            "GET /auth/callback?code=accepted-code&state={state} HTTP/1.1\r\nHost: localhost\r\n\r\n"
+        );
+        stream.write_all(request.as_bytes()).await.unwrap();
+    });
+    auth.finish_browser_login(login, None).await.unwrap();
+    assert_eq!(
+        CredentialStore::new(Some(path))
+            .get_chatgpt_oauth()
+            .unwrap()
+            .access_token,
+        "browser-access"
+    );
+
+    let denied = auth.begin_browser_login().await.unwrap();
+    let callback_host = if denied.has_ipv6_listener_for_test() {
+        "[::1]"
+    } else {
+        "127.0.0.1"
+    };
+    tokio::spawn(async move {
+        let mut stream = tokio::net::TcpStream::connect(format!("{callback_host}:1455"))
+            .await
+            .unwrap();
+        stream
+            .write_all(
+                b"GET /auth/callback?error=access_denied HTTP/1.1\r\nHost: localhost\r\n\r\n",
+            )
+            .await
+            .unwrap();
+    });
+    let error = auth.finish_browser_login(denied, None).await.unwrap_err();
+    assert!(error.to_string().contains("authorization was denied"));
+}
+
+#[tokio::test]
+async fn device_login_polls_pending_then_exchanges_returned_code() {
+    let temp = tempfile::tempdir().unwrap();
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base = format!("http://{}", listener.local_addr().unwrap());
+    tokio::spawn(async move {
+        for (status, body) in [
+            (
+                "200 OK",
+                r#"{"device_auth_id":"device-id","user_code":"ABCD-EFGH","interval":0}"#,
+            ),
+            ("403 Forbidden", r#"{}"#),
+            (
+                "200 OK",
+                r#"{"authorization_code":"authorization-code","code_verifier":"device-verifier"}"#,
+            ),
+            (
+                "200 OK",
+                r#"{"access_token":"device-access","refresh_token":"device-refresh","expires_in":3600}"#,
+            ),
+        ] {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut raw = [0_u8; 4096];
+            let _ = stream.read(&mut raw).await.unwrap();
+            let response = format!(
+                "HTTP/1.1 {status}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+        }
+    });
+    let path = temp.path().join("auth.json");
+    let auth = ChatGptAuthenticator::with_endpoints(
+        CredentialStore::new(Some(path.clone())),
+        format!("{base}/oauth/token"),
+        format!("{base}/device/code"),
+        format!("{base}/device/poll"),
+    );
+    let login = auth.begin_device_login(None).await.unwrap();
+    assert_eq!(login.user_code, "ABCD-EFGH");
+    assert_eq!(login.verification_url, protocol::DEVICE_VERIFY_URL);
+    auth.finish_device_login(login, None).await.unwrap();
+    assert_eq!(
+        CredentialStore::new(Some(path))
+            .get_chatgpt_oauth()
+            .unwrap()
+            .access_token,
+        "device-access"
+    );
+}
+
+#[tokio::test]
+async fn device_login_cancellation_is_immediate() {
+    let temp = tempfile::tempdir().unwrap();
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base = format!("http://{}", listener.local_addr().unwrap());
+    tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let mut raw = [0_u8; 4096];
+        let _ = stream.read(&mut raw).await.unwrap();
+        let body = r#"{"device_auth_id":"device-id","user_code":"ABCD-EFGH","interval":60}"#;
+        stream.write_all(format!("HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}", body.len()).as_bytes()).await.unwrap();
+    });
+    let auth = ChatGptAuthenticator::with_endpoints(
+        CredentialStore::new(Some(temp.path().join("auth.json"))),
+        format!("{base}/oauth/token"),
+        format!("{base}/device/code"),
+        format!("{base}/device/poll"),
+    );
+    let login = auth.begin_device_login(None).await.unwrap();
+    let cancelled = tokio_util::sync::CancellationToken::new();
+    cancelled.cancel();
+    assert!(matches!(
+        auth.finish_device_login(login, Some(&cancelled)).await,
+        Err(crate::HttpError::Interrupted)
+    ));
+}
+
+#[test]
+fn account_id_is_derived_from_the_chatgpt_auth_claim() {
+    let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .encode(br#"{"https://api.openai.com/auth":{"chatgpt_account_id":"acct_123"}}"#);
+    let token = format!("header.{payload}.signature");
+    assert_eq!(
+        super::authenticator::account_claim(&token).as_deref(),
+        Some("acct_123")
+    );
+}
+
+#[tokio::test]
+async fn mocked_device_login_refresh_inference_and_logout_end_to_end() {
+    let temp = tempfile::tempdir().unwrap();
+    let auth_path = temp.path().join("auth.json");
+
+    let oauth_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let oauth_base = format!("http://{}", oauth_listener.local_addr().unwrap());
+    tokio::spawn(async move {
+        for body in [
+            r#"{"device_auth_id":"device-id","user_code":"ABCD-EFGH","interval":0}"#,
+            r#"{"authorization_code":"authorization-code","code_verifier":"device-verifier"}"#,
+            r#"{"access_token":"initial-access","refresh_token":"initial-refresh","expires_in":3600}"#,
+            r#"{"access_token":"refreshed-access","refresh_token":"rotated-refresh","expires_in":3600}"#,
+        ] {
+            let (mut stream, _) = oauth_listener.accept().await.unwrap();
+            let mut raw = [0_u8; 4096];
+            let _ = stream.read(&mut raw).await.unwrap();
+            stream
+                .write_all(
+                    format!("HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}", body.len()).as_bytes(),
+                )
+                .await
+                .unwrap();
+        }
+    });
+
+    let inference_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let inference_url = format!("http://{}", inference_listener.local_addr().unwrap());
+    tokio::spawn(async move {
+        for (status, body) in [
+            ("401 Unauthorized", r#"{"error":{"message":"expired"}}"#),
+            ("200 OK", r#"{"ok":true}"#),
+        ] {
+            let (mut stream, _) = inference_listener.accept().await.unwrap();
+            let mut raw = [0_u8; 4096];
+            let count = stream.read(&mut raw).await.unwrap();
+            let request = String::from_utf8_lossy(&raw[..count]);
+            if status == "401 Unauthorized" {
+                assert!(request.contains("authorization: Bearer initial-access"));
+            } else {
+                assert!(request.contains("authorization: Bearer refreshed-access"));
+            }
+            stream
+                .write_all(
+                    format!("HTTP/1.1 {status}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}", body.len()).as_bytes(),
+                )
+                .await
+                .unwrap();
+        }
+    });
+
+    let authenticator = Arc::new(ChatGptAuthenticator::with_endpoints(
+        CredentialStore::new(Some(auth_path)),
+        format!("{oauth_base}/oauth/token"),
+        format!("{oauth_base}/device/code"),
+        format!("{oauth_base}/device/poll"),
+    ));
+    let device = authenticator.begin_device_login(None).await.unwrap();
+    authenticator
+        .finish_device_login(device, None)
+        .await
+        .unwrap();
+    assert!(matches!(authenticator.status(), LoginStatus::Active { .. }));
+
+    let client = HttpClient::new(inference_url, Default::default(), None)
+        .unwrap()
+        .with_request_authenticator(authenticator.clone());
+    assert!(
+        client
+            .post_json(&serde_json::json!({"model":"codex-test"}), None)
+            .await
+            .unwrap()
+            .success
+    );
+    assert!(authenticator.logout().unwrap());
+    assert_eq!(authenticator.status(), LoginStatus::LoggedOut);
+}

--- a/crates/opendev-http/src/client.rs
+++ b/crates/opendev-http/src/client.rs
@@ -6,7 +6,30 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
 use uuid::Uuid;
 
+use crate::chatgpt_auth::RequestAuthenticator;
 use crate::models::{HttpError, HttpResult, RetryConfig};
+
+fn api_error_message(status: u16, body: &str) -> String {
+    let json_message = serde_json::from_str::<serde_json::Value>(body)
+        .ok()
+        .and_then(|value| {
+            value
+                .pointer("/error/message")
+                .or_else(|| value.get("message"))
+                .or_else(|| value.get("detail"))
+                .and_then(|message| message.as_str().map(ToOwned::to_owned))
+        });
+    if let Some(message) = json_message.filter(|message| !message.trim().is_empty()) {
+        return message;
+    }
+
+    let body = body.trim();
+    if body.is_empty() {
+        format!("HTTP {status}")
+    } else {
+        body.chars().take(1_024).collect()
+    }
+}
 
 /// Timeout configuration for HTTP requests.
 #[derive(Debug, Clone)]
@@ -34,9 +57,15 @@ impl Default for TimeoutConfig {
 /// - Cancellation via `CancellationToken` (checked between retries and via `tokio::select!`)
 pub struct HttpClient {
     client: reqwest::Client,
+    /// A separate transport for requests that attach refreshable OAuth
+    /// credentials. Redirects are disabled here so those credentials can
+    /// never be forwarded to a different origin.
+    authenticated_client: reqwest::Client,
     api_url: String,
     retry_config: RetryConfig,
     circuit_breaker: Option<std::sync::Arc<crate::circuit_breaker::CircuitBreaker>>,
+    /// Optional dynamic auth applied immediately before every physical send.
+    authenticator: Option<std::sync::Arc<dyn RequestAuthenticator>>,
 }
 
 impl HttpClient {
@@ -48,23 +77,47 @@ impl HttpClient {
     ) -> Result<Self, HttpError> {
         let timeout = timeout.unwrap_or_default();
         let client = reqwest::Client::builder()
+            .default_headers(headers.clone())
+            .connect_timeout(timeout.connect)
+            .timeout(timeout.read)
+            .build()?;
+        let authenticated_client = reqwest::Client::builder()
             .default_headers(headers)
             .connect_timeout(timeout.connect)
             .timeout(timeout.read)
+            // Dynamic OAuth headers must never be carried through a redirect
+            // to an origin other than the source-pinned backend endpoint.
+            .redirect(reqwest::redirect::Policy::none())
             .build()?;
 
         Ok(Self {
             client,
+            authenticated_client,
             api_url: api_url.into(),
             retry_config: RetryConfig::default(),
             circuit_breaker: None,
+            authenticator: None,
         })
+    }
+
+    fn request_client(&self) -> &reqwest::Client {
+        if self.authenticator.is_some() {
+            &self.authenticated_client
+        } else {
+            &self.client
+        }
     }
 
     /// Create a client with custom retry configuration.
     pub fn with_retry_config(mut self, config: RetryConfig) -> Self {
         self.retry_config = config;
         self
+    }
+
+    /// Shared by the curl fallback so both physical transports classify HTTP
+    /// statuses with the same retry policy.
+    pub(crate) fn is_retryable_status(&self, status: u16) -> bool {
+        self.retry_config.is_retryable_status(status)
     }
 
     /// Attach a circuit breaker to this client.
@@ -76,6 +129,16 @@ impl HttpClient {
         cb: std::sync::Arc<crate::circuit_breaker::CircuitBreaker>,
     ) -> Self {
         self.circuit_breaker = Some(cb);
+        self
+    }
+
+    /// Attach refresh-aware request authentication. Unlike default headers,
+    /// these are generated per send so retries cannot reuse an expired token.
+    pub fn with_request_authenticator(
+        mut self,
+        authenticator: std::sync::Arc<dyn RequestAuthenticator>,
+    ) -> Self {
+        self.authenticator = Some(authenticator);
         self
     }
 
@@ -98,6 +161,7 @@ impl HttpClient {
         }
 
         let mut last_result: Option<HttpResult> = None;
+        let mut used_auth_retry = false;
 
         for attempt in 0..=self.retry_config.max_retries {
             // Check cancellation before each attempt
@@ -107,7 +171,18 @@ impl HttpClient {
                 return Ok(HttpResult::interrupted());
             }
 
-            let result = self.execute_request(payload, cancel).await;
+            let mut result = self.execute_request(payload, cancel).await;
+            // A token can be revoked after the pre-send expiry check. Refresh
+            // once and replay this physical request without consuming normal
+            // 429/5xx retry budget or opening the circuit on the first 401.
+            if matches!(&result, Ok(response) if response.status == Some(401))
+                && !used_auth_retry
+                && let Some(authenticator) = &self.authenticator
+            {
+                used_auth_retry = true;
+                authenticator.force_refresh(cancel).await?;
+                result = self.execute_request(payload, cancel).await;
+            }
 
             match result {
                 Ok(hr) if hr.success => {
@@ -215,8 +290,8 @@ impl HttpClient {
         let request_id = Uuid::new_v4().to_string();
         debug!(request_id = %request_id, api_url = %self.api_url, "Sending LLM request");
 
-        let request = self
-            .client
+        let mut request = self
+            .request_client()
             .post(&self.api_url)
             .header(CONTENT_TYPE, HeaderValue::from_static("application/json"))
             .header(
@@ -224,8 +299,11 @@ impl HttpClient {
                 HeaderValue::from_str(&request_id)
                     .unwrap_or_else(|_| HeaderValue::from_static("unknown")),
             )
-            .json(payload)
-            .send();
+            .json(payload);
+        if let Some(authenticator) = &self.authenticator {
+            request = request.headers(authenticator.headers_for_request(cancel).await?);
+        }
+        let request = request.send();
 
         let response = match cancel {
             Some(token) => {
@@ -351,6 +429,17 @@ impl HttpClient {
         payload: &serde_json::Value,
         cancel: Option<&CancellationToken>,
     ) -> Result<reqwest::Response, HttpError> {
+        self.send_streaming_request_inner(url, payload, cancel, false)
+            .await
+    }
+
+    async fn send_streaming_request_inner(
+        &self,
+        url: &str,
+        payload: &serde_json::Value,
+        cancel: Option<&CancellationToken>,
+        used_auth_retry: bool,
+    ) -> Result<reqwest::Response, HttpError> {
         // Check circuit breaker
         if let Some(cb) = &self.circuit_breaker {
             cb.check()?;
@@ -369,8 +458,8 @@ impl HttpClient {
             let request_id = Uuid::new_v4().to_string();
             debug!(request_id = %request_id, api_url = %url, attempt, "Sending streaming LLM request");
 
-            let request = self
-                .client
+            let mut request = self
+                .request_client()
                 .post(url)
                 .header(CONTENT_TYPE, HeaderValue::from_static("application/json"))
                 .header(
@@ -378,8 +467,11 @@ impl HttpClient {
                     HeaderValue::from_str(&request_id)
                         .unwrap_or_else(|_| HeaderValue::from_static("unknown")),
                 )
-                .json(payload)
-                .send();
+                .json(payload);
+            if let Some(authenticator) = &self.authenticator {
+                request = request.headers(authenticator.headers_for_request(cancel).await?);
+            }
+            let request = request.send();
 
             let response = match cancel {
                 Some(token) => {
@@ -410,15 +502,7 @@ impl HttpClient {
                             .and_then(|v| v.to_str().ok())
                             .map(String::from);
                         let body = resp.text().await.unwrap_or_default();
-                        let error_msg = serde_json::from_str::<serde_json::Value>(&body)
-                            .ok()
-                            .and_then(|v| {
-                                v.get("error")
-                                    .and_then(|e| e.get("message"))
-                                    .and_then(|m| m.as_str())
-                                    .map(String::from)
-                            })
-                            .unwrap_or_else(|| format!("HTTP {status}"));
+                        let error_msg = api_error_message(status, &body);
 
                         // Transient status (429/5xx): if retries run out, surface
                         // as RetriesExhausted so callers still classify it as
@@ -450,18 +534,23 @@ impl HttpClient {
                             "Streaming request exhausted {} retries",
                             self.retry_config.max_retries
                         );
+                    } else if status == 401 && !used_auth_retry && self.authenticator.is_some() {
+                        // Drop the stale response before re-sending with one
+                        // forced refresh. This does not consume retry budget.
+                        drop(resp);
+                        self.authenticator
+                            .as_ref()
+                            .expect("checked authenticator")
+                            .force_refresh(cancel)
+                            .await?;
+                        return Box::pin(
+                            self.send_streaming_request_inner(url, payload, cancel, true),
+                        )
+                        .await;
                     } else if status >= 400 {
                         // Non-retryable error — fail immediately
                         let body = resp.text().await.unwrap_or_default();
-                        let error_msg = serde_json::from_str::<serde_json::Value>(&body)
-                            .ok()
-                            .and_then(|v| {
-                                v.get("error")
-                                    .and_then(|e| e.get("message"))
-                                    .and_then(|m| m.as_str())
-                                    .map(String::from)
-                            })
-                            .unwrap_or_else(|| format!("HTTP {status}"));
+                        let error_msg = api_error_message(status, &body);
                         warn!(request_id = %request_id, status, error = %error_msg, "Streaming request failed");
                         self.cb_record_failure();
                         return Err(HttpError::Other(format!(

--- a/crates/opendev-http/src/client_tests.rs
+++ b/crates/opendev-http/src/client_tests.rs
@@ -9,6 +9,18 @@ fn test_timeout_config_default() {
 }
 
 #[test]
+fn test_api_error_message_preserves_top_level_and_plaintext_400_details() {
+    assert_eq!(
+        api_error_message(400, r#"{"message":"model is unavailable"}"#),
+        "model is unavailable"
+    );
+    assert_eq!(
+        api_error_message(400, "invalid request body"),
+        "invalid request body"
+    );
+}
+
+#[test]
 fn test_http_client_debug() {
     let client =
         HttpClient::new("https://api.example.com/v1/chat", HeaderMap::new(), None).unwrap();
@@ -152,4 +164,50 @@ fn test_http_client_debug_with_circuit_breaker() {
     let debug = format!("{:?}", client);
     assert!(debug.contains("circuit_breaker"));
     assert!(debug.contains("openai"));
+}
+
+#[tokio::test]
+async fn regular_clients_follow_same_origin_redirects() {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let (mut first, _) = listener.accept().await.unwrap();
+        let mut request = [0_u8; 4096];
+        let _ = first.read(&mut request).await.unwrap();
+        first
+            .write_all(
+                format!(
+                    "HTTP/1.1 307 Temporary Redirect\r\nlocation: http://{address}/final\r\ncontent-length: 0\r\nconnection: close\r\n\r\n"
+                )
+                .as_bytes(),
+            )
+            .await
+            .unwrap();
+
+        let (mut second, _) = listener.accept().await.unwrap();
+        let _ = second.read(&mut request).await.unwrap();
+        let body = r#"{"ok":true}"#;
+        second
+            .write_all(
+                format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                    body.len()
+                )
+                .as_bytes(),
+            )
+            .await
+            .unwrap();
+    });
+
+    let client =
+        HttpClient::new(format!("http://{address}/start"), HeaderMap::new(), None).unwrap();
+    let result = client
+        .post_json(&serde_json::json!({}), None)
+        .await
+        .unwrap();
+    assert!(result.success);
+    assert_eq!(result.body.unwrap()["ok"], true);
 }

--- a/crates/opendev-http/src/lib.rs
+++ b/crates/opendev-http/src/lib.rs
@@ -9,6 +9,7 @@
 pub mod adapted_client;
 pub mod adapters;
 pub mod auth;
+pub mod chatgpt_auth;
 pub mod circuit_breaker;
 pub mod client;
 pub mod models;
@@ -17,7 +18,7 @@ pub mod streaming;
 pub mod user_store;
 
 pub use adapted_client::AdaptedClient;
-pub use auth::CredentialStore;
+pub use auth::{ChatGptOAuthCredential, CredentialStore};
 pub use circuit_breaker::{CircuitBreaker, CircuitBreakerConfig};
 pub use client::HttpClient;
 pub use models::{HttpError, HttpResult, RetryConfig, classify_retryable_error, parse_retry_after};

--- a/crates/opendev-http/tests/chatgpt_foundation.rs
+++ b/crates/opendev-http/tests/chatgpt_foundation.rs
@@ -1,0 +1,237 @@
+//! Mocked cross-module coverage for the disabled-by-default ChatGPT foundation.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use async_trait::async_trait;
+use opendev_http::chatgpt_auth::RequestAuthenticator;
+use opendev_http::{AdaptedClient, ChatGptOAuthCredential, CredentialStore, HttpClient};
+use reqwest::header::{HeaderMap, HeaderValue};
+use tokio_util::sync::CancellationToken;
+
+struct MockAuthenticator;
+#[async_trait]
+impl RequestAuthenticator for MockAuthenticator {
+    async fn headers_for_request(
+        &self,
+        _: Option<&CancellationToken>,
+    ) -> Result<HeaderMap, opendev_http::HttpError> {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "authorization",
+            HeaderValue::from_static("Bearer integration-token"),
+        );
+        headers.insert(
+            "openai-beta",
+            HeaderValue::from_static("responses=experimental"),
+        );
+        Ok(headers)
+    }
+    async fn force_refresh(
+        &self,
+        _: Option<&CancellationToken>,
+    ) -> Result<(), opendev_http::HttpError> {
+        Ok(())
+    }
+}
+
+struct RefreshAuthenticator {
+    refreshed: AtomicBool,
+    refreshes: AtomicUsize,
+}
+
+#[async_trait]
+impl RequestAuthenticator for RefreshAuthenticator {
+    async fn headers_for_request(
+        &self,
+        _: Option<&CancellationToken>,
+    ) -> Result<HeaderMap, opendev_http::HttpError> {
+        let mut headers = HeaderMap::new();
+        let token = if self.refreshed.load(Ordering::SeqCst) {
+            "Bearer refreshed-token"
+        } else {
+            "Bearer stale-token"
+        };
+        headers.insert("authorization", HeaderValue::from_static(token));
+        Ok(headers)
+    }
+
+    async fn force_refresh(
+        &self,
+        _: Option<&CancellationToken>,
+    ) -> Result<(), opendev_http::HttpError> {
+        self.refreshes.fetch_add(1, Ordering::SeqCst);
+        self.refreshed.store(true, Ordering::SeqCst);
+        Ok(())
+    }
+}
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::sync::Mutex;
+
+#[tokio::test]
+async fn stored_credential_and_chatgpt_adapter_work_through_the_http_boundary() {
+    let auth_dir = tempfile::tempdir().unwrap();
+    let mut store = CredentialStore::new(Some(auth_dir.path().join("auth.json")));
+    store
+        .store_chatgpt_oauth(ChatGptOAuthCredential {
+            access_token: "test-access-token".to_string(),
+            refresh_token: "test-refresh-token".to_string(),
+            expires_at_ms: 4_102_444_800_000,
+            account_id: None,
+        })
+        .unwrap();
+    assert!(store.get_chatgpt_oauth().is_some());
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let request = Arc::new(Mutex::new(String::new()));
+    let request_for_server = Arc::clone(&request);
+    tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut raw = vec![0_u8; 8192];
+        let count = socket.read(&mut raw).await.unwrap();
+        *request_for_server.lock().await = String::from_utf8_lossy(&raw[..count]).into_owned();
+
+        let body = serde_json::json!({
+            "id": "resp_test",
+            "model": "codex-test",
+            "output": [{
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "hello"}]
+            }]
+        })
+        .to_string();
+        let response = format!(
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        socket.write_all(response.as_bytes()).await.unwrap();
+    });
+
+    let http = HttpClient::new(format!("http://{address}"), Default::default(), None)
+        .unwrap()
+        .with_request_authenticator(Arc::new(MockAuthenticator));
+    let adapter = AdaptedClient::adapter_for_provider("openai-chatgpt").unwrap();
+    let client = AdaptedClient::with_adapter(http, adapter);
+    let response = client
+        .post_json(
+            &serde_json::json!({
+                "model": "gpt-5.4",
+                "max_completion_tokens": 128000,
+                "_reasoning_effort": "medium",
+                "messages": [{"role": "user", "content": "hello"}]
+            }),
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert!(response.success);
+    assert_eq!(
+        response.body.unwrap()["choices"][0]["message"]["content"],
+        "hello"
+    );
+    let request = request.lock().await;
+    assert!(request.contains("\"store\":false"));
+    assert!(!request.contains("max_output_tokens"));
+    assert!(request.contains("\"summary\":\"auto\""));
+    assert!(request.contains("reasoning.encrypted_content"));
+    assert!(request.contains("authorization: Bearer integration-token"));
+    assert!(request.contains("openai-beta: responses=experimental"));
+    assert!(!request.contains("test-access-token"));
+}
+
+#[tokio::test]
+async fn a_401_forces_one_refresh_and_replays_with_fresh_headers() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let requests = Arc::new(Mutex::new(Vec::new()));
+    let requests_for_server = Arc::clone(&requests);
+    tokio::spawn(async move {
+        for (status, body) in [
+            ("401 Unauthorized", r#"{"error":{"message":"expired"}}"#),
+            ("200 OK", r#"{"ok":true}"#),
+        ] {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut raw = vec![0_u8; 8192];
+            let count = socket.read(&mut raw).await.unwrap();
+            requests_for_server
+                .lock()
+                .await
+                .push(String::from_utf8_lossy(&raw[..count]).into_owned());
+            socket
+                .write_all(
+                    format!("HTTP/1.1 {status}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}", body.len()).as_bytes(),
+                )
+                .await
+                .unwrap();
+        }
+    });
+    let auth = Arc::new(RefreshAuthenticator {
+        refreshed: AtomicBool::new(false),
+        refreshes: AtomicUsize::new(0),
+    });
+    let http = HttpClient::new(format!("http://{address}"), HeaderMap::new(), None)
+        .unwrap()
+        .with_request_authenticator(auth.clone());
+    let result = http
+        .post_json(&serde_json::json!({"hello":"world"}), None)
+        .await
+        .unwrap();
+    assert!(result.success);
+    assert_eq!(auth.refreshes.load(Ordering::SeqCst), 1);
+    let requests = requests.lock().await;
+    assert!(requests[0].contains("authorization: Bearer stale-token"));
+    assert!(requests[1].contains("authorization: Bearer refreshed-token"));
+}
+
+#[tokio::test]
+async fn streaming_401_forces_one_refresh_and_replays_with_fresh_headers() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let requests = Arc::new(Mutex::new(Vec::new()));
+    let requests_for_server = Arc::clone(&requests);
+    tokio::spawn(async move {
+        for (status, content_type, body) in [
+            (
+                "401 Unauthorized",
+                "application/json",
+                r#"{"error":{"message":"expired"}}"#,
+            ),
+            ("200 OK", "text/event-stream", "data: [DONE]\n\n"),
+        ] {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut raw = vec![0_u8; 8192];
+            let count = socket.read(&mut raw).await.unwrap();
+            requests_for_server
+                .lock()
+                .await
+                .push(String::from_utf8_lossy(&raw[..count]).into_owned());
+            socket
+                .write_all(
+                    format!("HTTP/1.1 {status}\r\ncontent-type: {content_type}\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}", body.len()).as_bytes(),
+                )
+                .await
+                .unwrap();
+        }
+    });
+    let auth = Arc::new(RefreshAuthenticator {
+        refreshed: AtomicBool::new(false),
+        refreshes: AtomicUsize::new(0),
+    });
+    let http = HttpClient::new(format!("http://{address}"), HeaderMap::new(), None)
+        .unwrap()
+        .with_request_authenticator(auth.clone());
+    let response = http
+        .send_streaming_request(&format!("http://{address}"), &serde_json::json!({}), None)
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+    assert_eq!(auth.refreshes.load(Ordering::SeqCst), 1);
+    let requests = requests.lock().await;
+    assert!(requests[0].contains("authorization: Bearer stale-token"));
+    assert!(requests[1].contains("authorization: Bearer refreshed-token"));
+}

--- a/crates/opendev-models/src/config/mod.rs
+++ b/crates/opendev-models/src/config/mod.rs
@@ -25,6 +25,25 @@ pub(crate) fn default_max_tokens() -> u32 {
     16384
 }
 
+// ── ExperimentalConfig ──
+
+/// Explicit opt-ins for features that are not part of the default provider set.
+///
+/// Every experimental integration must remain disabled when this section is
+/// absent so existing configurations retain their current behaviour.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExperimentalConfig {
+    /// Permit the separately authenticated ChatGPT/Codex provider.
+    #[serde(default)]
+    pub chatgpt_auth: bool,
+}
+
+impl ExperimentalConfig {
+    fn is_default(value: &Self) -> bool {
+        value == &Self::default()
+    }
+}
+
 // ── AutoModeConfig ──
 
 /// Auto mode configuration.
@@ -98,6 +117,10 @@ pub struct AppConfig {
     pub model_provider: String,
     #[serde(default = "default_model")]
     pub model: String,
+
+    /// Explicit opt-ins for experimental functionality.
+    #[serde(default, skip_serializing_if = "ExperimentalConfig::is_default")]
+    pub experimental: ExperimentalConfig,
 
     // Vision/Multi-modal model
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -258,6 +281,7 @@ impl Default for AppConfig {
         Self {
             model_provider: default_model_provider(),
             model: default_model(),
+            experimental: ExperimentalConfig::default(),
             model_vlm: None,
             model_vlm_provider: None,
             api_key: None,
@@ -321,6 +345,12 @@ impl AppConfig {
     /// 4. `self.api_key` (stored in config by the setup wizard)
     /// 5. `OPENAI_API_KEY` (last resort for truly unknown providers)
     pub fn get_api_key_with_env(&self, registry_env_var: Option<&str>) -> Result<String, String> {
+        if self.model_provider == "openai-chatgpt" {
+            return Err(
+                "openai-chatgpt uses locally stored ChatGPT OAuth credentials, not an API key"
+                    .to_string(),
+            );
+        }
         // Try registry env var first (authoritative for models.dev providers)
         if let Some(env_var) = registry_env_var
             && !env_var.is_empty()

--- a/crates/opendev-models/src/config/tests.rs
+++ b/crates/opendev-models/src/config/tests.rs
@@ -7,6 +7,23 @@ fn test_default_config() {
     assert_eq!(config.temperature, 0.6);
     assert_eq!(config.max_tokens, 16384);
     assert!(config.enable_bash);
+    assert!(!config.experimental.chatgpt_auth);
+}
+
+#[test]
+fn test_chatgpt_provider_never_resolves_an_api_key() {
+    let config = AppConfig {
+        model_provider: "openai-chatgpt".to_string(),
+        api_key: Some("must-not-be-used".to_string()),
+        ..AppConfig::default()
+    };
+
+    assert!(
+        config
+            .get_api_key()
+            .unwrap_err()
+            .contains("OAuth credentials")
+    );
 }
 
 #[test]
@@ -16,6 +33,21 @@ fn test_config_roundtrip() {
     let deserialized: AppConfig = serde_json::from_str(&json).unwrap();
     assert_eq!(deserialized.model_provider, config.model_provider);
     assert_eq!(deserialized.model, config.model);
+}
+
+#[test]
+fn test_disabled_chatgpt_experiment_is_omitted_from_normal_config_serialization() {
+    let normal = serde_json::to_value(AppConfig::default()).unwrap();
+    assert!(normal.get("experimental").is_none());
+
+    let chatgpt = AppConfig {
+        experimental: ExperimentalConfig { chatgpt_auth: true },
+        ..AppConfig::default()
+    };
+    assert_eq!(
+        serde_json::to_value(chatgpt).unwrap()["experimental"]["chatgpt_auth"],
+        true
+    );
 }
 
 #[test]

--- a/crates/opendev-models/src/lib.rs
+++ b/crates/opendev-models/src/lib.rs
@@ -18,8 +18,8 @@ pub mod validator;
 
 // Re-export commonly used types at crate root
 pub use config::{
-    AgentConfigInline, AppConfig, AutoModeConfig, ChannelsConfig, DmPolicy, ModelVariant,
-    OperationConfig, PermissionConfig, TelegramChannelConfig, ToolPermission,
+    AgentConfigInline, AppConfig, AutoModeConfig, ChannelsConfig, DmPolicy, ExperimentalConfig,
+    ModelVariant, OperationConfig, PermissionConfig, TelegramChannelConfig, ToolPermission,
 };
 pub use file_change::{FileChange, FileChangeType};
 pub use message::{ChatMessage, InputProvenance, ProvenanceKind, Role, ToolCall};

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -39,6 +39,45 @@ Environment variables always win. This lets you override stored credentials per-
 
 ## Supported Providers
 
+### Experimental ChatGPT/Codex OAuth
+
+`openai-chatgpt` is an opt-in, experimental ChatGPT/Codex OAuth provider. It
+is not an OpenAI Platform API-key provider, cannot be pointed at a custom
+`api_base_url`, and never falls back to `OPENAI_API_KEY`.
+
+**Release status: compatibility approval pending.** OpenAI's public guidance
+documents ChatGPT OAuth and device-code login for the Codex CLI, not for a
+separate third-party provider. Do not enable or distribute this integration
+until an OpenDev maintainer has recorded Phase 0 approval for the standalone
+OAuth profile, supported account/workspace types, and protocol ownership. The
+implementation and mocked tests exist to support that review; they are not an
+authorization to use a ChatGPT subscription as a general API replacement.
+
+After that approval, use the first-run setup flow: select **OpenAI**, then
+choose **ChatGPT Pro/Plus (browser)** or **ChatGPT Pro/Plus (headless)**. The
+wizard always asks you to sign in and, after a successful sign-in, replaces
+the previous local OAuth credential. It then loads OpenAI model
+metadata from OpenDev's dynamically refreshed models.dev catalogue (the same
+catalogue approach used by OpenCode), and writes `experimental.chatgpt_auth = true`,
+`model_provider = "openai-chatgpt"`, and the selected model to
+`~/.opendev/settings.json`. The model list is discovery metadata, not an entitlement
+guarantee; an unavailable model is reported by the backend rather than falling
+back to Platform API-key authentication.
+
+Browser login uses a loopback PKCE callback. `--headless` uses the device-code
+flow, shows a verification URL and code, then polls until it can exchange the
+returned authorization code with its PKCE verifier. Device login can require a
+personal security setting or workspace-admin permission. Credentials are stored
+only in OpenDev's local auth store; the flow does not require `codex` or read
+Codex's credential store. To sign in again, change accounts, or recover from a
+missing/expired credential, rerun `opendev setup` and select the ChatGPT option.
+
+The initial credential backend is the plaintext `~/.opendev/auth.json` file
+with owner-only permissions on Unix. Do not run multiple OpenDev processes
+that refresh the same ChatGPT credential at once: refresh-token rotation is
+single-flight within a process, and OpenDev warns about the cross-process
+limitation.
+
 ### OpenAI
 
 - Env var: `OPENAI_API_KEY`


### PR DESCRIPTION
## Summary

Adds an opt-in openai-chatgpt provider for using an eligible ChatGPT/Codex subscription directly from OpenDev. This does not require a separately installed Codex CLI or codex app-server.

## Authentication flow

- Browser authorization-code login with PKCE (S256), state validation, and a localhost callback.
- Headless device-code login followed by PKCE token exchange.
- Local credential storage for access token, refresh token, expiry, and account metadata.
- Refresh before expiry plus one forced refresh/replay on HTTP 401 for normal and streaming requests.
- Dedicated ChatGPT/Codex Responses adapter and streaming response handling.

## Setup

1. Run opendev for first-time setup, or opendev setup to reconfigure.
2. Select OpenAI.
3. Select ChatGPT Pro/Plus (browser) or ChatGPT Pro/Plus (headless).
4. Confirm the experimental ChatGPT/Codex subscription flow, authenticate, and select a model from the dynamic OpenAI catalogue.

A successful sign-in replaces the previous local ChatGPT OAuth credential only after the new login succeeds.

## Safety and scope

- Disabled by default: experimental.chatgpt_auth defaults to false.
- The openai-chatgpt provider is rejected unless explicitly enabled.
- ChatGPT OAuth credentials are separated from Platform API keys and are not used by other providers.
- Existing provider routes retain their existing authentication behavior.

## Validation

- Tests passed locally on macOS and Ubuntu.
- cargo check --workspace, cargo clippy --workspace -- -D warnings, and release build passed locally on macOS.
- Added mocked coverage for PKCE/device login, credential persistence and refresh-token rotation, revoked-token cleanup, request/streaming 401 refresh-replay, adapter translation, and disabled-by-default validation.
- Ran ten real ChatGPT subscription integration tasks with gpt-5.4-mini: five brownfield and five greenfield projects.

## CI

[Fork CI run](https://github.com/Haiduongcable/opendev/actions/runs/29348102510) passed:

- Format and Clippy
- cargo check on Ubuntu, macOS, and Windows
- cargo test on Ubuntu, macOS, and Windows