### PR TITLE
⚡ Bolt: Refactor synchronous fs calls to async in memory consolidation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -90,3 +90,6 @@
 ## 2024-08-03 - Replacing synchronous std::fs operations with tokio::fs in memory_consolidation.rs
 **Learning:** In `crates/opendev-agents/src/memory_consolidation.rs`, using synchronous `std::fs` operations (e.g., `create_dir_all`, `copy`, `remove_file`, `rename`) inside the async functions `consolidate` and `run_consolidation` blocks the async executor thread, degrading concurrent performance.
 **Action:** Replace `std::fs` calls within async functions with `tokio::fs` equivalents (e.g., `tokio::fs::create_dir_all(...).await`) to ensure non-blocking file I/O operations and improve overall application concurrency.
+## 2024-08-04 - Replacing synchronous std::fs operations with tokio::fs in regenerate_index
+**Learning:** In `crates/opendev-agents/src/memory_consolidation.rs`, the `regenerate_index` function used synchronous `std::fs` operations (e.g., `read_dir`, `read_to_string`, `rename`) inside an async context. This blocked the async executor thread, degrading concurrent performance.
+**Action:** Replace `std::fs` calls within async functions with `tokio::fs` equivalents (e.g., `tokio::fs::read_dir(...).await`) to ensure non-blocking file I/O operations and improve overall application concurrency.

--- a/crates/opendev-agents/src/doom_loop_tests.rs
+++ b/crates/opendev-agents/src/doom_loop_tests.rs
@@ -141,7 +141,7 @@ fn test_recovery_action_redirect_returns_nudge() {
     // Trigger first detection (Redirect)
     det.check(&[tc.clone()]);
     det.check(&[tc.clone()]);
-    let (action, warning) = det.check(&[tc.clone()]);
+    let (action, _warning) = det.check(&[tc.clone()]);
     assert_eq!(action, DoomLoopAction::Redirect);
 
     let recovery = det.recovery_action(&action);
@@ -164,7 +164,7 @@ fn test_recovery_action_notify_returns_step_back() {
     det.check(&[tc.clone()]);
 
     // Second detection (Notify)
-    let (action, warning) = det.check(&[tc.clone()]);
+    let (action, _warning) = det.check(&[tc.clone()]);
     assert_eq!(action, DoomLoopAction::Notify);
 
     let recovery = det.recovery_action(&action);

--- a/crates/opendev-agents/src/memory_consolidation.rs
+++ b/crates/opendev-agents/src/memory_consolidation.rs
@@ -248,7 +248,7 @@ async fn run_consolidation(memory_dir: &Path, backup_dir: &Path) -> Option<Conso
     }
 
     // Update MEMORY.md index
-    let _ = regenerate_index(memory_dir);
+    let _ = regenerate_index(memory_dir).await;
 
     info!(
         "Consolidation complete: {} files merged, {} pruned, {} backed up",
@@ -446,11 +446,11 @@ fn save_meta(path: &Path, meta: &ConsolidationMeta) {
     }
 }
 
-fn regenerate_index(dir: &Path) -> std::io::Result<()> {
-    let entries = std::fs::read_dir(dir)?;
+async fn regenerate_index(dir: &Path) -> std::io::Result<()> {
+    let mut entries = tokio::fs::read_dir(dir).await?;
     let mut files: Vec<(String, String)> = Vec::new();
 
-    for entry in entries.flatten() {
+    while let Ok(Some(entry)) = entries.next_entry().await {
         let path = entry.path();
         if !path.is_file() {
             continue;
@@ -464,7 +464,7 @@ fn regenerate_index(dir: &Path) -> std::io::Result<()> {
             continue;
         }
 
-        let content = std::fs::read_to_string(&path).unwrap_or_default();
+        let content = tokio::fs::read_to_string(&path).await.unwrap_or_default();
         let desc = extract_desc(&content);
         files.push((name, desc));
     }
@@ -493,22 +493,25 @@ fn regenerate_index(dir: &Path) -> std::io::Result<()> {
     {
         #[cfg(unix)]
         {
-            use std::os::unix::fs::OpenOptionsExt;
-            let mut opts = std::fs::OpenOptions::new();
+            use tokio::io::AsyncWriteExt;
+            let mut opts = tokio::fs::OpenOptions::new();
             opts.write(true).create_new(true).mode(0o600);
-            let mut file = opts.open(&tmp_path)?;
-            std::io::Write::write_all(&mut file, final_content.as_bytes())?;
+            let mut file = opts.open(&tmp_path).await?;
+            file.write_all(final_content.as_bytes()).await?;
+            file.sync_all().await?;
         }
         #[cfg(not(unix))]
         {
-            let mut opts = std::fs::OpenOptions::new();
+            use tokio::io::AsyncWriteExt;
+            let mut opts = tokio::fs::OpenOptions::new();
             opts.write(true).create_new(true);
-            let mut file = opts.open(&tmp_path)?;
-            std::io::Write::write_all(&mut file, final_content.as_bytes())?;
+            let mut file = opts.open(&tmp_path).await?;
+            file.write_all(final_content.as_bytes()).await?;
+            file.sync_all().await?;
         }
     }
 
-    std::fs::rename(&tmp_path, &index_path)?;
+    tokio::fs::rename(&tmp_path, &index_path).await?;
     Ok(())
 }
 

--- a/crates/opendev-agents/src/memory_consolidation_tests.rs
+++ b/crates/opendev-agents/src/memory_consolidation_tests.rs
@@ -106,8 +106,8 @@ fn test_load_save_meta() {
     assert_eq!(loaded.files_processed, 5);
 }
 
-#[test]
-fn test_regenerate_index() {
+#[tokio::test]
+async fn test_regenerate_index() {
     let dir = TempDir::new().unwrap();
 
     std::fs::write(
@@ -121,7 +121,7 @@ fn test_regenerate_index() {
     )
     .unwrap();
 
-    regenerate_index(dir.path()).unwrap();
+    regenerate_index(dir.path()).await.unwrap();
 
     let index = std::fs::read_to_string(dir.path().join("MEMORY.md")).unwrap();
     assert!(index.contains("# Memory Index"));

--- a/crates/opendev-agents/src/prompts/composer/factories_tests.rs
+++ b/crates/opendev-agents/src/prompts/composer/factories_tests.rs
@@ -3,7 +3,7 @@ use super::*;
 #[test]
 fn test_create_default_composer_section_count() {
     let dir = tempfile::TempDir::new().unwrap();
-    let mut composer = create_default_composer(dir.path());
+    let composer = create_default_composer(dir.path());
     // Should have many sections registered
     assert!(composer.section_count() > 15);
 }

--- a/crates/opendev-agents/src/react_loop/helpers/tests.rs
+++ b/crates/opendev-agents/src/react_loop/helpers/tests.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 
 use super::super::*;
-use crate::prompts::embedded;
 use crate::subagents::spec::{PermissionAction, PermissionRule};
 use crate::traits::{AgentError, AgentResult, LlmResponse};
 fn make_loop() -> ReactLoop {

--- a/crates/opendev-agents/src/subagents/spec/types_tests.rs
+++ b/crates/opendev-agents/src/subagents/spec/types_tests.rs
@@ -1,4 +1,3 @@
-use super::super::permissions::PermissionAction;
 use super::*;
 
 #[test]


### PR DESCRIPTION
💡 What: Refactored `regenerate_index` in `crates/opendev-agents/src/memory_consolidation.rs` to use asynchronous `tokio::fs` operations instead of synchronous `std::fs` operations.
🎯 Why: Synchronous I/O operations within async functions block the executor thread, preventing other tasks from making progress and degrading overall application concurrency and performance.
📊 Impact: Improves concurrency and responsiveness of the application by ensuring the executor thread isn't blocked during memory index generation.
🔬 Measurement: Verify by running `cargo test -p opendev-agents` to ensure `memory_consolidation` tests pass and index regeneration completes successfully without blocking the main thread.

---
*PR created automatically by Jules for task [12400340490566530704](https://jules.google.com/task/12400340490566530704) started by @bdqnghi*