### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TOCTOU vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -173,3 +173,7 @@
 **Vulnerability:** Used `std::fs::write` to persist patch content to disk in `crates/opendev-tools-impl/src/patch/unified.rs`. This function uses permissive default attributes and does not enforce exclusive file creation, making it vulnerable to symlink-based arbitrary file overwrite attacks.
 **Learning:** For atomic writes to be entirely secure and robust against system crashes, `file.sync_all()` must be called before the file is closed and renamed. Furthermore, temporary files must be manually deleted if the write operation fails to avoid resource leaks. Using a dependency like `uuid` requires ensuring the `v4` feature flag is enabled in `Cargo.toml`.
 **Prevention:** Replaced `std::fs::write` with an atomic write pattern utilizing a randomized UUID temporary filename, `std::fs::OpenOptions` with `.create_new(true)`, a `file.sync_all()` call, and error handling to remove the temp file on failure.
+## 2025-02-18 - Fix TOCTOU vulnerability in session manager
+**Vulnerability:** A TOCTOU symlink vulnerability due to use of std::fs::write in write_project_marker
+**Learning:** std::fs::write does not guarantee exclusive file creation and can follow symlinks, leading to arbitrary file overwrite. Must use OpenOptions with .create_new(true) and random temp file rename for atomic writes.
+**Prevention:** Always implement secure atomic writes by generating a UUID tmp file with create_new(true) before renaming it to the target.

--- a/crates/opendev-history/Cargo.toml
+++ b/crates/opendev-history/Cargo.toml
@@ -18,7 +18,7 @@ reqwest = { workspace = true }
 regex = { workspace = true }
 fd-lock = "4"
 dirs = "6"
-uuid = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
 similar = "2"
 
 [dev-dependencies]

--- a/crates/opendev-history/src/session_manager/mod.rs
+++ b/crates/opendev-history/src/session_manager/mod.rs
@@ -67,7 +67,29 @@ impl SessionManager {
     /// whose original working directory has been deleted.
     pub fn write_project_marker(&self, working_dir: &Path) {
         let marker = self.session_dir.join("OPENDEV_PROJECT_PATH");
-        let _ = std::fs::write(&marker, working_dir.to_string_lossy().as_bytes());
+
+        let tmp_path =
+            marker.with_file_name(format!("OPENDEV_PROJECT_PATH.tmp.{}", uuid::Uuid::new_v4()));
+
+        if let Ok(mut f) = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&tmp_path)
+        {
+            use std::io::Write;
+            let success = f
+                .write_all(working_dir.to_string_lossy().as_bytes())
+                .is_ok()
+                && f.sync_data().is_ok();
+
+            drop(f);
+
+            if success {
+                let _ = std::fs::rename(&tmp_path, &marker);
+            } else {
+                let _ = std::fs::remove_file(&tmp_path);
+            }
+        }
     }
 
     /// Get the current session (if any).


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: TOCTOU symlink vulnerability in `write_project_marker`. `std::fs::write` does not guarantee exclusive file creation and can be exploited via symlink attacks.
🎯 Impact: A local attacker could create a symlink at the marker file path, causing the application to overwrite arbitrary files with the project path content.
🔧 Fix: Implemented atomic file writes using `OpenOptions::new().write(true).create_new(true)` with randomized temporary filenames (`uuid::Uuid::new_v4()`) and `std::fs::rename`.
✅ Verification: Ensured unit tests pass and code is well-formatted.

---
*PR created automatically by Jules for task [6954426748349908837](https://jules.google.com/task/6954426748349908837) started by @bdqnghi*