### PR TITLE
docs: fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,11 +297,11 @@ See the [Roadmap](./ROADMAP.md) for current priorities and areas where community
 ### Star History
 
 <p align="center">
-  <a href="https://star-history.com/#opendev-to/opendev&Date">
+  <a href="https://star-history.dera.page/#opendev-to/opendev&type=Date">
    <picture>
-     <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=opendev-to/opendev&type=Date&theme=dark" />
-     <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=opendev-to/opendev&type=Date" />
-     <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=opendev-to/opendev&type=Date" />
+     <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=opendev-to/opendev&type=Date&theme=dark" />
+     <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=opendev-to/opendev&type=Date" />
+     <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=opendev-to/opendev&type=Date" />
    </picture>
   </a>
 </p>


### PR DESCRIPTION
The star history chart shown in the README is broken and does not render anymore. This change updates the chart links so the chart is displayed correctly again.

It is a small documentation fix with no impact on functionality.