### PR TITLE
⚡ Bolt: [performance improvement] Replace reduce with for...of loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -99,3 +99,6 @@
 ## 2024-11-20 - Replacing synchronous std::fs operations with tokio::fs in memory consolidation
 **Learning:** In `crates/opendev-agents/src/memory_consolidation.rs`, using synchronous `std::fs` operations inside `load_meta` and `save_meta` blocks the async executor thread, even though these are called from async contexts.
 **Action:** Replace `std::fs` calls within these functions with `tokio::fs` equivalents and make them `async` to ensure non-blocking file I/O operations and improve overall application concurrency.
+## 2025-06-03 - Replacing Array.prototype.reduce with for...of loops for large array aggregations
+**Learning:** Using `Array.prototype.reduce` inside `useMemo` for aggregating properties of large arrays creates unnecessary overhead due to callback function allocations and execution overhead on every render when dependencies change. This can cause minor UI lag compared to traditional iterative loops.
+**Action:** Replace `.reduce()` array aggregations with a traditional `for...of` loop to avoid closure allocation overhead and improve execution speed, particularly for frequently updated components.

--- a/web-ui/src/components/CodeWiki/RepositoryExplorer.tsx
+++ b/web-ui/src/components/CodeWiki/RepositoryExplorer.tsx
@@ -97,7 +97,11 @@ export function RepositoryExplorer({ selectedRepo, onRepoSelect, searchQuery }: 
   }, [deferredSearchQuery]);
 
   const totalFiles = useMemo(() => {
-    return filteredRepos.reduce((sum, repo) => sum + repo.files, 0);
+    let sum = 0;
+    for (const repo of filteredRepos) {
+      sum += repo.files;
+    }
+    return sum;
   }, [filteredRepos]);
 
   const toggleExpanded = (repoId: string) => {

--- a/web-ui/src/components/CodeWiki/RepositoryGrid.tsx
+++ b/web-ui/src/components/CodeWiki/RepositoryGrid.tsx
@@ -39,9 +39,15 @@ export function RepositoryGrid({ repositories, searchQuery, onSearchChange, onAd
   // ⚡ Bolt Performance Optimization:
   // Memoize the aggregations derived from filteredRepositories.
   const { totalFiles, totalDocs } = useMemo(() => {
+    let files = 0;
+    let docs = 0;
+    for (const repo of filteredRepositories) {
+      files += repo.files;
+      docs += repo.docsFound;
+    }
     return {
-      totalFiles: filteredRepositories.reduce((sum, repo) => sum + repo.files, 0),
-      totalDocs: filteredRepositories.reduce((sum, repo) => sum + repo.docsFound, 0),
+      totalFiles: files,
+      totalDocs: docs,
     };
   }, [filteredRepositories]);
 


### PR DESCRIPTION
💡 What: Replaced `Array.prototype.reduce` with `for...of` loops in `RepositoryExplorer` and `RepositoryGrid` aggregations.
🎯 Why: `Array.prototype.reduce` incurs unnecessary closure allocation and functional overhead when processing large filtered array lists frequently on every keystroke, which can cause UI lag.
📊 Impact: Improves execution speed of the `useMemo` block by eliminating callback allocation and invocation overhead on large sets, enabling faster keystroke rendering.
🔬 Measurement: Verify changes pass tests with `node --experimental-strip-types --test`.

---
*PR created automatically by Jules for task [8786157730339805207](https://jules.google.com/task/8786157730339805207) started by @bdqnghi*