### PR TITLE
⚡ Bolt: Replace blocking std::fs operations with tokio::fs in memory consolidation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -90,6 +90,3 @@
 ## 2024-08-03 - Replacing synchronous std::fs operations with tokio::fs in memory_consolidation.rs
 **Learning:** In `crates/opendev-agents/src/memory_consolidation.rs`, using synchronous `std::fs` operations (e.g., `create_dir_all`, `copy`, `remove_file`, `rename`) inside the async functions `consolidate` and `run_consolidation` blocks the async executor thread, degrading concurrent performance.
 **Action:** Replace `std::fs` calls within async functions with `tokio::fs` equivalents (e.g., `tokio::fs::create_dir_all(...).await`) to ensure non-blocking file I/O operations and improve overall application concurrency.
-## 2024-08-04 - Replacing synchronous std::fs operations with tokio::fs in memory_consolidation.rs
-**Learning:** Using synchronous `std::fs` operations like `std::fs::remove_file` or `std::fs::OpenOptions::new().open()` inside the async `consolidate` function blocks the async executor thread, degrading concurrent performance.
-**Action:** Replace `std::fs` calls within async functions with `tokio::fs` equivalents and use `.await` to ensure non-blocking file I/O operations and improve overall application concurrency.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -90,3 +90,6 @@
 ## 2024-08-03 - Replacing synchronous std::fs operations with tokio::fs in memory_consolidation.rs
 **Learning:** In `crates/opendev-agents/src/memory_consolidation.rs`, using synchronous `std::fs` operations (e.g., `create_dir_all`, `copy`, `remove_file`, `rename`) inside the async functions `consolidate` and `run_consolidation` blocks the async executor thread, degrading concurrent performance.
 **Action:** Replace `std::fs` calls within async functions with `tokio::fs` equivalents (e.g., `tokio::fs::create_dir_all(...).await`) to ensure non-blocking file I/O operations and improve overall application concurrency.
+## 2024-08-04 - Replacing synchronous std::fs operations with tokio::fs in memory_consolidation.rs
+**Learning:** Using synchronous `std::fs` operations like `std::fs::remove_file` or `std::fs::OpenOptions::new().open()` inside the async `consolidate` function blocks the async executor thread, degrading concurrent performance.
+**Action:** Replace `std::fs` calls within async functions with `tokio::fs` equivalents and use `.await` to ensure non-blocking file I/O operations and improve overall application concurrency.

--- a/crates/opendev-agents/src/memory_consolidation.rs
+++ b/crates/opendev-agents/src/memory_consolidation.rs
@@ -95,13 +95,16 @@ pub async fn consolidate(working_dir: &Path) -> Option<ConsolidationReport> {
     let backup_dir = paths.memory_backup_dir();
 
     // Acquire lock
-    let mut open_opts = std::fs::OpenOptions::new();
+    let mut open_opts = tokio::fs::OpenOptions::new();
     open_opts.write(true).create_new(true);
 
-    let lock_result = open_opts.open(&lock_path).and_then(|mut f| {
-        use std::io::Write;
-        f.write_all(b"locked")
-    });
+    let lock_result = match open_opts.open(&lock_path).await {
+        Ok(mut f) => {
+            use tokio::io::AsyncWriteExt;
+            f.write_all(b"locked").await
+        }
+        Err(e) => Err(e),
+    };
 
     if let Err(e) = lock_result {
         warn!("Failed to acquire consolidation lock: {e}");
@@ -119,7 +122,7 @@ pub async fn consolidate(working_dir: &Path) -> Option<ConsolidationReport> {
     save_meta(&meta_path, &meta);
 
     // Release lock
-    let _ = std::fs::remove_file(&lock_path);
+    let _ = tokio::fs::remove_file(&lock_path).await;
 
     result
 }
@@ -200,18 +203,23 @@ async fn run_consolidation(memory_dir: &Path, backup_dir: &Path) -> Option<Conso
     let write_result = {
         #[cfg(unix)]
         {
-            use std::os::unix::fs::OpenOptionsExt;
-            let mut opts = std::fs::OpenOptions::new();
+            use tokio::io::AsyncWriteExt;
+            let mut opts = tokio::fs::OpenOptions::new();
             opts.write(true).create_new(true).mode(0o600);
-            opts.open(&tmp_path)
-                .and_then(|mut f| std::io::Write::write_all(&mut f, full_content.as_bytes()))
+            match opts.open(&tmp_path).await {
+                Ok(mut f) => f.write_all(full_content.as_bytes()).await,
+                Err(e) => Err(e),
+            }
         }
         #[cfg(not(unix))]
         {
-            let mut opts = std::fs::OpenOptions::new();
+            use tokio::io::AsyncWriteExt;
+            let mut opts = tokio::fs::OpenOptions::new();
             opts.write(true).create_new(true);
-            opts.open(&tmp_path)
-                .and_then(|mut f| std::io::Write::write_all(&mut f, full_content.as_bytes()))
+            match opts.open(&tmp_path).await {
+                Ok(mut f) => f.write_all(full_content.as_bytes()).await,
+                Err(e) => Err(e),
+            }
         }
     };
 

--- a/fix3.patch
+++ b/fix3.patch
@@ -1,0 +1,9 @@
+--- a/.jules/bolt.md
++++ b/.jules/bolt.md
+@@ -90,6 +90,3 @@
+ ## 2024-08-03 - Replacing synchronous std::fs operations with tokio::fs in memory_consolidation.rs
+ **Learning:** In `crates/opendev-agents/src/memory_consolidation.rs`, using synchronous `std::fs` operations (e.g., `create_dir_all`, `copy`, `remove_file`, `rename`) inside the async functions `consolidate` and `run_consolidation` blocks the async executor thread, degrading concurrent performance.
+ **Action:** Replace `std::fs` calls within async functions with `tokio::fs` equivalents (e.g., `tokio::fs::create_dir_all(...).await`) to ensure non-blocking file I/O operations and improve overall application concurrency.
+-## 2024-08-04 - Replacing synchronous std::fs operations with tokio::fs in memory_consolidation.rs
+-**Learning:** Using synchronous `std::fs` operations like `std::fs::remove_file` or `std::fs::OpenOptions::new().open()` inside the async `consolidate` function blocks the async executor thread, degrading concurrent performance.
+-**Action:** Replace `std::fs` calls within async functions with `tokio::fs` equivalents and use `.await` to ensure non-blocking file I/O operations and improve overall application concurrency.


### PR DESCRIPTION
💡 What: Replaced blocking `std::fs` operations (`OpenOptions`, `remove_file`, `write_all`) inside async functions with non-blocking `tokio::fs` and `tokio::io` equivalents.
🎯 Why: Synchronous I/O operations inside `async` contexts block the Tokio executor thread, degrading the concurrent performance of the memory consolidation system.
📊 Impact: Prevents executor starvation and improves concurrent throughput when memory consolidation runs.
🔬 Measurement: Observe lower latency in parallel agent operations when memory consolidation is triggered in the background.

---
*PR created automatically by Jules for task [14776262579587232932](https://jules.google.com/task/14776262579587232932) started by @bdqnghi*